### PR TITLE
Update URL for GMS/metadata service

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the Kubernetes [Helm](https://helm.sh/) charts for deploying
      Note, we only support Helm 3.
    
 ## Components
-Datahub consists of 4 main components: [GMS](https://datahubproject.io/docs/gms), 
+Datahub consists of 4 main components: [GMS](https://datahubproject.io/docs/metadata-service/), 
 [MAE Consumer](https://datahubproject.io/docs/metadata-jobs/mae-consumer-job) (optional), 
 [MCE Consumer](https://datahubproject.io/docs/metadata-jobs/mce-consumer-job) (optional), and 
 [Frontend](https://datahubproject.io/docs/datahub-frontend). Kubernetes deployment 


### PR DESCRIPTION
Old URL 404s - pointing to Metadata Service link.



## Checklist
- [X ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
