### PR TITLE
Option to add podAnnotations to jobs.

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.85
+version: 0.2.86
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.40
@@ -26,7 +26,7 @@ dependencies:
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron
-    version: 0.2.3
+    version: 0.2.4
     repository: file://./subcharts/datahub-ingestion-cron
     condition: datahub-ingestion-cron.enabled
   - name: datahub-jmxexporter

--- a/charts/datahub/README.md
+++ b/charts/datahub/README.md
@@ -33,26 +33,31 @@ helm install datahub datahub/datahub --values <<path-to-values-file>>
 | datahub-ingestion-cron.enabled | bool | `false` | Enable cronjob for periodic ingestion |
 | datahubUpgrade.podSecurityContext | object | `{}` | Pod security context for datahubUpgrade jobs |
 | datahubUpgrade.securityContext | object | `{}` | Container security context for datahubUpgrade jobs |
+| datahubUpgrade.podAnnotations | object | `{}` | Pod annotations for datahubUpgrade jobs |
 | elasticsearchSetupJob.enabled | bool | `true` | Enable setup job for elasicsearch |
 | elasticsearchSetupJob.image.repository | string | `"linkedin/datahub-elasticsearch-setup"` | Image repository for elasticsearchSetupJob |
 | elasticsearchSetupJob.image.tag | string | `"v0.8.40"` | Image repository for elasticsearchSetupJob |
 | elasticsearchSetupJob.podSecurityContext | object | `{"fsGroup": 1000}` | Pod security context for elasticsearchSetupJob |
 | elasticsearchSetupJob.securityContext | object | `{"runAsUser": 1000}` | Container security context for elasticsearchSetupJob |
+| elasticsearchSetupJob.podAnnotations | object | `{}` | Pod annotations for elasticsearchSetupJob |
 | kafkaSetupJob.enabled | bool | `true` | Enable setup job for kafka |
 | kafkaSetupJob.image.repository | string | `"linkedin/datahub-kafka-setup"` | Image repository for kafkaSetupJob |
 | kafkaSetupJob.image.tag | string | `"v0.8.40"` | Image repository for kafkaSetupJob |
 | kafkaSetupJob.podSecurityContext | object | `{"fsGroup": 1000}` | Pod security context for kafkaSetupJob |
 | kafkaSetupJob.securityContext | object | `{"runAsUser": 1000}` | Container security context for kafkaSetupJob |
+| kafkaSetupJob.podAnnotations | object | `{}` | Pod annotations for kafkaSetupJob |
 | mysqlSetupJob.enabled | bool | `false` | Enable setup job for mysql |
 | mysqlSetupJob.image.repository | string | `"acryldata/datahub-mysql-setup"` | Image repository for mysqlSetupJob |
 | mysqlSetupJob.image.tag | string | `"v0.8.40"` | Image repository for mysqlSetupJob |
 | mysqlSetupJob.podSecurityContext | object | `{"fsGroup": 1000}` | Pod security context for mysqlSetupJob |
 | mysqlSetupJob.securityContext | object | `{"runAsUser": 1000}` | Container security context for mysqlSetupJob |
+| mysqlSetupJob.podAnnotations | object | `{}` | Pod annotations for mysqlSetupJob |
 | postgresqlSetupJob.enabled | bool | `false` | Enable setup job for postgresql |
 | postgresqlSetupJob.image.repository | string | `"acryldata/datahub-postgres-setup"` | Image repository for postgresqlSetupJob |
 | postgresqlSetupJob.image.tag | string | `"v0.8.40"` | Image repository for postgresqlSetupJob |
 | postgresqlSetupJob.podSecurityContext | object | `{"fsGroup": 1000}` | Pod security context for mysqlSetupJob |
 | postgresqlSetupJob.securityContext | object | `{"runAsUser": 1000}` | Container security context for mysqlSetupJob |
