### PR TITLE
fix(cronjob) Update CronJobs to use stable api in k8s 1.21

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.65
+version: 0.2.66
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.32

--- a/charts/datahub/subcharts/datahub-ingestion-cron/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/templates/_helpers.tpl
@@ -61,3 +61,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for cronjob.
+*/}}
+{{- define "datahub-ingestion-cron.cronjob.apiVersion" -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version -}}
+{{- print "batch/v1" -}}
+{{- else -}}
+{{- print "batch/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
@@ -2,7 +2,7 @@
 {{- $labels := include "datahub-ingestion-cron.labels" .}}
 {{- range $jobName, $val := .Values.crons }}
 {{- $defaultCommand := printf "datahub ingest -c /etc/recipe/%s" $val.recipe.fileName }}
-apiVersion: batch/v1beta1
+apiVersion: {{ template "datahub-ingestion-cron.cronjob.apiVersion" . }}
 kind: CronJob
 metadata:
   name: "{{ $baseName }}-{{ $jobName }}"

--- a/charts/datahub/templates/_helpers.tpl
+++ b/charts/datahub/templates/_helpers.tpl
@@ -61,3 +61,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for cronjob.
+*/}}
+{{- define "datahub-ingestion-cron.cronjob.apiVersion" -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version -}}
+{{- print "batch/v1" -}}
+{{- else -}}
+{{- print "batch/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/datahub/templates/datahub-upgrade/datahub-cleanup-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-cleanup-job-template.yml
@@ -3,7 +3,7 @@
 # Creates a suspended cronJob that you can use to create an adhoc job when ready to run clean up.
 # Run the following command to do so
 # kubectl create job --from=cronjob/<<release-name>>-datahub-cleanup-job-template datahub-cleanup-job
-apiVersion: batch/v1beta1
+apiVersion: {{ template "datahub-ingestion-cron.cronjob.apiVersion" . }}
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-datahub-cleanup-job-template

--- a/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
@@ -3,7 +3,7 @@
 # Creates a suspended cronJob that you can use to create an adhoc job when ready to run clean up.
 # Run the following command to do so
 # kubectl create job --from=cronjob/<<release-name>>-datahub-restore-indices-job-template datahub-restore-indices-job
-apiVersion: batch/v1beta1
+apiVersion: {{ template "datahub-ingestion-cron.cronjob.apiVersion" . }}
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-datahub-restore-indices-job-template

--- a/charts/datahub/templates/datahub-upgrade/datahub-upgrade-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-upgrade-job.yml
@@ -1,5 +1,5 @@
 {{- if .Values.datahubUpgrade.enabled -}}
-apiVersion: batch/v1
+apiVersion: {{ template "datahub-ingestion-cron.cronjob.apiVersion" . }}
 kind: Job
 metadata:
   name: {{ .Release.Name }}-datahub-upgrade-job


### PR DESCRIPTION
Uses helper methods to detect k8s version being used and changes API spec in CronJob resources accordingly.
Tested locally using minikube with helm dry-runs, cron job warnings no longer appear.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
