### PR TITLE
Enable PE consumer + migrate to DataHub Actions Container

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.79
+version: 0.2.80
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.36

--- a/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
@@ -63,8 +63,6 @@ spec:
               value: "{{ .Values.global.kafka.schemaregistry.url }}"
             - name: KAFKA_AUTO_OFFSET_POLICY
               value: "{{ .Values.actions.kafkaAutoOffsetPolicy }}"
-            - name: ACTION_FILE_NAME
-              value: "{{ .Values.actionFileName }}"
             {{- if .Values.global.springKafkaConfigurationOverrides }}
             {{- range $configName, $configValue := .Values.global.springKafkaConfigurationOverrides }}
             - name: KAFKA_PROPERTIES_{{ $configName | replace "." "_" | upper }}

--- a/charts/datahub/subcharts/acryl-datahub-actions/values.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/values.yaml
@@ -4,8 +4,8 @@
 replicaCount: 1
 
 image:
-  repository: public.ecr.aws/datahub/acryl-datahub-actions
-  tag: "v0.0.1-beta.13"
+  repository: acryldata/datahub-actions
+  tag: "v0.0.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -53,9 +53,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-
-# The action pipeline to run: expected to be found at /etc/datahub/actions/{actionFileName} for the container
-actionFileName: "executor.yaml"
 
 actions:
   kafkaAutoOffsetPolicy: "latest"

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -90,6 +90,8 @@ spec:
               value: "true"
             - name: MAE_CONSUMER_ENABLED
               value: "true"
+            - name: PE_CONSUMER_ENABLED
+              value: "true"
             {{- end }}
             - name: ENTITY_REGISTRY_CONFIG_PATH
               value: /datahub/datahub-gms/resources/entity-registry.yml

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -87,6 +87,8 @@ spec:
             {{- end }}
             - name: MAE_CONSUMER_ENABLED
               value: "true"
+            - name: PE_CONSUMER_ENABLED
+              value: "true"
             - name: ENTITY_REGISTRY_CONFIG_PATH
               value: /datahub/datahub-mae-consumer/resources/entity-registry.yml
             - name: DATAHUB_GMS_HOST


### PR DESCRIPTION
Title says it. 

- Enable PE consumer in gms pod / mae consumer pod 
- Migrate to new DataHub Actions container

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
