### PR TITLE
feat(datahub-frontend): Allow lifecycle hooks

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.85
+version: 0.2.86
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.40

--- a/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
@@ -53,6 +53,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          lifecycle: {{ .Values.lifecycle }}
           ports:
             - name: http
               containerPort: 9002

--- a/charts/datahub/subcharts/datahub-frontend/values.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/values.yaml
@@ -42,8 +42,8 @@ service:
   targetPort: http
   protocol: TCP
   name: http
-  # Annotations to add to the service, this will help in adding 
-  # Internal load balancer or various other annotation support in AWS 
+  # Annotations to add to the service, this will help in adding
+  # Internal load balancer or various other annotation support in AWS
   annotations: {}
     # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
 
@@ -80,6 +80,7 @@ extraVolumeMounts: []
 
 extraInitContainers: []
 
+lifecycle: {}
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -174,7 +175,7 @@ global:
     gms:
       port: "8080"
     appVersion: "1.0"
-    metadata_service_authentication: 
+    metadata_service_authentication:
       enabled: false
       systemClientId: "__datahub_system"
       # systemClientSecret:


### PR DESCRIPTION
This PR adds a lifecycle node to the datahub-frontend deployment template.
It can be used to execute lifecycle hooks, e.g. postStart actions, like
replacing the default user.props file.



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
