### PR TITLE
feat(helm postgesqljob)

### DIFF
--- a/charts/datahub/README.md
+++ b/charts/datahub/README.md
@@ -41,6 +41,9 @@ helm install datahub datahub/datahub --values <<path-to-values-file>>
 | mysqlSetupJob.enabled | bool | `false` | Enable setup job for mysql |
 | mysqlSetupJob.image.repository | string | `"acryldata/datahub-mysql-setup"` | Image repository for mysqlSetupJob |
 | mysqlSetupJob.image.tag | string | `"v0.8.23.0"` | Image repository for mysqlSetupJob |
+| postgresqlSetupJob.enabled | bool | `false` | Enable setup job for postgresql |
+| postgresqlSetupJob.image.repository | string | `"acryldata/datahub-postgres-setup"` | Image repository for postgresqlSetupJob |
+| postgresqlSetupJob.image.tag | string | `"v0.8.23.0"` | Image repository for postgresqlSetupJob |
 | global.datahub_standalone_consumers_enabled | boolean | true | Enable standalone consumers for kafka |
 | global.datahub_analytics_enabled | boolean | true | Enable datahub usage analytics |
 | global.datahub.appVersion | string | `"1.0"` | App version for annotation |

--- a/charts/datahub/templates/postgresql-setup-job.yml
+++ b/charts/datahub/templates/postgresql-setup-job.yml
@@ -1,0 +1,81 @@
+{{- if .Values.postgresqlSetupJob.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-postgresql-setup-job
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    spec:
+    {{- with .Values.global.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.postgresqlSetupJob.serviceAccount }}
+      serviceAccountName: {{ . }}
+    {{- end }}
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      volumes:
+      {{- with .Values.postgresqlSetupJob.extraVolumes }}
+        {{- toYaml . | nindent 8}}
+      {{- end }}
+      restartPolicy: Never
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: postgresql-setup-job
+          image: "{{ .Values.postgresqlSetupJob.image.repository }}:{{ .Values.postgresqlSetupJob.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresqlSetupJob.imagePullPolicy | default "Always" }}
+          env:
+            - name: POSTGRES_USERNAME
+              value: {{ .Values.global.sql.datasource.username | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.sql.datasource.password.secretRef }}"
+                  key: "{{ .Values.global.sql.datasource.password.secretKey }}"
+            - name: POSTGRES_HOST
+              value: {{ .Values.global.sql.datasource.hostForpostgresqlClient | quote }}
+            - name: POSTGRES_PORT
+              value: {{ .Values.global.sql.datasource.port | quote }}
+          {{- with .Values.postgresqlSetupJob.extraEnvs }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+          {{- with .Values.postgresqlSetupJob.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 300m
+              memory: 256Mi
+      {{- with .Values.postgresqlSetupJob.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgresqlSetupJob.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgresqlSetupJob.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end -}}

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -50,7 +50,7 @@ mysqlSetupJob:
     tag: "v0.8.23.0"
 
 postgresqlSetupJob:
-  enabled: true
+  enabled: false
   image:
     repository: acryldata/datahub-postgres-setup
     tag: "v0.8.23.0"

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -49,6 +49,12 @@ mysqlSetupJob:
     repository: acryldata/datahub-mysql-setup
     tag: "v0.8.23.0"
 
+postgresqlSetupJob:
+  enabled: true
+  image:
+    repository: acryldata/datahub-postgres-setup
+    tag: "v0.8.23.0"
+
 datahubUpgrade:
   enabled: true
   image:


### PR DESCRIPTION
DataHub's architecture supports postgresql as backend database but the helm chart doesn't provide the job to create the schema. 

This PR will create the job using `acryldata/datahub-postgres-setup` image and use the same values defined in the `sql:`block. 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
