### PR TITLE
fix(ingress): fix redirect by annotation on k8s >= 1.19

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.63
+version: 0.2.64
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.32

--- a/charts/datahub/subcharts/datahub-frontend/templates/ingress.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/ingress.yaml
@@ -39,7 +39,11 @@ spec:
               service:
                 name: {{ .name }}
                 port:
+                {{- if eq .port "use-annotation" }}
+                  name: {{ .port }}
+                {{- else }}
                   number: {{ .port }}
+                {{- end }}
             {{- else }}
             backend:
               serviceName: {{ .name }}

--- a/charts/datahub/subcharts/datahub-gms/templates/ingress.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/ingress.yaml
@@ -39,7 +39,11 @@ spec:
               service:
                 name: {{ .name }}
                 port:
+                {{- if eq .port "use-annotation" }}
+                  name: {{ .port }}
+                {{- else }}
                   number: {{ .port }}
+                {{- end }}
             {{- else }}
             backend:
               serviceName: {{ .name }}


### PR DESCRIPTION
The API version change to the ingresses are broken when used with ports that are not numbers. E.g. ALB ingress controller annotations.

Refs: https://github.com/acryldata/datahub-helm/pull/98/files/20521ec9661db7afdb3f9b96dbe53181c62947ad#r831117346

This is my relevant configuration, that worked before on a v1.21 cluster:

```hcl
ingress = {
  enabled = true
  hosts = [{
    host  = local.datahub_fqdn
    paths = ["/*"]
    redirectPaths = [{
      path = "/*"
      name = "ssl-redirect"
      port = "use-annotation" // <- this is not a number!
    }]
  }]
  annotations = {
    "kubernetes.io/ingress.class"            = "alb"
    "alb.ingress.kubernetes.io/target-type"  = "ip"
    "alb.ingress.kubernetes.io/group.name"   = "internal"
    "alb.ingress.kubernetes.io/listen-ports" = jsonencode([{ HTTP = 80 }, { HTTPS = 443 }])
    "alb.ingress.kubernetes.io/actions.ssl-redirect" = jsonencode({
      Type = "redirect",
      RedirectConfig = {
        Protocol   = "HTTPS",
        Port       = "443",
        StatusCode = "HTTP_301"
      }
    })
  }
}
```
