### PR TITLE
feat: support service account name for ingestion

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.19
+version: 0.2.20
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.11

--- a/charts/datahub/subcharts/datahub-ingestion-cron/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.3.1
+appVersion: 0.3.2

--- a/charts/datahub/subcharts/datahub-ingestion-cron/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.3
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/subcharts/datahub-ingestion-cron/README.md
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/README.md
@@ -25,3 +25,4 @@ A Helm chart for datahub's metadata-ingestion framework with kerberos authentica
 | crons.extraVolumes | array | `[]` | Additional volumes to add to the pods |
 | crons.extraVolumeMounts | array | `[]` | Additional volume mounts to add to the pods |
 | crons.extraInitContainers | object | `{}` | Init containers to add to the cronjob container |
+| crons.serviceAccountName | string | | Service account name used for the cronjob container |

--- a/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
@@ -24,6 +24,9 @@ spec:
         {{- if .hostAliases }}
           hostAliases: {{- include "common.tplvalues.render" (dict "value" .hostAliases "context" $) | nindent 10 }}
         {{- end }}
+        {{- if .serviceAccountName }}
+          serviceAccountName: {{ .serviceAccountName }}
+        {{- end }}
           containers:
           - name: {{ $jobName }}-crawler
             image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"

--- a/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
@@ -50,3 +50,7 @@ crons: {}
     ## Add your own init container or uncomment and modify the given example.
     ##
     #extraInitContainers: {}
+
+    ## If you want to specify your own service account, set its name like so.
+    ##
+    #serviceAccountName: "my-cron-service"


### PR DESCRIPTION
This PR allows the service account name to be specified for crons. This is useful if you have created specific accounts with permissions that are needed to access the metadata (e.g. you might have a Kubernetes Service Account that assumes an IAM Role with access to Glue for a Glue Metadata Cronjob).

I was manually creating my `cronjobs` and then noticed that the chart has this nice capability to specify a bunch of cronjobs which is very convenient. However, I need to be able to specify the service account for each one, as each one has its own specific permissions to the AWS resources it ingests metadata from.

**Request for Comments**

For many of the deployed services (`datahub-mae-consumer`, `datahub-mce-consumer`, etc), you can specify a complete `serviceAccount` object as per the defaults when creating a Helm chart (meaning you can specify the name, annotations and so on). However, for the setup and upgrade jobs, the `serviceAccount` value is *only* the service account name. This is something of an inconsistency - sometimes `serviceAccount` is an object, sometimes it is a string. To avoid this inconsistency I have explicitly named the variable `serviceAccountName` so that there is no ambiguity as to whether this is specifying a service account object or just the name. But feel free to let me know if it should be changed!

**Notes**

I wasn't sure whether I should update both version numbers or just one. This is a feature but non-breaking so I made it a patch, I can make it a minor bump if that's better.