### PR TITLE
feat(labels): Add podLabels to Helm charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.lock
 *.tgz
 .vscode
+.idea

--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,25 +4,25 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.62
+version: 0.2.63
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.8.31
+appVersion: 0.8.32
 dependencies:
   - name: datahub-gms
-    version: 0.2.3
+    version: 0.2.4
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.2.1
+    version: 0.2.2
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer
-    version: 0.2.3
+    version: 0.2.4
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.2.3
+    version: 0.2.4
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron
@@ -33,7 +33,7 @@ dependencies:
     version: 0.2.1
     repository: file://./subcharts/datahub-jmxexporter
   - name: acryl-datahub-actions
-    version: 0.0.1
+    version: 0.0.2
     repository: file://./subcharts/acryl-datahub-actions
     condition: acryl-datahub-actions.enabled
 maintainers:

--- a/charts/datahub/README.md
+++ b/charts/datahub/README.md
@@ -74,7 +74,7 @@ helm install datahub datahub/datahub --values <<path-to-values-file>>
 | global.sql.datasource.username | string | `"root"` | SQL user name |
 | global.sql.datasource.password.secretRef | string | `"mysql-secrets"` | Secret that contains the MySQL password |
 | global.sql.datasource.password.secretKey | string | `"mysql-password"` | Secret key that contains the MySQL password |
-| global.graph_service_impl | string | `neo4j` | One of `neo4j` or `elasticsearch`. Determines which backend to use for the GMS graph service. Elastic is recommended for a simplified deployment. Neo4j will be the default for now to maintain backwards compatibility.
+| global.graph_service_impl | string | `neo4j` | One of `neo4j` or `elasticsearch`. Determines which backend to use for the GMS graph service. Elastic is recommended for a simplified deployment. Neo4j will be the default for now to maintain backwards compatibility |
 
 ## Optional Chart Values
 

--- a/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.0.1
+appVersion: 0.0.2

--- a/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
     {{- end }}
       labels:
         {{- include "acryl-datahub-actions.selectorLabels" . | nindent 8 }}
+        {{- range $key, $value := .Values.global.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.3.1
+appVersion: 0.3.2

--- a/charts/datahub/subcharts/datahub-frontend/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-frontend/templates/_helpers.tpl
@@ -66,7 +66,7 @@ Create the name of the service account to use
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "datahub-frontend.ingress.apiVersion" -}}
-{{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.Version -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.Version -}}
 {{- print "networking.k8s.io/v1" -}}
 {{- else if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version }}
 {{- print "extensions/v1beta1" -}}

--- a/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
     {{- end }}
       labels:
         {{- include "datahub-frontend.selectorLabels" . | nindent 8 }}
