### PR TITLE
fix: remove yanked cli as default

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.73
+version: 0.2.74
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.34

--- a/charts/datahub/README.md
+++ b/charts/datahub/README.md
@@ -101,6 +101,6 @@ helm install datahub datahub/datahub --values <<path-to-values-file>>
 | global.datahub.managed_ingestion.enabled | bool | `true` | Whether or not UI-based ingestion experience is enabled. |
 | global.datahub.encryptionKey.secretRef | string | `datahub-encryption-secrets` | The reference to a secret containing an alpha-numeric encryption key, which is used to encrypt Secrets on DataHub. If a secret reference is not provided, a random one will be generated for you in a Kubernetes secret named `datahub-encryption-secrets`. |
 | global.datahub.encryptionKey.secretKey | string | `encryption_key_secret` | The key of a secret containing an alpha-numeric encryption key, which is used to encrypt Secrets on DataHub. If a secret reference is not provided, a random one will be generated for you in a Kubernetes secret value named `encryption_key_secret` within a secret named `datahub-encryption-secrets`. |
-| global.datahub.managed_ingestion.defaultCliVersion | string | `0.8.34` | This is the version of the DataHub CLI to use for UI ingestion, by default. |
+| global.datahub.managed_ingestion.defaultCliVersion | string | `0.8.34.1` | This is the version of the DataHub CLI to use for UI ingestion, by default. |
 | global.datahub.encryptionKey.provisionSecret | bool | `true` | Whether an encryption key secret should be provisioned on the first deployment for you. Set this to false if you are overriding global.datahub.encryptionKey.secretRef. |
 | global.datahub.enable_retention | bool | `false` | Whether or not to enable retention on local DB |

--- a/charts/datahub/quickstart-values-with-neo4j.yaml
+++ b/charts/datahub/quickstart-values-with-neo4j.yaml
@@ -102,4 +102,4 @@ global:
 
     managed_ingestion:
       enabled: true
-      defaultCliVersion: "0.8.34"
+      defaultCliVersion: "0.8.34.1"

--- a/charts/datahub/subcharts/datahub-gms/README.md
+++ b/charts/datahub/subcharts/datahub-gms/README.md
@@ -73,5 +73,5 @@ Current chart version is `0.2.0`
 | global.datahub.managed_ingestion.enabled | bool | `true` | Whether or not UI-based ingestion experience is enabled. |
 | global.datahub.encryptionKey.secretRef | string | `nil` | The reference to a secret containing an alpha-numeric encryption key, which is used to encrypt Secrets on DataHub. Required if managed_ingestion_enabled is 'true'. |
 | global.datahub.encryptionKey.secretKey | string | `nil` | The key of a secret containing an alpha-numeric encryption key, which is used to encrypt Secrets on DataHub. Required if managed_ingestion_enabled is 'true'. |
-| global.datahub.managed_ingestion.defaultCliVersion | string | `0.8.34` | This is the version of the DataHub CLI to use for UI ingestion, by default. You do not need to explicitly provide this. By default the underlying datahub-gms container will provide a latest version compatible with the server. |
+| global.datahub.managed_ingestion.defaultCliVersion | string | `0.8.34.1` | This is the version of the DataHub CLI to use for UI ingestion, by default. You do not need to explicitly provide this. By default the underlying datahub-gms container will provide a latest version compatible with the server. |
 | global.datahub.enable_retention | bool | `false` | Whether or not to enable retention on local DB |

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -156,7 +156,7 @@ global:
 
     managed_ingestion:
       enabled: true
-      defaultCliVersion: "0.8.34"
+      defaultCliVersion: "0.8.34.1"
 
     metadata_service_authentication:
       enabled: false


### PR DESCRIPTION
0.8.34 is yanked https://pypi.org/project/acryl-datahub/0.8.34/ We should not be using that.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
