### PR TITLE
feat(prerequisites): add postgresql to prerequistes Helm chart as an optional dependency

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.92
+version: 0.2.93
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.44

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -96,6 +96,7 @@ datahubUpgrade:
   batchDelayMs: 100
   noCodeDataMigration:
     sqlDbType: "MYSQL"
+    # sqlDbType: "POSTGRES"
   podSecurityContext: {}
     # fsGroup: 1000
   securityContext: {}
@@ -154,6 +155,17 @@ global:
         secretRef: mysql-secrets
         secretKey: mysql-root-password
 
+      ## Use below for usage of PostgreSQL instead of MySQL
+      # host: "prerequisites-postgresql:5432"
+      # hostForpostgresqlClient: "prerequisites-postgresql"
+      # port: "5432"
+      # url: "jdbc:postgresql://prerequisites-postgresql:5432/datahub"
+      # driver: "org.postgresql.Driver"
+      # username: "postgres"
+      # password:
+      #   secretRef: postgresql-secrets
+      #   secretKey: postgres-password
+
   datahub:
     gms:
       port: "8080"
@@ -194,10 +206,11 @@ global:
 #      hostnames:
 #        - "broker"
 #        - "mysql"
+#        - "postgresql"
 #        - "elasticsearch"
 #        - "neo4j"
 
-##  Add below to enable SSL for kafka
+## Add below to enable SSL for kafka
 #  credentialsAndCertsSecrets:
 #    name: datahub-certs
 #    path: /mnt/datahub/certs

--- a/charts/prerequisites/Chart.yaml
+++ b/charts/prerequisites/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for packages that Datahub depends on
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.9
+version: 0.0.10
 dependencies:
   - name: elasticsearch
     version: 7.16.2
@@ -24,6 +24,10 @@ dependencies:
     version: 9.1.2
     repository: https://charts.bitnami.com/bitnami
     condition: mysql.enabled
+  - name: postgresql
+    version: 11.2.2
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled
   # This chart deploys an enterprise version of kafka that requires commercial license
   # Note, Schema registry and kafka rest proxy do not require the commercial license
   - name: cp-helm-charts

--- a/charts/prerequisites/values.yaml
+++ b/charts/prerequisites/values.yaml
@@ -56,6 +56,12 @@ mysql:
     # For better security, add mysql-secrets k8s secret with mysql-root-password, mysql-replication-password and mysql-password
     existingSecret: mysql-secrets
 
+postgresql:
+  enabled: false
+  auth:
+    # For better security, add postgresql-secrets k8s secret with postgres-password, replication-password and password
+    existingSecret: postgresql-secrets
+
 cp-helm-charts:
   # Schema registry is under the community license
   cp-schema-registry:


### PR DESCRIPTION
This PR adds the postgresql chart from the Bitnami chart repository as an optional and by default disabled dependency to the prerequisites Helm chart. Additionally I have added some example configuration to the values.yaml of the datahub Helm chart for documentation purposes (as far as I know the usage of PostgreSQL is not documented anywhere, as I had to search the repository for the [correct values](https://github.com/datahub-project/datahub/blob/master/docker/datahub-gms/env/docker.postgres.env) etc.).

I am not sure if this should be part of the official Helm charts, but as I wanted to use PostgreSQL in my local deployment and I already changed the charts accordingly, maybe others also want to use it and do not want to do the work twice.

If this PR is merged, we could also add some documentation [here](https://datahubproject.io/docs/deploy/kubernetes/), to explain how to use PostgreSQL, etc.

See also issue #49.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
