### PR TITLE
fix(security): generate a new token_service_salt if it is not set in the existing secret

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.76
+version: 0.2.77
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.35

--- a/charts/datahub/templates/datahub-auth-secrets.yml
+++ b/charts/datahub/templates/datahub-auth-secrets.yml
@@ -16,6 +16,13 @@ data:
   # if set, then use the old value
   system_client_secret: {{ index $secret.data "system_client_secret" }}
   token_service_signing_key: {{ index $secret.data "token_service_signing_key" }}
+  # token_service_salt must be checked separately, because this key might be missing in the existing secret
+  {{- if not (index $secret.data "token_service_salt") }}
+  # if the key is not set, then generate a new salt
+  token_service_salt: {{ randAlphaNum 32 | b64enc | quote }}
+  {{ else }}
+  # if the key is set, then use the old value
   token_service_salt: {{ index $secret.data "token_service_salt" }}
+  {{ end }}
   {{ end }}
 {{- end -}}


### PR DESCRIPTION
A missing "token_service_salt" key in an existing "datahub-auth-secrets" secret (which was introduced with PR #118) causes a failed upgrade: `Error: UPGRADE FAILED: error validating "": error validating data: unknown object type "nil" in Secret.data.token_service_salt`

This PR fixes this problem by generating a new salt when the key is not already set in the existing secret.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
