### PR TITLE
feat: allow to configure whitelistObjectNames and blacklistObjectNames for jmx

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,13 +4,13 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.39
+version: 0.2.40
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.23
 dependencies:
   - name: datahub-gms
-    version: 0.2.2
+    version: 0.2.3
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
@@ -18,11 +18,11 @@ dependencies:
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer
-    version: 0.2.1
+    version: 0.2.3
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.2.1
+    version: 0.2.3
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/subcharts/datahub-gms/templates/config-jmx-exporter.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/config-jmx-exporter.yaml
@@ -10,17 +10,13 @@ data:
     hostPort: localhost:{{ .Values.env.JMXPORT }}
     lowercaseOutputName: {{ .Values.exporters.jmx.config.lowercaseOutputName }}
     lowercaseOutputLabelNames: {{ .Values.exporters.jmx.config.lowercaseOutputLabelNames }}
-    {{- if .Values.exporters.jmx.config.whitelistObjectNames }}
     {{- with .Values.exporters.jmx.config.whitelistObjectNames }}
     whitelistObjectNames:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- end }}
-    {{- if .Values.exporters.jmx.config.blacklistObjectNames }}
     {{- with .Values.exporters.jmx.config.blacklistObjectNames }}
     blacklistObjectNames:
       {{- toYaml . | nindent 6 }}
-    {{- end }}
     {{- end }}
     rules:
 {{ .Values.exporters.jmx.config.rules | toYaml | indent 6 }}

--- a/charts/datahub/subcharts/datahub-gms/templates/config-jmx-exporter.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/config-jmx-exporter.yaml
@@ -13,13 +13,13 @@ data:
     {{- if .Values.exporters.jmx.config.whitelistObjectNames }}
     {{- with .Values.exporters.jmx.config.whitelistObjectNames }}
     whitelistObjectNames:
-    {{- toYaml . | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- end }}
     {{- if .Values.exporters.jmx.config.blacklistObjectNames }}
     {{- with .Values.exporters.jmx.config.blacklistObjectNames }}
     blacklistObjectNames:
-    {{- toYaml . | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- end }}
     rules:

--- a/charts/datahub/subcharts/datahub-gms/templates/config-jmx-exporter.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/config-jmx-exporter.yaml
@@ -10,6 +10,18 @@ data:
     hostPort: localhost:{{ .Values.env.JMXPORT }}
     lowercaseOutputName: {{ .Values.exporters.jmx.config.lowercaseOutputName }}
     lowercaseOutputLabelNames: {{ .Values.exporters.jmx.config.lowercaseOutputLabelNames }}
+    {{- if .Values.exporters.jmx.config.whitelistObjectNames }}
+    {{- with .Values.exporters.jmx.config.whitelistObjectNames }}
+    whitelistObjectNames:
+    {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.exporters.jmx.config.blacklistObjectNames }}
+    {{- with .Values.exporters.jmx.config.blacklistObjectNames }}
+    blacklistObjectNames:
+    {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
     rules:
 {{ .Values.exporters.jmx.config.rules | toYaml | indent 6 }}
     ssl: false

--- a/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/config-jmx-exporter.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/config-jmx-exporter.yaml
@@ -10,17 +10,13 @@ data:
     hostPort: localhost:{{ .Values.env.JMXPORT }}
     lowercaseOutputName: {{ .Values.exporters.jmx.config.lowercaseOutputName }}
     lowercaseOutputLabelNames: {{ .Values.exporters.jmx.config.lowercaseOutputLabelNames }}
-    {{- if .Values.exporters.jmx.config.whitelistObjectNames }}
     {{- with .Values.exporters.jmx.config.whitelistObjectNames }}
     whitelistObjectNames:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- end }}
-    {{- if .Values.exporters.jmx.config.blacklistObjectNames }}
     {{- with .Values.exporters.jmx.config.blacklistObjectNames }}
     blacklistObjectNames:
       {{- toYaml . | nindent 6 }}
-    {{- end }}
     {{- end }}
     rules:
 {{ .Values.exporters.jmx.config.rules | toYaml | indent 6 }}

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/config-jmx-exporter.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/config-jmx-exporter.yaml
@@ -13,13 +13,13 @@ data:
     {{- if .Values.exporters.jmx.config.whitelistObjectNames }}
     {{- with .Values.exporters.jmx.config.whitelistObjectNames }}
     whitelistObjectNames:
-    {{- toYaml . | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- end }}
     {{- if .Values.exporters.jmx.config.blacklistObjectNames }}
     {{- with .Values.exporters.jmx.config.blacklistObjectNames }}
     blacklistObjectNames:
-    {{- toYaml . | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- end }}
     rules:

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/config-jmx-exporter.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/config-jmx-exporter.yaml
@@ -10,6 +10,18 @@ data:
     hostPort: localhost:{{ .Values.env.JMXPORT }}
     lowercaseOutputName: {{ .Values.exporters.jmx.config.lowercaseOutputName }}
     lowercaseOutputLabelNames: {{ .Values.exporters.jmx.config.lowercaseOutputLabelNames }}
