### PR TITLE
docs: add missing docs for defining host for postgresqlSetupJob

### DIFF
--- a/charts/datahub/README.md
+++ b/charts/datahub/README.md
@@ -107,3 +107,4 @@ helm install datahub datahub/datahub --values <<path-to-values-file>>
 | global.datahub.managed_ingestion.defaultCliVersion | string | `0.8.36` | This is the version of the DataHub CLI to use for UI ingestion, by default. |
 | global.datahub.encryptionKey.provisionSecret | bool | `true` | Whether an encryption key secret should be provisioned on the first deployment for you. Set this to false if you are overriding global.datahub.encryptionKey.secretRef. |
 | global.datahub.enable_retention | bool | `false` | Whether or not to enable retention on local DB |
+| global.sql.datasource.hostForpostgresqlClient | string | `""` | SQL database host (without port) when using postgresqlSetupJob |


### PR DESCRIPTION
When using postgresqlSetupJob the database host has to be specified in `values.yaml`.  The necessary field, `global.sql.datasource. hostForPostgresqlClient`, was missing from README.md.


## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable)
