### PR TITLE
fix(ui-ingestion): Explicitly set ui ingestion enabled to false when told to do so

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.61
+version: 0.2.62
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.31

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -198,6 +198,9 @@ spec:
                 secretKeyRef:
                   name: "{{ .Values.global.datahub.encryptionKey.secretRef }}"
                   key: "{{ .Values.global.datahub.encryptionKey.secretKey }}"
+            {{- else }}
+            - name: UI_INGESTION_ENABLED
+              value: "false"
             {{- end }}
             {{- if .Values.global.datahub.managed_ingestion.defaultCliVersion }}
             - name: UI_INGESTION_DEFAULT_CLI_VERSION

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -160,6 +160,9 @@ spec:
             {{- if .Values.global.datahub.managed_ingestion.enabled }}
             - name: UI_INGESTION_ENABLED
               value: "true"
+            {{- else }}
+            - name: UI_INGESTION_ENABLED
+              value: "false"
             {{- end }}
             {{- if .Values.global.datahub.managed_ingestion.defaultCliVersion }}
             - name: UI_INGESTION_DEFAULT_CLI_VERSION


### PR DESCRIPTION
When env is not set, it is defaulted to true, so need to make sure it is explicitly set to false if ui_ingestion is not enabled
## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
