### PR TITLE
feat(charts): add an option to configure revisionHistoryLimit to subcharts

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.94
+version: 0.2.95
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.44

--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.93
+version: 0.2.94
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.44

--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.95
+version: 0.2.96
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.44

--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -10,11 +10,11 @@ version: 0.2.95
 appVersion: 0.8.44
 dependencies:
   - name: datahub-gms
-    version: 0.2.7
+    version: 0.2.8
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.2.5
+    version: 0.2.6
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer

--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.92
+version: 0.2.93
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.44

--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -10,19 +10,19 @@ version: 0.2.92
 appVersion: 0.8.44
 dependencies:
   - name: datahub-gms
-    version: 0.2.5
+    version: 0.2.7
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.2.4
+    version: 0.2.5
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer
-    version: 0.2.5
+    version: 0.2.6
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.2.6
+    version: 0.2.7
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.5
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/subcharts/datahub-frontend/README.md
+++ b/charts/datahub/subcharts/datahub-frontend/README.md
@@ -46,6 +46,7 @@ Current chart version is `0.2.0`
 | readinessProbe.periodSeconds | int | `30` |  |
 | readinessProbe.failureThreshold | int | `4` |  |
 | replicaCount | int | `1` |  |
+| revisionHistoryLimit | int | `10` |  |
 | lifecycle | object | `{}` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |

--- a/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "datahub-frontend.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "datahub-frontend.selectorLabels" . | nindent 6 }}

--- a/charts/datahub/subcharts/datahub-frontend/values.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/values.yaml
@@ -4,6 +4,8 @@
 
 replicaCount: 1
 
+revisionHistoryLimit: 10
+
 image:
   repository: linkedin/datahub-frontend-react
   tag: "head"

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.6
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.7
+version: 0.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/subcharts/datahub-gms/README.md
+++ b/charts/datahub/subcharts/datahub-gms/README.md
@@ -58,6 +58,7 @@ Current chart version is `0.2.0`
 | readinessProbe.periodSeconds | int | `30` |  |
 | readinessProbe.failureThreshold | int | `8` |  |
 | replicaCount | int | `1` |  |
+| revisionHistoryLimit | int | `10` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
 | service.port | int | `8080` |  |

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "datahub-gms.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "datahub-gms.selectorLabels" . | nindent 6 }}

--- a/charts/datahub/subcharts/datahub-gms/values.yaml
+++ b/charts/datahub/subcharts/datahub-gms/values.yaml
@@ -4,6 +4,8 @@
 
 replicaCount: 1
 
+revisionHistoryLimit: 10
+
 image:
   repository: linkedin/datahub-gms
   pullPolicy: IfNotPresent
@@ -42,8 +44,8 @@ service:
   targetPort: http
   protocol: TCP
   name: http
-  # Annotations to add to the service, this will help in adding 
-  # Internal load balancer or various other annotation support in AWS 
+  # Annotations to add to the service, this will help in adding
+  # Internal load balancer or various other annotation support in AWS
   annotations: {}
     # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
 
@@ -152,12 +154,12 @@ global:
 
     managed_ingestion:
       enabled: true
-      # defaultCliVersion: "X.X.X" --> Optional: Controls the acryl-datahub package version downloaded from PyPI. 
+      # defaultCliVersion: "X.X.X" --> Optional: Controls the acryl-datahub package version downloaded from PyPI.
 
-    metadata_service_authentication: 
+    metadata_service_authentication:
       enabled: false
       # tokenService:
-      #   signingKey: 
+      #   signingKey:
       #    secretRef: <secret-ref>
       #    secretKey: <secret-key>
       #   salt:

--- a/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.5
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/subcharts/datahub-mae-consumer/README.md
+++ b/charts/datahub/subcharts/datahub-mae-consumer/README.md
@@ -52,6 +52,7 @@ Current chart version is `0.2.0`
 | readinessProbe.periodSeconds | int | `30` |  |
 | readinessProbe.failureThreshold | int | `8` |  |
 | replicaCount | int | `1` |  |
+| revisionHistoryLimit | int | `10` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
 | service.port | int | `80` |  |

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "datahub-mae-consumer.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "datahub-mae-consumer.selectorLabels" . | nindent 6 }}

--- a/charts/datahub/subcharts/datahub-mae-consumer/values.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/values.yaml
@@ -4,6 +4,8 @@
 
 replicaCount: 1
 
+revisionHistoryLimit: 10
+
 image:
   repository: linkedin/datahub-mae-consumer
   pullPolicy: IfNotPresent
@@ -176,7 +178,7 @@ global:
     mae_consumer:
       port: "9091"
 
-    metadata_service_authentication: 
+    metadata_service_authentication:
       enabled: false
       systemClientId: "__datahub_system"
       # systemClientSecret:

--- a/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.6
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/subcharts/datahub-mce-consumer/README.md
+++ b/charts/datahub/subcharts/datahub-mce-consumer/README.md
@@ -42,6 +42,7 @@ Current chart version is `0.2.0`
 | readinessProbe.periodSeconds | int | `30` |  |
 | readinessProbe.failureThreshold | int | `4` |  |
 | replicaCount | int | `1` |  |
+| revisionHistoryLimit | int | `10` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
 | service.port | int | `80` |  |

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "datahub-mce-consumer.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "datahub-mce-consumer.selectorLabels" . | nindent 6 }}

--- a/charts/datahub/subcharts/datahub-mce-consumer/values.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/values.yaml
@@ -4,6 +4,8 @@
 
 replicaCount: 1
 
+revisionHistoryLimit: 10
+
 image:
   repository: linkedin/datahub-mce-consumer
   pullPolicy: IfNotPresent
@@ -156,7 +158,7 @@ global:
       enablePrometheus: false
     gms:
       port: "8080"
-    metadata_service_authentication: 
+    metadata_service_authentication:
       enabled: false
       systemClientId: "__datahub_system"
       # systemClientSecret:


### PR DESCRIPTION
This PR adds the ability for end-users to configure `revisitonHistoryLimit` for the deployments of subcharts.

In addition, bumps chart version to 0.2.96

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
