### PR TITLE
feat: add extra labels to ingress configurations

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,17 +4,17 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.93
+version: 0.2.94
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.44
 dependencies:
   - name: datahub-gms
-    version: 0.2.5
+    version: 0.2.7
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.2.4
+    version: 0.2.5
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/subcharts/datahub-frontend/README.md
+++ b/charts/datahub/subcharts/datahub-frontend/README.md
@@ -24,6 +24,7 @@ Current chart version is `0.2.0`
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
+| ingress.extraLabels | object | `{}` | provides extra labels for ingress configuration |
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.hosts[0].paths | list | `[]` |  |
 | ingress.hosts[0].redirectPaths | list | `[]` |  |

--- a/charts/datahub/subcharts/datahub-frontend/templates/ingress.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/ingress.yaml
@@ -8,6 +8,9 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "datahub-frontend.labels" . | nindent 4 }}
+    {{- range $key, $val := .Values.ingress.extraLabels }}
+    {{ $key }}: {{ $val }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/datahub/subcharts/datahub-frontend/values.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/values.yaml
@@ -50,6 +50,7 @@ service:
 ingress:
   # className: ""
   enabled: false
+  extraLabels: {}
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.6
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/subcharts/datahub-gms/README.md
+++ b/charts/datahub/subcharts/datahub-gms/README.md
@@ -43,6 +43,7 @@ Current chart version is `0.2.0`
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
+| ingress.extraLabels | object | `{}` | provides extra labels for ingress configuration |
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.hosts[0].paths | list | `[]` |  |
 | ingress.tls | list | `[]` |  |

--- a/charts/datahub/subcharts/datahub-gms/templates/ingress.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/ingress.yaml
@@ -8,6 +8,9 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "datahub-gms.labels" . | nindent 4 }}
+    {{- range $key, $val := .Values.ingress.extraLabels }}
+    {{ $key }}: {{ $val }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/datahub/subcharts/datahub-gms/values.yaml
+++ b/charts/datahub/subcharts/datahub-gms/values.yaml
@@ -50,6 +50,7 @@ service:
 ingress:
   # className: ""
   enabled: false
+  extraLabels: {}
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
Added support for providing extra labels for ingress configuration in datahub-gms and datahub-frontend sub-charts. Updated README files. This change resolves issue #162 

This is a minor and non-intrusive change



## Checklist
- [ x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x ] Docs related to the changes have been added/updated (if applicable)
