### PR TITLE
DP-982 : Increase resources and batchsize for datahubupgrade job

### DIFF
--- a/charts/datahub/templates/datahub-upgrade/datahub-upgrade-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-upgrade-job.yml
@@ -54,7 +54,7 @@ spec:
             - "-u"
             - "NoCodeDataMigration"
             - "-a"
-            - "batchSize=1000"
+            - "batchSize=10000"
             - "-a"
             - "batchDelayMs=100"
             - "-a"
@@ -151,11 +151,11 @@ spec:
           {{- end }}
           resources:
             limits:
-              cpu: 500m
-              memory: 512Mi
+              cpu: 1
+              memory: 2Gi
             requests:
-              cpu: 300m
-              memory: 256Mi
+              cpu: 500m
+              memory: 1Gi
       {{- with .Values.datahubUpgrade.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
If we go with the default params the upgrade can take hours due to low CPU, memory and batchsize