### PR TITLE
docs: add secret key information

### DIFF
--- a/charts/prerequisites/values.yaml
+++ b/charts/prerequisites/values.yaml
@@ -47,7 +47,7 @@ neo4j-community:
   enabled: true   # set this to false, if you have a license for the enterprise edition
   acceptLicenseAgreement: "yes"
   defaultDatabase: "graph.db"
-  # For better security, add password to neo4j-secrets k8s secret and uncomment below
+  # For better security, add neo4j-secrets k8s secret with neo4j-password and uncomment below
   existingPasswordSecret: neo4j-secrets
 
 mysql:


### PR DESCRIPTION
Added information about the key name in the secret, or it will fail like this:
Error: couldn't find key neo4j-password in Secret default/neo4j-secrets



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
