### PR TITLE
add pod level annotations on job templates

### DIFF
--- a/charts/datahub/templates/datahub-upgrade/datahub-cleanup-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-cleanup-job-template.yml
@@ -18,8 +18,12 @@ spec:
   jobTemplate:
     spec:
       template:
-        {{- if .Values.global.podLabels }}
         metadata:
+        {{- with .Values.datahubUpgrade.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.global.podLabels }}
           labels:
             {{- range $key, $value := .Values.global.podLabels }}
             {{ $key }}: {{ $value | quote }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
@@ -18,8 +18,12 @@ spec:
   jobTemplate:
     spec:
       template:
-        {{- if .Values.global.podLabels }}
         metadata:
+        {{- with .Values.datahubUpgrade.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.global.podLabels }}
           labels:
             {{- range $key, $value := .Values.global.podLabels }}
             {{ $key }}: {{ $value | quote }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-upgrade-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-upgrade-job.yml
@@ -16,8 +16,12 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
-    {{- if .Values.global.podLabels }}
     metadata:
+    {{- with .Values.datahubUpgrade.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if .Values.global.podLabels }}
       labels:
         {{- range $key, $value := .Values.global.podLabels }}
         {{ $key }}: {{ $value | quote }}

--- a/charts/datahub/templates/elasticsearch-setup-job.yml
+++ b/charts/datahub/templates/elasticsearch-setup-job.yml
@@ -16,8 +16,12 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
-    {{- if .Values.global.podLabels }}
+    {{- with .Values.elasticsearchSetupJob.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     metadata:
+    {{- if .Values.global.podLabels }}
       labels:
         {{- range $key, $value := .Values.global.podLabels }}
         {{ $key }}: {{ $value | quote }}

--- a/charts/datahub/templates/kafka-setup-job.yml
+++ b/charts/datahub/templates/kafka-setup-job.yml
@@ -16,8 +16,12 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
-    {{- if .Values.global.podLabels }}
+    {{- with .Values.kafkaSetupJob.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     metadata:
+    {{- if .Values.global.podLabels }}
       labels:
         {{- range $key, $value := .Values.global.podLabels }}
         {{ $key }}: {{ $value | quote }}

--- a/charts/datahub/templates/mysql-setup-job.yml
+++ b/charts/datahub/templates/mysql-setup-job.yml
@@ -16,8 +16,12 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
-    {{- if .Values.global.podLabels }}
     metadata:
+    {{- with .Values.mysqlSetupJob.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if .Values.global.podLabels }}
       labels:
         {{- range $key, $value := .Values.global.podLabels }}
         {{ $key }}: {{ $value | quote }}

--- a/charts/datahub/templates/postgresql-setup-job.yml
+++ b/charts/datahub/templates/postgresql-setup-job.yml
@@ -16,8 +16,12 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
-    {{- if .Values.global.podLabels }}
     metadata:
+    {{- with .Values.postgresqlSetupJob.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if .Values.global.podLabels }}
       labels:
         {{- range $key, $value := .Values.global.podLabels }}
         {{ $key }}: {{ $value | quote }}


### PR DESCRIPTION
Hi team, 

I find that we need to add pod annotation at the job level too. In current, an environment that I'm deploying has https://istio.io/ enabled and it injects the istio-proxy container into pods. 

Due to this, the job containers are not completing as they should. 

Reference: https://stackoverflow.com/questions/65807748/disable-istio-sidecar-injection-to-the-job-pod


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
