### PR TITLE
Fix configuration values of services that use kafka and zookeeper

### DIFF
--- a/charts/datahub/quickstart-values-without-neo4j.yaml
+++ b/charts/datahub/quickstart-values-without-neo4j.yaml
@@ -51,9 +51,9 @@ global:
 
   kafka:
     bootstrap:
-      server: "prerequisites-kafka:9092"
+      server: "prerequisites-cp-kafka:9092"
     zookeeper:
-      server: "prerequisites-zookeeper:2181"
+      server: "prerequisites-cp-zookeeper:2181"
     schemaregistry:
       url: "http://prerequisites-cp-schema-registry:8081"
 

--- a/charts/datahub/quickstart-values.yaml
+++ b/charts/datahub/quickstart-values.yaml
@@ -51,9 +51,9 @@ global:
 
   kafka:
     bootstrap:
-      server: "prerequisites-kafka:9092"
+      server: "prerequisites-cp-kafka:9092"
     zookeeper:
-      server: "prerequisites-zookeeper:2181"
+      server: "prerequisites-cp-zookeeper:2181"
     schemaregistry:
       url: "http://prerequisites-cp-schema-registry:8081"
 

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -68,9 +68,9 @@ global:
 
   kafka:
     bootstrap:
-      server: "prerequisites-kafka:9092"
+      server: "prerequisites-cp-kafka:9092"
     zookeeper:
-      server: "prerequisites-zookeeper:2181"
+      server: "prerequisites-cp-zookeeper:2181"
     ## For AWS MSK set this to a number larger than 1
     # partitions: 3
     # replicationFactor: 3

--- a/charts/prerequisites/values.yaml
+++ b/charts/prerequisites/values.yaml
@@ -58,7 +58,7 @@ cp-helm-charts:
   cp-schema-registry:
     enabled: true
     kafka:
-      bootstrapServers: "prerequisites-kafka:9092"  # <<release-name>>-kafka:9092
+      bootstrapServers: "prerequisites-cp-kafka:9092"  # <<release-name>>-cp-kafka:9092
   cp-kafka:
     enabled: false
   cp-zookeeper:


### PR DESCRIPTION
The configuration of the services that use either Kafka or Zookeeper in the values.yml files link to the wrong name of service and fail.

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
