### PR TITLE
fix: Make security context configurable for jobs

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.48
+version: 0.2.49
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.26

--- a/charts/datahub/README.md
+++ b/charts/datahub/README.md
@@ -31,15 +31,23 @@ helm install datahub datahub/datahub --values <<path-to-values-file>>
 | datahub-mce-consumer.image.repository | string | `"linkedin/datahub-mce-consumer"` | Image repository for datahub-mce-consumer |
 | datahub-mce-consumer.image.tag | string | `"v0.8.26"` | Image tag for datahub-mce-consumer |
 | datahub-ingestion-cron.enabled | bool | `false` | Enable cronjob for periodic ingestion |
+| datahubUpgrade.podSecurityContext | object | `{}` | Pod security context for datahubUpgrade jobs |
+| datahubUpgrade.securityContext | object | `{}` | Container security context for datahubUpgrade jobs |
 | elasticsearchSetupJob.enabled | bool | `true` | Enable setup job for elasicsearch |
 | elasticsearchSetupJob.image.repository | string | `"linkedin/datahub-elasticsearch-setup"` | Image repository for elasticsearchSetupJob |
 | elasticsearchSetupJob.image.tag | string | `"v0.8.26"` | Image repository for elasticsearchSetupJob |
+| elasticsearchSetupJob.podSecurityContext | object | `{"fsGroup": 1000}` | Pod security context for elasticsearchSetupJob |
+| elasticsearchSetupJob.securityContext | object | `{"runAsUser": 1000}` | Container security context for elasticsearchSetupJob |
 | kafkaSetupJob.enabled | bool | `true` | Enable setup job for kafka |
 | kafkaSetupJob.image.repository | string | `"linkedin/datahub-kafka-setup"` | Image repository for kafkaSetupJob |
 | kafkaSetupJob.image.tag | string | `"v0.8.26"` | Image repository for kafkaSetupJob |
+| kafkaSetupJob.podSecurityContext | object | `{"fsGroup": 1000}` | Pod security context for kafkaSetupJob |
+| kafkaSetupJob.securityContext | object | `{"runAsUser": 1000}` | Container security context for kafkaSetupJob |
 | mysqlSetupJob.enabled | bool | `false` | Enable setup job for mysql |
 | mysqlSetupJob.image.repository | string | `"acryldata/datahub-mysql-setup"` | Image repository for mysqlSetupJob |
 | mysqlSetupJob.image.tag | string | `"v0.8.26.0"` | Image repository for mysqlSetupJob |
+| mysqlSetupJob.podSecurityContext | object | `{"fsGroup": 1000}` | Pod security context for mysqlSetupJob |
+| mysqlSetupJob.securityContext | object | `{"runAsUser": 1000}` | Container security context for mysqlSetupJob |
 | global.datahub_standalone_consumers_enabled | boolean | true | Enable standalone consumers for kafka |
 | global.datahub_analytics_enabled | boolean | true | Enable datahub usage analytics |
 | global.datahub.appVersion | string | `"1.0"` | App version for annotation |

--- a/charts/datahub/templates/datahub-upgrade/datahub-cleanup-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-cleanup-job-template.yml
@@ -36,8 +36,7 @@ spec:
           {{- end }}
           restartPolicy: Never
           securityContext:
-            runAsUser: 1000
-            fsGroup: 1000
+            {{- toYaml .Values.datahubUpgrade.podSecurityContext | nindent 12 }}
           initContainers:
           {{- with .Values.datahubUpgrade.extraInitContainers }}
             {{- toYaml . | nindent 12 }}
@@ -114,6 +113,8 @@ spec:
               {{- with .Values.datahubUpgrade.extraEnvs }}
                 {{- toYaml . | nindent 16 }}
               {{- end }}
