### PR TITLE
fix: Solve Registry path in the datahub-mae-consumer

### DIFF
--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
             - name: MAE_CONSUMER_ENABLED
               value: "true"
             - name: ENTITY_REGISTRY_CONFIG_PATH
-              value: /datahub/datahub-gms/resources/entity-registry.yml
+              value: /datahub/datahub-mae-consumer/resources/entity-registry.yml
             - name: GMS_HOST
               value: {{ printf "%s-%s" .Release.Name "datahub-gms" }}
             - name: GMS_PORT


### PR DESCRIPTION
Hi there!

It seems that the new registry path in the mae-consumer is pointing to the wrong directory?

If I compare it with the docker-compose file the value is the proposed one.
https://github.com/linkedin/datahub/blob/master/docker/datahub-mae-consumer/env/docker.env#L13