### PR TITLE
fix: Fix elasticsearch Readiness probe failed

### DIFF
--- a/charts/prerequisites/values.yaml
+++ b/charts/prerequisites/values.yaml
@@ -8,6 +8,9 @@ elasticsearch:
   # a master node when deploying on a single node Minikube / Kind / etc cluster.
   # antiAffinity: "soft"
 
+  # # If your running a single replica cluster add the following helm value
+  # clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
+
   # # Shrink default JVM heap.
   # esJavaOpts: "-Xmx128m -Xms128m"
 


### PR DESCRIPTION
Fix elasticsearch Readiness probe failed.

Ref: [elastic/helm-charts/elasticsearch: Readiness probe failed: Waiting for elasticsearch cluster to become ready #783](https://github.com/elastic/helm-charts/issues/783)

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
