### PR TITLE
fix(upgrade): typo on mae-consumer ENTITY_REGISTRY_CONFIG_PATH for v0.8.7

### DIFF
--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
             - name: MAE_CONSUMER_ENABLED
               value: "true"
             - name: ENTITY_REGISTRY_CONFIG_PATH
-              value: /datahub/datahub-gms/resources/entity-registry.yml
+              value: /datahub/datahub-mae-consumer/resources/entity-registry.yml
             - name: GMS_HOST
               value: {{ printf "%s-%s" .Release.Name "datahub-gms" }}
             - name: GMS_PORT


### PR DESCRIPTION
<img width="1151" alt="Screenshot 2021-08-04 at 1 36 19 PM" src="https://user-images.githubusercontent.com/39326969/128124125-78e41bc5-ba27-4c08-9fdf-e2ce1a51363b.png">

datahub-mae-consumer's ENTITY_REGISTRY_CONFIG_PATH should be under datahub-mae-consumer, not datahub-gms. This PR fixes the above error and redirect to mae-consumer's entity-registry yaml file.