### PR TITLE
feat: datahub-frontend add oidc authentication client secret reference

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.94
+version: 0.2.95
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.44

--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,17 +4,17 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.93
+version: 0.2.94
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.8.44
+appVersion: 0.8.45
 dependencies:
   - name: datahub-gms
-    version: 0.2.5
+    version: 0.2.6
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.2.4
+    version: 0.2.5
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer

--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.2.5
+    version: 0.2.6
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer

--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 version: 0.2.94
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.8.45
+appVersion: 0.8.44
 dependencies:
   - name: datahub-gms
     version: 0.2.7

--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.2.6
+    version: 0.2.7
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.6
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.5
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.3.4
+appVersion: 0.3.3

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.3.3
+appVersion: 0.3.4

--- a/charts/datahub/subcharts/datahub-frontend/README.md
+++ b/charts/datahub/subcharts/datahub-frontend/README.md
@@ -39,7 +39,7 @@ Current chart version is `0.2.0`
 | oidcAuthentication.clientId | string | `""` | A unique identifier for your application with the identity provider |
 | oidcAuthentication.clientSecret | string | `""` | A shared secret to use for exchange between you and your identity provider |
 | oidcAuthentication.clientSecretRef.secretRef | string | `"nil"` | Optional, this is the reference to the shared secret to use for exchange between you and your identity provider |
-| oidcAuthentication.clientSecret.secretKey | string | `"nil"` | Optional, this is the key of the shared secret to use for exchange between you and your identity provider |
+| oidcAuthentication.clientSecretRef.secretKey | string | `"nil"` | Optional, this is the key of the shared secret to use for exchange between you and your identity provider |
 | oidcAuthentication.oktaDomain | string | `""` | Okta domain, e.g. `dev-12345.okta.com`; needed only if `provider` is set to `okta` |
 | oidcAuthentication.azureTenantId | string | `""` | Azure directory (tenant) ID; neede only if `provider` is set to `azure` |
 | podAnnotations | object | `{}` |  |

--- a/charts/datahub/subcharts/datahub-frontend/README.md
+++ b/charts/datahub/subcharts/datahub-frontend/README.md
@@ -37,6 +37,8 @@ Current chart version is `0.2.0`
 | oidcAuthentication.provider | string | `""` | One of the supported OIDC providers: [google](https://datahubproject.io/docs/authentication/guides/sso/configure-oidc-react-google), [okta](https://datahubproject.io/docs/authentication/guides/sso/configure-oidc-react-okta), or [azure](https://datahubproject.io/docs/authentication/guides/sso/configure-oidc-react-azure) |
 | oidcAuthentication.clientId | string | `""` | A unique identifier for your application with the identity provider |
 | oidcAuthentication.clientSecret | string | `""` | A shared secret to use for exchange between you and your identity provider |
+| oidcAuthentication.clientSecretRef.secretRef | string | `"nil"` | Optional, this is the reference to the shared secret to use for exchange between you and your identity provider |
+| oidcAuthentication.clientSecret.secretKey | string | `"nil"` | Optional, this is the key of the shared secret to use for exchange between you and your identity provider |
 | oidcAuthentication.oktaDomain | string | `""` | Okta domain, e.g. `dev-12345.okta.com`; needed only if `provider` is set to `okta` |
 | oidcAuthentication.azureTenantId | string | `""` | Azure directory (tenant) ID; neede only if `provider` is set to `azure` |
 | podAnnotations | object | `{}` |  |

--- a/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
@@ -159,7 +159,14 @@ spec:
             - name: AUTH_OIDC_CLIENT_ID
               value: {{ .clientId }}
             - name: AUTH_OIDC_CLIENT_SECRET
+            {{- if (.clientSecretRef).secretRef }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .clientSecretRef.secretRef }}
+                  key: {{ .clientSecretRef.secretKey }}
+            {{- else }}
               value: {{ .clientSecret }}
+            {{- end }}
             - name: AUTH_OIDC_BASE_URL
               value: https://{{ (first $.Values.ingress.hosts).host }}
             {{- if eq .provider "google" }}

--- a/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
@@ -159,7 +159,7 @@ spec:
             - name: AUTH_OIDC_CLIENT_ID
               value: {{ .clientId }}
             - name: AUTH_OIDC_CLIENT_SECRET
-            {{- if (.clientSecretRef).secretRef }}
+            {{- if .clientSecretRef }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .clientSecretRef.secretRef }}

--- a/charts/datahub/subcharts/datahub-frontend/values.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/values.yaml
@@ -68,7 +68,10 @@ oidcAuthentication:
   # provider: google/okta/azure  <- choose only one
   # clientId: your-client-id
   # clientSecret: your-client-secret
-
+  # only needed if you would like to store the client secret in secret
+  # clientSecretRef:
+  #   secretRef: <secret-ref>
+  #   secretKey: <secret-key>
   # only needed if provider is `okta`
   # oktaDomain: your-okta-domain.com
 


### PR DESCRIPTION
This PR adds an option to configure OIDC authentication client secret to refer to Kubernetes Secrets. The deployment YAML will retrieve `AUTH_OIDC_CLIENT_SECRET` from Kubernetes Secrets if `datahub-frontend.oidcAuthentication.clientSecretRef` is present.

This implementation is also backward compatible with the existing `datahub-frontend.oidcAuthentication` config.

Local testing has been done through rendering using `helm template . > preview.yaml.`


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
