### PR TITLE
upgrade elasticsearch to 7.16.2 to avoid apache log4j vulnerability

### DIFF
--- a/charts/prerequisites/Chart.yaml
+++ b/charts/prerequisites/Chart.yaml
@@ -4,10 +4,10 @@ description: A Helm chart for packages that Datahub depends on
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.5
+version: 0.0.6
 dependencies:
   - name: elasticsearch
-    version: 7.9.3
+    version: 7.16.2
     repository: https://helm.elastic.co
     condition: elasticsearch.enabled
   # This chart deploys an enterprise version of neo4j that requires commercial license


### PR DESCRIPTION
DataHub is using elasticsearch 7.9.3 which is using vulnerable log4j version.

This PR will upgrade the version of elasticsearch from 7.9.3 to 7.16.2 to avoid log4j vulnerability. https://www.elastic.co/blog/new-elasticsearch-and-logstash-releases-upgrade-apache-log4j2

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
