### PR TITLE
fix(deployment): added jmx port for mce deployment, jmx only

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,13 +4,13 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.69
+version: 0.2.70
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.33
 dependencies:
   - name: datahub-gms
-    version: 0.2.4
+    version: 0.2.5
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
@@ -18,11 +18,11 @@ dependencies:
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer
-    version: 0.2.4
+    version: 0.2.5
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.2.4
+    version: 0.2.5
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-          {{- if .Values.global.datahub.monitoring.enablePrometheus }}
+          {{- if or .Values.global.datahub.monitoring.enablePrometheus .Values.global.datahub.monitoring.enableJMXPort }}
             - name: jmx
               containerPort: 4318
               protocol: TCP

--- a/charts/datahub/subcharts/datahub-gms/values.yaml
+++ b/charts/datahub/subcharts/datahub-gms/values.yaml
@@ -191,6 +191,7 @@ global:
   datahub:
     monitoring:
       enablePrometheus: false
+      enableJMXPort: false
     gms:
       port: "8080"
     appVersion: "1.0"

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
             - name: http
               containerPort: 9091
               protocol: TCP
-          {{- if .Values.global.datahub.monitoring.enablePrometheus }}
+          {{- if or .Values.global.datahub.monitoring.enablePrometheus .Values.global.datahub.monitoring.enableJMXPort }}
             - name: jmx
               containerPort: 4318
               protocol: TCP

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
@@ -57,6 +57,12 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+          {{- if or .Values.global.datahub.monitoring.enablePrometheus .Values.global.datahub.monitoring.enableJMXPort }}
+            - name: jmx
+              containerPort: 4318
+              protocol: TCP
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /actuator/health


### PR DESCRIPTION
## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

This PR is to add JMX port for MCE deployment which was missing.

When working on exposing JMX metrics, I think we cannot assume that everyone will be using prometheus exporter?
Hence I added `enableJMXPort` , happy to discuss or remove it.
In my case I was using Datadog, which has a direct JMX integration. 

Let me know what I need to change too. Thanks
Will be happy to add this as a comment as well, so that developers will be onboarded faster.

>       - name: JMX_OPTS
>         value: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=4318 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"