+    {{- if .Values.exporters.jmx.config.whitelistObjectNames }}
+    {{- with .Values.exporters.jmx.config.whitelistObjectNames }}
+    whitelistObjectNames:
+    {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.exporters.jmx.config.blacklistObjectNames }}
+    {{- with .Values.exporters.jmx.config.blacklistObjectNames }}
+    blacklistObjectNames:
+    {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
     rules:
 {{ .Values.exporters.jmx.config.rules | toYaml | indent 6 }}
     ssl: false

--- a/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/config-jmx-exporter.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/config-jmx-exporter.yaml
@@ -10,17 +10,13 @@ data:
     hostPort: localhost:{{ .Values.env.JMXPORT }}
     lowercaseOutputName: {{ .Values.exporters.jmx.config.lowercaseOutputName }}
     lowercaseOutputLabelNames: {{ .Values.exporters.jmx.config.lowercaseOutputLabelNames }}
-    {{- if .Values.exporters.jmx.config.whitelistObjectNames }}
     {{- with .Values.exporters.jmx.config.whitelistObjectNames }}
     whitelistObjectNames:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- end }}
-    {{- if .Values.exporters.jmx.config.blacklistObjectNames }}
     {{- with .Values.exporters.jmx.config.blacklistObjectNames }}
     blacklistObjectNames:
       {{- toYaml . | nindent 6 }}
-    {{- end }}
     {{- end }}
     rules:
 {{ .Values.exporters.jmx.config.rules | toYaml | indent 6 }}

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/config-jmx-exporter.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/config-jmx-exporter.yaml
@@ -13,13 +13,13 @@ data:
     {{- if .Values.exporters.jmx.config.whitelistObjectNames }}
     {{- with .Values.exporters.jmx.config.whitelistObjectNames }}
     whitelistObjectNames:
-    {{- toYaml . | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- end }}
     {{- if .Values.exporters.jmx.config.blacklistObjectNames }}
     {{- with .Values.exporters.jmx.config.blacklistObjectNames }}
     blacklistObjectNames:
-    {{- toYaml . | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- end }}
     rules:

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/config-jmx-exporter.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/config-jmx-exporter.yaml
@@ -10,6 +10,18 @@ data:
     hostPort: localhost:{{ .Values.env.JMXPORT }}
     lowercaseOutputName: {{ .Values.exporters.jmx.config.lowercaseOutputName }}
     lowercaseOutputLabelNames: {{ .Values.exporters.jmx.config.lowercaseOutputLabelNames }}
+    {{- if .Values.exporters.jmx.config.whitelistObjectNames }}
+    {{- with .Values.exporters.jmx.config.whitelistObjectNames }}
+    whitelistObjectNames:
+    {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.exporters.jmx.config.blacklistObjectNames }}
+    {{- with .Values.exporters.jmx.config.blacklistObjectNames }}
+    blacklistObjectNames:
+    {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
     rules:
 {{ .Values.exporters.jmx.config.rules | toYaml | indent 6 }}
     ssl: false


### PR DESCRIPTION
Adding the possibility to define `whitelistObjectNames` and `blacklistObjectNames` for the jmx exporter as documented in [jmx_exporter#configuration](https://github.com/prometheus/jmx_exporter#configuration).

closes: https://github.com/acryldata/datahub-helm/issues/58

For example, the result with the following values:
```
datahub-gms:
  enabled: true
  image:
    repository: linkedin/datahub-gms
    tag: "v0.8.17"
  exporters:
    jmx:
      enabled: true
      image:
        repository: bitnami/jmx-exporter
        tag: 0.15.0
        pullPolicy: IfNotPresent
      config:
        lowercaseOutputName: true
        whitelistObjectNames:
          # JVM
          - "java.lang:type=Runtime"
          - "java.lang:type=OperatingSystem"
          - "java.lang:type=GarbageCollector,name=*"
          - "java.lang:type=Memory"
        blacklistObjectNames:
          # Kafka
          - "kafka.consumer:type=consumer-fetch-manager-metrics,client-id=*"
          - "kafka.producer:type=producer-metrics,client-id=*"
        rules:
          - pattern: ".*"
        startDelaySeconds: 30
      env: {}
      resources: {}
      path: /metrics
      ports:
        jmxxp:
          containerPort: 5556
          protocol: TCP
      livenessProbe:
        httpGet:
          path: /metrics
          port: jmxxp
        initialDelaySeconds: 30
        periodSeconds: 15
        timeoutSeconds: 60
        failureThreshold: 8
        successThreshold: 1
      readinessProbe:
        httpGet:
          path: /metrics
          port: jmxxp
        initialDelaySeconds: 30
        periodSeconds: 15
        timeoutSeconds: 60
        failureThreshold: 8
        successThreshold: 1
      serviceMonitor:
        interval: 30s
        scrapeTimeout: 30s
        scheme: http
```

will be:
```
# Source: datahub/charts/datahub-gms/templates/config-jmx-exporter.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-datahub-gms-config-jmx-exporter
  labels:
    helm.sh/chart: datahub-gms-0.2.2
    app.kubernetes.io/name: datahub-gms
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.3.1"
    app.kubernetes.io/managed-by: Helm
data:
  config.yml: |-
    hostPort: localhost:1099
    lowercaseOutputName: true
    lowercaseOutputLabelNames: 
    whitelistObjectNames:
      - java.lang:type=Runtime
      - java.lang:type=OperatingSystem
      - java.lang:type=GarbageCollector,name=*
      - java.lang:type=Memory
    blacklistObjectNames:
      - kafka.consumer:type=consumer-fetch-manager-metrics,client-id=*
      - kafka.producer:type=producer-metrics,client-id=*
    rules:
      - pattern: .*
    ssl: false
    startDelaySeconds: 30
```


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
