### PR TITLE
fix(): New helm charts version with compatible datahub-actions version

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.102
+version: 0.2.103
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.44

--- a/charts/datahub/quickstart-values-with-neo4j.yaml
+++ b/charts/datahub/quickstart-values-with-neo4j.yaml
@@ -19,7 +19,7 @@ acryl-datahub-actions:
   enabled: true
   image:
     repository: acryldata/datahub-actions
-    tag: "v0.0.6"
+    tag: "v0.0.7"
   resources:
     limits:
       cpu: 500m
@@ -102,4 +102,4 @@ global:
 
     managed_ingestion:
       enabled: true
-      defaultCliVersion: "0.8.43"
+      defaultCliVersion: "0.8.44"

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -19,7 +19,7 @@ acryl-datahub-actions:
   enabled: true
   image:
     repository: acryldata/datahub-actions
-    tag: "v0.0.6"
+    tag: "v0.0.7"
   resources:
     limits:
       memory: 512Mi


### PR DESCRIPTION
- Bumping the pinned version of datahub-actions to be compatible with v0.8.44 frontend containers.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