+| postgresqlSetupJob.podAnnotations | object | `{}` | Pod annotations for mysqlSetupJob |
 | global.datahub_standalone_consumers_enabled | boolean | true | Enable standalone consumers for kafka |
 | global.datahub_analytics_enabled | boolean | true | Enable datahub usage analytics |
 | global.datahub.appVersion | string | `"1.0"` | App version for annotation |

--- a/charts/datahub/subcharts/datahub-ingestion-cron/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/subcharts/datahub-ingestion-cron/README.md
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/README.md
@@ -26,3 +26,4 @@ A Helm chart for datahub's metadata-ingestion framework with kerberos authentica
 | crons.extraVolumeMounts | array | `[]` | Additional volume mounts to add to the pods |
 | crons.extraInitContainers | object | `{}` | Init containers to add to the cronjob container |
 | crons.serviceAccountName | string | | Service account name used for the cronjob container |
+| crons.podAnnotations | object | `{}` | Annotations to add to the pods |

--- a/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
@@ -11,7 +11,12 @@ spec:
   schedule: {{ default "0 0 * * *" .schedule | quote}}
   jobTemplate:
     spec:
-      template:
+      template:        
+        {{- with $val.podAnnotations }}
+        metadata:
+          annotations:
+            {{- toYaml . | nindent 12 }}    
+        {{- end }}
         spec:
         {{- with $.Values.imagePullSecrets }}
           imagePullSecrets:

--- a/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
@@ -54,3 +54,7 @@ crons: {}
     ## If you want to specify your own service account, set its name like so.
     ##
     #serviceAccountName: "my-cron-service"
+
+    ## Add your own pod annotations.
+    ##
+    #podAnnotations: {}

--- a/charts/datahub/templates/datahub-upgrade/datahub-cleanup-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-cleanup-job-template.yml
@@ -18,12 +18,18 @@ spec:
   jobTemplate:
     spec:
       template:
-        {{- if .Values.global.podLabels }}
+        {{- if or .Values.global.podLabels .Values.datahubUpgrade.podAnnotations }}
         metadata:
+        {{- with .Values.datahubUpgrade.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.global.podLabels }}
           labels:
-            {{- range $key, $value := .Values.global.podLabels }}
+            {{- range $key, $value := . }}
             {{ $key }}: {{ $value | quote }}
             {{- end }}
