### PR TITLE
docs(datahub-values): add sql port to docs

### DIFF
--- a/charts/datahub/README.md
+++ b/charts/datahub/README.md
@@ -70,6 +70,7 @@ helm install datahub datahub/datahub --values <<path-to-values-file>>
 | global.sql.datasource.driver | string | `"com.mysql.cj.jdbc.Driver"` | Driver for the SQL database |
 | global.sql.datasource.host | string | `"prerequisites-mysql:3306"` | SQL database host (with port) |
 | global.sql.datasource.hostForMysqlClient | string | `"prerequisites-mysql"` | SQL database host (without port) |
+| global.sql.datasource.port | string | `"3306"` | SQL database port |
 | global.sql.datasource.url | string | `"jdbc:mysql://prerequisites-mysql:3306/datahub?verifyServerCertificate=false\u0026useSSL=true"` | URL to access SQL database |
 | global.sql.datasource.username | string | `"root"` | SQL user name |
 | global.sql.datasource.password.secretRef | string | `"mysql-secrets"` | Secret that contains the MySQL password |


### PR DESCRIPTION
Docs for the chart values do not mention the port override parameter for SQL dbs. In this pr, I'm adding that to the docs for its visibility


## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable)
