### PR TITLE
Mount a customer defined k8s secret for ssl secrets needed in ingestion recipes

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.99
+version: 0.2.100
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.44

--- a/charts/datahub/README.md
+++ b/charts/datahub/README.md
@@ -87,6 +87,7 @@ helm install datahub datahub/datahub --values <<path-to-values-file>>
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| acryl-datahub-actions.ingestionSslSecrets.name | string | `""` | Name of the secret that holds SSL certificates and private keys that are used in your ingestion recipes |
 | global.credentialsAndCertsSecrets.name | string | `""` | Name of the secret that holds SSL certificates (keystores, truststores) |
 | global.credentialsAndCertsSecrets.path | string | `"/mnt/certs"` | Path to mount the SSL certificates |
 | global.credentialsAndCertsSecrets.secureEnv | map | `{}` | Map of SSL config name and the corresponding value in the secret |

--- a/charts/datahub/README.md
+++ b/charts/datahub/README.md
@@ -87,7 +87,7 @@ helm install datahub datahub/datahub --values <<path-to-values-file>>
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| acryl-datahub-actions.ingestionSslSecrets.name | string | `""` | Name of the secret that holds SSL certificates and private keys that are used in your ingestion recipes |
+| acryl-datahub-actions.ingestionSecretFiles.name | string | `""` | Name of the k8s secret that holds any secret files (e.g., SSL certificates and private keys) that are used in your ingestion recipes |
 | global.credentialsAndCertsSecrets.name | string | `""` | Name of the secret that holds SSL certificates (keystores, truststores) |
 | global.credentialsAndCertsSecrets.path | string | `"/mnt/certs"` | Path to mount the SSL certificates |
 | global.credentialsAndCertsSecrets.secureEnv | map | `{}` | Map of SSL config name and the corresponding value in the secret |

--- a/charts/datahub/README.md
+++ b/charts/datahub/README.md
@@ -87,7 +87,7 @@ helm install datahub datahub/datahub --values <<path-to-values-file>>
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| acryl-datahub-actions.ingestionSecretFiles.name | string | `""` | Name of the k8s secret that holds any secret files (e.g., SSL certificates and private keys) that are used in your ingestion recipes |
+| acryl-datahub-actions.ingestionSecretFiles.name | string | `""` | Name of the k8s secret that holds any secret files (e.g., SSL certificates and private keys) that are used in your ingestion recipes. The keys in the secret will be mounted as individual files under `/etc/datahub/ingestion-secret-files` |
 | global.credentialsAndCertsSecrets.name | string | `""` | Name of the secret that holds SSL certificates (keystores, truststores) |
 | global.credentialsAndCertsSecrets.path | string | `"/mnt/certs"` | Path to mount the SSL certificates |
 | global.credentialsAndCertsSecrets.secureEnv | map | `{}` | Map of SSL config name and the corresponding value in the secret |

--- a/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
@@ -35,8 +35,8 @@ spec:
             defaultMode: 0444
             secretName: {{ .name }}
       {{- end }}
-      {{- with .Values.ingestionSslSecrets }}
-        - name: ingestion-ssl-secrets
+      {{- with .Values.ingestionSecretFiles }}
+        - name: ingestion-secret-files
           secret:
             defaultMode: 0444
             secretName: {{ .name }}
@@ -109,10 +109,10 @@ spec:
           {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.ingestionSslSecrets }}
-            - name: ingestion-ssl-secrets
+          {{- with .Values.ingestionSecretFiles }}
+            - name: ingestion-secret-files
               readOnly: true
-              mountPath: "/etc/datahub/ingestion-ssl-secrets"
+              mountPath: "/etc/datahub/ingestion-secret-files"
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
@@ -35,6 +35,12 @@ spec:
             defaultMode: 0444
             secretName: {{ .name }}
       {{- end }}
+      {{- with .Values.ingestionSslSecrets }}
+        - name: ingestion-ssl-secrets
+          secret:
+            defaultMode: 0444
+            secretName: {{ .name }}
+      {{- end }}
       {{- if .Values.extraVolumes }}
         {{ toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}
@@ -102,6 +108,11 @@ spec:
           {{- end }}
           {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.ingestionSslSecrets }}
+            - name: ingestion-ssl-secrets
+              readOnly: true
+              mountPath: "/etc/datahub/ingestion-ssl-secrets"
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
This PR introduces a general way for passing SSL secrets needed for some ingestion sources such as MySQL when the `require_secure_transport` flag is on. Because MySQL driver requires the SSL certificates to be in files, we cannot easily use env vars to do this without modifying `datahub-actions`.

This approach uses a customer created k8s secret and then mount the secret as a volume in the `datahub-actions` container. Because when a k8s secret is mounted as a volume, [each key name is automatically mounted as a file on the mount path](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod), we can easily refer to these certificate/key files in the ingestion recipe.

Below is an example of how this works for ingestion from a MySQL instance that is configured to require SSL connections:

**First**, create a k8s secret using the `server-ca.pem`, `client-cert.pem` and `client-key.pem` as follows:

```shell
kubectl create secret generic datahub-actions-ingestion-ssl-secret \
  --from-file=server-ca=<path to server-ca.pem> \
  --from-file=client-cert=<path to client-cert.pem> \
  --from-file=client-key=<path to client-key.pem>
```

**Second**, add the following to your `values.yaml` file and then upgrade/install your datahub instance.

```
acryl-datahub-actions:
  ingestionSecretFiles:
    name: datahub-actions-ingestion-ssl-secret
```

**Third**, add the following to your MySQL ingestion recipe. The ingestion should work now.

```
        options:
            connect_args:
                ssl_ca: /etc/datahub/ingestion-secret-files/server-ca
                ssl_cert: /etc/datahub/ingestion-secret-files/client-cert
                ssl_key: /etc/datahub/ingestion-secret-files/client-key
```

**Finally**, this approach can easily support ssl secrets for multiple different ingestion sources because a user controls both the creation of the k8s secret and the ingestion recipe. For example, the command below creates a k8s for SSL secrets for two different sources: `instance1` and `instance2`.

```shell
kubectl create secret generic datahub-actions-ingestion-ssl-secret \
  --from-file=instance1-server-ca=<path to server-ca.pem> \
  --from-file=instance1-client-cert=<path to client-cert.pem> \
  --from-file=instance1-client-key=<path to client-key.pem> \
  --from-file=instance2-server-ca=<path to server-ca.pem> \
  --from-file=instance2-client-cert=<path to client-cert.pem> \
  --from-file=instance2-client-key=<path to client-key.pem>
```

Then ingestion recipe for instance1 can refer to the secrets as follows:
```
        options:
            connect_args:
                ssl_ca: /etc/datahub/ingestion-secret-files/instance1-server-ca
                ssl_cert: /etc/datahub/ingestion-secret-files/instance1-client-cert
                ssl_key: /etc/datahub/ingestion-secret-files/instance1-client-key
```

For instance2, the recipe looks like below:
```
        options:
            connect_args:
                ssl_ca: /etc/datahub/ingestion-secret-files/instance2-server-ca
                ssl_cert: /etc/datahub/ingestion-secret-files/instance2-client-cert
                ssl_key: /etc/datahub/ingestion-secret-files/instance2-client-key
```

Tested this in my own GKE deployment. 

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable)
