### PR TITLE
feat(initContainer): Add initContainer for postgres setup

### DIFF
--- a/charts/datahub/templates/postgresql-setup-job.yml
+++ b/charts/datahub/templates/postgresql-setup-job.yml
@@ -48,6 +48,10 @@ spec:
       restartPolicy: Never
       securityContext:
         {{- toYaml .Values.postgresqlSetupJob.podSecurityContext | nindent 8 }}
+      initContainers:
+      {{ - with .Values.postgresqlSetupJob.extraInitContainers }}
+        {{ - toYaml . | nindent 8 }}
+      {{ - end }}
       containers:
         - name: postgresql-setup-job
           image: "{{ .Values.postgresqlSetupJob.image.repository }}:{{ .Values.postgresqlSetupJob.image.tag }}"

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -78,6 +78,7 @@ mysqlSetupJob:
 
 postgresqlSetupJob:
   enabled: false
+  extraInitContainers: []
   image:
     repository: acryldata/datahub-postgres-setup
     tag: "v0.8.43"


### PR DESCRIPTION
Adding support for init containers on postgress setup job. Needed in case additional checks are necessary  before starting the setup (eg: database is already available). Otherwise, the setup job might fail.



## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