+              securityContext:
+                {{- toYaml .Values.datahubUpgrade.securityContext | nindent 16 }}
               volumeMounts:
               {{- with .Values.datahubUpgrade.extraVolumeMounts }}
                 {{- toYaml . | nindent 16 }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
@@ -42,8 +42,7 @@ spec:
           {{- end }}
           restartPolicy: Never
           securityContext:
-            runAsUser: 1000
-            fsGroup: 1000
+            {{- toYaml .Values.datahubUpgrade.podSecurityContext | nindent 12 }}
           initContainers:
           {{- with .Values.datahubUpgrade.extraInitContainers }}
             {{- toYaml . | nindent 12 }}
@@ -137,6 +136,8 @@ spec:
               {{- with .Values.datahubUpgrade.extraEnvs }}
                 {{- toYaml . | nindent 16 }}
               {{- end }}
+              securityContext:
+                {{- toYaml .Values.datahubUpgrade.securityContext | nindent 16 }}
               volumeMounts:
               {{- with .Values.global.credentialsAndCertsSecrets }}
                 - name: datahub-certs-dir

--- a/charts/datahub/templates/datahub-upgrade/datahub-upgrade-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-upgrade-job.yml
@@ -40,8 +40,7 @@ spec:
       {{- end }}
       restartPolicy: Never
       securityContext:
-        runAsUser: 1000
-        fsGroup: 1000
+        {{- toYaml .Values.datahubUpgrade.podSecurityContext | nindent 8 }}
       initContainers:
       {{- with .Values.datahubUpgrade.extraInitContainers }}
         {{- toYaml . | nindent 12 }}
@@ -141,6 +140,8 @@ spec:
           {{- with .Values.datahubUpgrade.extraEnvs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          securityContext:
+            {{- toYaml .Values.datahubUpgrade.securityContext | nindent 12 }}
           volumeMounts:
           {{- with .Values.global.credentialsAndCertsSecrets }}
             - name: datahub-certs-dir

--- a/charts/datahub/templates/elasticsearch-setup-job.yml
+++ b/charts/datahub/templates/elasticsearch-setup-job.yml
@@ -34,8 +34,7 @@ spec:
       {{- end }}
       restartPolicy: Never
       securityContext:
-        runAsUser: 1000
-        fsGroup: 1000
+        {{- toYaml .Values.elasticsearchSetupJob.podSecurityContext | nindent 8 }}
       containers:
         - name: elasticsearch-setup-job
           image: "{{ .Values.elasticsearchSetupJob.image.repository }}:{{ .Values.elasticsearchSetupJob.image.tag }}"
@@ -67,6 +66,8 @@ spec:
           {{- with .Values.elasticsearchSetupJob.extraEnvs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          securityContext:
+            {{- toYaml .Values.elasticsearchSetupJob.securityContext | nindent 12 }}
           volumeMounts:
           {{- with .Values.elasticsearchSetupJob.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}

--- a/charts/datahub/templates/kafka-setup-job.yml
+++ b/charts/datahub/templates/kafka-setup-job.yml
@@ -26,8 +26,7 @@ spec:
     {{- end }}
       restartPolicy: Never
       securityContext:
-        runAsUser: 1000
-        fsGroup: 1000
+        {{- toYaml .Values.kafkaSetupJob.podSecurityContext | nindent 8 }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -77,6 +76,8 @@ spec:
           {{- with .Values.kafkaSetupJob.extraEnvs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          securityContext:
+            {{- toYaml .Values.kafkaSetupJob.securityContext | nindent 12 }}
           volumeMounts:
           {{- if .Values.global.credentialsAndCertsSecrets }}
             - name: datahub-certs-dir

--- a/charts/datahub/templates/mysql-setup-job.yml
+++ b/charts/datahub/templates/mysql-setup-job.yml
@@ -34,8 +34,7 @@ spec:
       {{- end }}
       restartPolicy: Never
       securityContext:
-        runAsUser: 1000
-        fsGroup: 1000
+        {{- toYaml .Values.mysqlSetupJob.podSecurityContext | nindent 8 }}
       containers:
         - name: mysql-setup-job
           image: "{{ .Values.mysqlSetupJob.image.repository }}:{{ .Values.mysqlSetupJob.image.tag }}"
@@ -55,6 +54,8 @@ spec:
           {{- with .Values.mysqlSetupJob.extraEnvs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          securityContext:
+            {{- toYaml .Values.mysqlSetupJob.securityContext | nindent 12 }}
           volumeMounts:
           {{- with .Values.mysqlSetupJob.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -36,18 +36,30 @@ elasticsearchSetupJob:
   image:
     repository: linkedin/datahub-elasticsearch-setup
     tag: "v0.8.26"
+  podSecurityContext:
+    fsGroup: 1000
+  securityContext:
+    runAsUser: 1000
 
 kafkaSetupJob:
   enabled: true
   image:
     repository: linkedin/datahub-kafka-setup
     tag: "v0.8.26"
+  podSecurityContext:
+    fsGroup: 1000
+  securityContext:
+    runAsUser: 1000
 
 mysqlSetupJob:
   enabled: true
   image:
     repository: acryldata/datahub-mysql-setup
     tag: "v0.8.26.0"
+  podSecurityContext:
+    fsGroup: 1000
+  securityContext:
+    runAsUser: 1000
 
 datahubUpgrade:
   enabled: true
@@ -56,6 +68,10 @@ datahubUpgrade:
     tag: "v0.8.26.0"
   noCodeDataMigration:
     sqlDbType: "MYSQL"
+  podSecurityContext: {}
+    # fsGroup: 1000
+  securityContext: {}
+    # runAsUser: 1000
 
 global:
   graph_service_impl: neo4j


### PR DESCRIPTION
Make security context configurable to be able to use the chart on
Openshift, which typically has restrictions on security contexts and do
not allow the previously hardcoded security contexts.

Some comment about the change:
* I separated podSecurityContext and securityContext as that is how it is done in the deployments. 
* I kept the runAsUser and fsGroup for elasticsearchSetupJob, kafkaSetupJob and mysqlSetupJob as those pods runs as root, but not for datahubUpgrade pod as they typically run as user 101 similar to most of the other datahub pods.  

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