+        {{- range $key, $value := .Values.global.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.3.1
+appVersion: 0.3.2

--- a/charts/datahub/subcharts/datahub-gms/README.md
+++ b/charts/datahub/subcharts/datahub-gms/README.md
@@ -37,7 +37,7 @@ Current chart version is `0.2.0`
 | global.sql.datasource.username | string | `"datahub"` |  |
 | global.sql.datasource.password.secretRef | string | `"mysql-secrets"` |  |
 | global.sql.datasource.password.secretKey | string | `"mysql-password"` |  |
-| global.graph_service_impl | string | `neo4j` | One of `neo4j` or `elasticsearch`. Determines which backend to use for the GMS graph service. Elastic is recommended for a simplified deployment. Neo4j will be the default for now to maintain backwards compatibility.
+| global.graph_service_impl | string | `neo4j` | One of `neo4j` or `elasticsearch`. Determines which backend to use for the GMS graph service. Elastic is recommended for a simplified deployment. Neo4j will be the default for now to maintain backwards compatibility |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"linkedin/datahub-gms"` |  |
 | image.tag | string | `"head"` |  |

--- a/charts/datahub/subcharts/datahub-gms/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-gms/templates/_helpers.tpl
@@ -66,7 +66,7 @@ Create the name of the service account to use
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "datahub-gms.ingress.apiVersion" -}}
-{{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.Version -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.Version -}}
 {{- print "networking.k8s.io/v1" -}}
 {{- else if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version }}
 {{- print "extensions/v1beta1" -}}

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
     {{- end }}
       labels:
         {{- include "datahub-gms.selectorLabels" . | nindent 8 }}
+        {{- range $key, $value := .Values.global.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
     {{- with .Values.global.hostAliases }}
       hostAliases:

--- a/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.3.1
+appVersion: 0.3.2

--- a/charts/datahub/subcharts/datahub-mae-consumer/README.md
+++ b/charts/datahub/subcharts/datahub-mae-consumer/README.md
@@ -31,7 +31,7 @@ Current chart version is `0.2.0`
 | global.hostAliases[0].hostnames[2] | string | `"elasticsearch"` |  |
 | global.hostAliases[0].hostnames[3] | string | `"neo4j"` |  |
 | global.hostAliases[0].ip | string | `"192.168.0.104"` |  |
-| global.graph_service_impl | string | `neo4j` | One of `neo4j` or `elasticsearch`. Determines which backend to use for the GMS graph service. Elastic is recommended for a simplified deployment. Neo4j will be the default for now to maintain backwards compatibility.
+| global.graph_service_impl | string | `neo4j` | One of `neo4j` or `elasticsearch`. Determines which backend to use for the GMS graph service. Elastic is recommended for a simplified deployment. Neo4j will be the default for now to maintain backwards compatibility |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"linkedin/datahub-mae-consumer"` |  |
 | image.tag | string | `"head"` |  |

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
     {{- end }}
       labels:
         {{- include "datahub-mae-consumer.selectorLabels" . | nindent 8 }}
+        {{- range $key, $value := .Values.global.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
     {{- with .Values.global.hostAliases }}
       hostAliases:

--- a/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.3.1
+appVersion: 0.3.2

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
     {{- end }}
       labels:
         {{- include "datahub-mce-consumer.selectorLabels" . | nindent 8 }}
+        {{- range $key, $value := .Values.global.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
     {{- with .Values.global.hostAliases }}
       hostAliases:

--- a/charts/datahub/templates/datahub-upgrade/datahub-cleanup-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-cleanup-job-template.yml
@@ -18,6 +18,13 @@ spec:
   jobTemplate:
     spec:
       template:
+        {{- if .Values.global.podLabels }}
+        metadata:
+          labels:
+            {{- range $key, $value := .Values.global.podLabels }}
+            {{ $key }}: {{ $value | quote }}
+            {{- end }}
+        {{- end }}
         spec:
         {{- with .Values.global.hostAliases }}
           hostAliases:

--- a/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
@@ -18,6 +18,13 @@ spec:
   jobTemplate:
     spec:
       template:
+        {{- if .Values.global.podLabels }}
+        metadata:
+          labels:
+            {{- range $key, $value := .Values.global.podLabels }}
+            {{ $key }}: {{ $value | quote }}
+            {{- end }}
+        {{- end }}
         spec:
         {{- with .Values.global.hostAliases }}
           hostAliases:

--- a/charts/datahub/templates/datahub-upgrade/datahub-upgrade-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-upgrade-job.yml
@@ -16,6 +16,13 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
+    {{- if .Values.global.podLabels }}
+    metadata:
+      labels:
+        {{- range $key, $value := .Values.global.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
     spec:
     {{- with .Values.global.hostAliases }}
       hostAliases:

--- a/charts/datahub/templates/elasticsearch-setup-job.yml
+++ b/charts/datahub/templates/elasticsearch-setup-job.yml
@@ -16,6 +16,13 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
+    {{- if .Values.global.podLabels }}
+    metadata:
+      labels:
+        {{- range $key, $value := .Values.global.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
     spec:
     {{- with .Values.global.hostAliases }}
       hostAliases:

--- a/charts/datahub/templates/kafka-setup-job.yml
+++ b/charts/datahub/templates/kafka-setup-job.yml
@@ -16,6 +16,13 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
+    {{- if .Values.global.podLabels }}
+    metadata:
+      labels:
+        {{- range $key, $value := .Values.global.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
     spec:
     {{- with .Values.global.hostAliases }}
       hostAliases:

--- a/charts/datahub/templates/mysql-setup-job.yml
+++ b/charts/datahub/templates/mysql-setup-job.yml
@@ -16,6 +16,13 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
+    {{- if .Values.global.podLabels }}
+    metadata:
+      labels:
+        {{- range $key, $value := .Values.global.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
     spec:
     {{- with .Values.global.hostAliases }}
       hostAliases:

--- a/charts/datahub/templates/postgresql-setup-job.yml
+++ b/charts/datahub/templates/postgresql-setup-job.yml
@@ -16,6 +16,13 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
+    {{- if .Values.global.podLabels }}
+    metadata:
+      labels:
+        {{- range $key, $value := .Values.global.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
     spec:
     {{- with .Values.global.hostAliases }}
       hostAliases:


### PR DESCRIPTION
This is useful when a K8s cluster requires certain labels to deploy pods. I have tested this on an internal kubernetes instance and it behaves well both when `podLabels` is supplied and when it isn't.

Other changes include migrating to the new ingress API when it becomes available rather then waiting for it to be removed entirely, and some README fixes to the tables.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)