+        {{- end }}
         {{- end }}
         spec:
         {{- with .Values.global.hostAliases }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
@@ -18,12 +18,18 @@ spec:
   jobTemplate:
     spec:
       template:
-        {{- if .Values.global.podLabels }}
+        {{- if or .Values.global.podLabels .Values.datahubUpgrade.podAnnotations }}
         metadata:
+        {{- with .Values.datahubUpgrade.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.global.podLabels }}
           labels:
-            {{- range $key, $value := .Values.global.podLabels }}
+            {{- range $key, $value := . }}
             {{ $key }}: {{ $value | quote }}
             {{- end }}
+        {{- end }}
         {{- end }}
         spec:
         {{- with .Values.global.hostAliases }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-upgrade-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-upgrade-job.yml
@@ -16,12 +16,18 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
-    {{- if .Values.global.podLabels }}
+    {{- if or .Values.global.podLabels .Values.datahubUpgrade.podAnnotations}}
     metadata:
+    {{- with .Values.datahubUpgrade.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.global.podLabels }}
       labels:
-        {{- range $key, $value := .Values.global.podLabels }}
+        {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
+    {{- end }}
     {{- end }}
     spec:
     {{- with .Values.global.hostAliases }}

--- a/charts/datahub/templates/elasticsearch-setup-job.yml
+++ b/charts/datahub/templates/elasticsearch-setup-job.yml
@@ -16,12 +16,18 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
-    {{- if .Values.global.podLabels }}
+    {{- if or .Values.global.podLabels .Values.elasticsearchSetupJob.podAnnotations }}
     metadata:
+    {{- with .Values.elasticsearchSetupJob.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.global.podLabels }}
       labels:
-        {{- range $key, $value := .Values.global.podLabels }}
+        {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
+    {{- end }}
     {{- end }}
     spec:
     {{- with .Values.global.hostAliases }}

--- a/charts/datahub/templates/kafka-setup-job.yml
+++ b/charts/datahub/templates/kafka-setup-job.yml
@@ -16,12 +16,18 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
-    {{- if .Values.global.podLabels }}
+    {{- if or .Values.global.podLabels .Values.kafkaSetupJob.podAnnotations }}
     metadata:
+    {{- with .Values.kafkaSetupJob.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.global.podLabels }}
       labels:
-        {{- range $key, $value := .Values.global.podLabels }}
+        {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
+    {{- end }}
     {{- end }}
     spec:
     {{- with .Values.global.hostAliases }}

--- a/charts/datahub/templates/mysql-setup-job.yml
+++ b/charts/datahub/templates/mysql-setup-job.yml
@@ -16,12 +16,18 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
-    {{- if .Values.global.podLabels }}
+    {{- if or .Values.global.podLabels .Values.mysqlSetupJob.podAnnotations }}
     metadata:
+    {{- with .Values.mysqlSetupJob.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.global.podLabels }}
       labels:
-        {{- range $key, $value := .Values.global.podLabels }}
+        {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
+    {{- end }}
     {{- end }}
     spec:
     {{- with .Values.global.hostAliases }}

--- a/charts/datahub/templates/postgresql-setup-job.yml
+++ b/charts/datahub/templates/postgresql-setup-job.yml
@@ -16,12 +16,18 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
-    {{- if .Values.global.podLabels }}
+    {{- if or .Values.global.podLabels .Values.postgresqlSetupJob.podAnnotations }}
     metadata:
+    {{- with .Values.postgresqlSetupJob.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.global.podLabels }}
       labels:
-        {{- range $key, $value := .Values.global.podLabels }}
+        {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
+    {{- end }}
     {{- end }}
     spec:
     {{- with .Values.global.hostAliases }}

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -52,6 +52,7 @@ elasticsearchSetupJob:
     fsGroup: 1000
   securityContext:
     runAsUser: 1000
+  podAnnotations: {}
 
 kafkaSetupJob:
   enabled: true
@@ -62,6 +63,7 @@ kafkaSetupJob:
     fsGroup: 1000
   securityContext:
     runAsUser: 1000
+  podAnnotations: {}
 
 mysqlSetupJob:
   enabled: true
@@ -72,6 +74,7 @@ mysqlSetupJob:
     fsGroup: 1000
   securityContext:
     runAsUser: 1000
+  podAnnotations: {}
 
 postgresqlSetupJob:
   enabled: false
@@ -82,6 +85,7 @@ postgresqlSetupJob:
     fsGroup: 1000
   securityContext:
     runAsUser: 1000
+  podAnnotations: {}
 
 datahubUpgrade:
   enabled: true
@@ -94,6 +98,7 @@ datahubUpgrade:
     # fsGroup: 1000
   securityContext: {}
     # runAsUser: 1000
+  podAnnotations: {}
 
 global:
   graph_service_impl: neo4j


### PR DESCRIPTION
Adds an option to add `podAnnotations` to jobs. The style is the same as with `deployments` e.g. here https://github.com/acryldata/datahub-helm/blob/21d4f781d7b0cb276a3e6bf076ebeaafabc5b48c/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml#L12-L17

Motivation:
- adding [vault annotations](https://banzaicloud.com/docs/bank-vaults/mutating-webhook/annotations/) to inject secrets from vault - many jobs require some sort of connection string, that may be usually stored in vault
- adding [datadog annotations](https://docs.datadoghq.com/agent/kubernetes/integrations/?tab=kubernetes#configuration) to configure log collection

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
  - Tested my changes locally with `helm template charts/datahub -f charts/datahub/values.yaml`
  - Tried adding annotations to `charts/datahub/values.yaml` and rendering templates again
- [ ] Docs related to the changes have been added/updated (if applicable)
