### PR TITLE
fix(auth-secret): Make template use correct retrieval method

### DIFF
--- a/charts/datahub/templates/datahub-auth-secrets.yml
+++ b/charts/datahub/templates/datahub-auth-secrets.yml
@@ -7,7 +7,7 @@ metadata:
   name: "datahub-auth-secrets"
 type: Opaque
 data:
-  system_client_secret: {{ index $data "system_client_secret" | default (randAlphaNum 32 | b64enc | quote) }}
-  token_service_signing_key: {{ index $data "token_service_signing_key" | default (randAlphaNum 32 | b64enc | quote) }}
-  token_service_salt: {{ index $data "token_service_salt" | default (randAlphaNum 32 | b64enc | quote) }}
+  system_client_secret: {{ get $data "system_client_secret" | default (randAlphaNum 32 | b64enc | quote) }}
+  token_service_signing_key: {{ get $data "token_service_signing_key" | default (randAlphaNum 32 | b64enc | quote) }}
+  token_service_salt: {{ get $data "token_service_salt" | default (randAlphaNum 32 | b64enc | quote) }}
 {{- end -}}


### PR DESCRIPTION
`datahub-auth-secret` yaml was incorrectly using the `index` template function which is for list variables. For dictionaries as is the case with the `$secret.data` object, the correct method is: https://helm.sh/docs/chart_template_guide/function_list/#get

Tested locally, that this works against a running cluster.



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
