### PR TITLE
feat(sql): extend sql username/password configuration

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.113
+version: 0.2.114
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.9.1

--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.112
+version: 0.2.113
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.9.1

--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.2.114
 appVersion: 0.9.1
 dependencies:
   - name: datahub-gms
-    version: 0.2.112
+    version: 0.2.113
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend

--- a/charts/datahub/README.md
+++ b/charts/datahub/README.md
@@ -81,12 +81,25 @@ helm install datahub datahub/datahub --values <<path-to-values-file>>
 | global.sql.datasource.username | string | `"root"` | SQL user name |
 | global.sql.datasource.password.secretRef | string | `"mysql-secrets"` | Secret that contains the MySQL password |
 | global.sql.datasource.password.secretKey | string | `"mysql-password"` | Secret key that contains the MySQL password |
+| global.sql.datasource.password.value | string | `"mysql-password"` | Alternative to using the secret above, uses raw string value instead |
 | global.graph_service_impl | string | `neo4j` | One of `neo4j` or `elasticsearch`. Determines which backend to use for the GMS graph service. Elastic is recommended for a simplified deployment. Neo4j will be the default for now to maintain backwards compatibility |
 
 ## Optional Chart Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| datahub-gms.sql.datasource.username | string | `root` | SQL username for GMS (overrides global value) |
+| datahub-gms.sql.datasource.password.secretRef | string | `"mysql-secrets"` | Secret that contains the GMS SQL password (overrides global value) |
+| datahub-gms.sql.datasource.password.secretKey | string | `"mysql-password"` | Secret key that contains the GMS SQL password (overrides global value) |
+| datahub-gms.sql.datasource.password.value | string | `"mysql-password"` | Alternative to using the secret above, uses raw string value for GMS SQL login (overrides global value) |
+| mysqlSetupJob.username | string | `root` | SQL username for mysqlSetupJob (overrides global value) |
+| mysqlSetupJob.password.secretRef | string | `"mysql-secrets"` | Secret that contains the mysqlSetupJob SQL password (overrides global value) |
+| mysqlSetupJob.password.secretKey | string | `"mysql-password"` | Secret key that contains the mysqlSetupJob SQL password (overrides global value) |
+| mysqlSetupJob.password.value | string | `"mysql-password"` | Alternative to using the secret above, uses raw string value for mysqlSetupJob SQL login (overrides global value) |
+| postgresqlSetupJob.username | string | `root` | SQL username for postgresqlSetupJob (overrides global value) |
+| postgresqlSetupJob.password.secretRef | string | `"mysql-secrets"` | Secret that contains the postgresqlSetupJob SQL password (overrides global value) |
+| postgresqlSetupJob.password.secretKey | string | `"mysql-password"` | Secret key that contains the postgresqlSetupJob SQL password (overrides global value) |
+| postgresqlSetupJob.password.value | string | `"mysql-password"` | Alternative to using the secret above, uses raw string value for postgresqlSetupJob SQL login (overrides global value) |
 | acryl-datahub-actions.ingestionSecretFiles.name | string | `""` | Name of the k8s secret that holds any secret files (e.g., SSL certificates and private keys) that are used in your ingestion recipes. The keys in the secret will be mounted as individual files under `/etc/datahub/ingestion-secret-files` |
 | global.credentialsAndCertsSecrets.name | string | `""` | Name of the secret that holds SSL certificates (keystores, truststores) |
 | global.credentialsAndCertsSecrets.path | string | `"/mnt/certs"` | Path to mount the SSL certificates |

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for LinkedIn DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.112
+version: 0.2.113
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.9.2

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -94,12 +94,17 @@ spec:
             - name: DATAHUB_ANALYTICS_ENABLED
               value: "{{ .Values.global.datahub_analytics_enabled }}"
             - name: EBEAN_DATASOURCE_USERNAME
-              value: "{{ .Values.global.sql.datasource.username }}"
+              value: "{{ .Values.sql.datasource.username | default .Values.global.sql.datasource.username }}"
             - name: EBEAN_DATASOURCE_PASSWORD
+              {{- $passwordValue := .Values.sql.datasource.password.value | default .Values.global.sql.datasource.password.value }}
+              {{- if $passwordValue }}
+              value: "{{ $passwordValue }}"
+              {{- else }}
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.global.sql.datasource.password.secretRef }}"
-                  key: "{{ .Values.global.sql.datasource.password.secretKey }}"
+                  name: "{{ .Values.sql.datasource.password.secretRef | default .Values.global.sql.datasource.password.secretRef }}"
+                  key: "{{ .Values.sql.datasource.password.secretKey | default .Values.global.sql.datasource.password.secretKey }}"
+              {{- end }}
             - name: EBEAN_DATASOURCE_HOST
               value: "{{ .Values.global.sql.datasource.host }}"
             - name: EBEAN_DATASOURCE_URL

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -94,16 +94,16 @@ spec:
             - name: DATAHUB_ANALYTICS_ENABLED
               value: "{{ .Values.global.datahub_analytics_enabled }}"
             - name: EBEAN_DATASOURCE_USERNAME
-              value: {{ .Values.sql.datasource.username | default .Values.global.sql.datasource.username | quote }}
+              value: {{ (.Values.sql).datasource.username | default .Values.global.sql.datasource.username | quote }}
             - name: EBEAN_DATASOURCE_PASSWORD
-              {{- $passwordValue := .Values.sql.datasource.password.value | default .Values.global.sql.datasource.password.value }}
+              {{- $passwordValue := (.Values.sql).datasource.password.value | default .Values.global.sql.datasource.password.value }}
               {{- if $passwordValue }}
               value: {{ $passwordValue | quote }}
               {{- else }}
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.sql.datasource.password.secretRef | default .Values.global.sql.datasource.password.secretRef }}"
-                  key: "{{ .Values.sql.datasource.password.secretKey | default .Values.global.sql.datasource.password.secretKey }}"
+                  name: "{{ (.Values.sql).datasource.password.secretRef | default .Values.global.sql.datasource.password.secretRef }}"
+                  key: "{{ (.Values.sql).datasource.password.secretKey | default .Values.global.sql.datasource.password.secretKey }}"
               {{- end }}
             - name: EBEAN_DATASOURCE_HOST
               value: "{{ .Values.global.sql.datasource.host }}"

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -94,11 +94,11 @@ spec:
             - name: DATAHUB_ANALYTICS_ENABLED
               value: "{{ .Values.global.datahub_analytics_enabled }}"
             - name: EBEAN_DATASOURCE_USERNAME
-              value: "{{ .Values.sql.datasource.username | default .Values.global.sql.datasource.username }}"
+              value: {{ .Values.sql.datasource.username | default .Values.global.sql.datasource.username | quote }}
             - name: EBEAN_DATASOURCE_PASSWORD
               {{- $passwordValue := .Values.sql.datasource.password.value | default .Values.global.sql.datasource.password.value }}
               {{- if $passwordValue }}
-              value: "{{ $passwordValue }}"
+              value: {{ $passwordValue | quote }}
               {{- else }}
               valueFrom:
                 secretKeyRef:

--- a/charts/datahub/templates/mysql-setup-job.yml
+++ b/charts/datahub/templates/mysql-setup-job.yml
@@ -54,12 +54,17 @@ spec:
           imagePullPolicy: {{ .Values.mysqlSetupJob.imagePullPolicy | default "IfNotPresent" }}
           env:
             - name: MYSQL_USERNAME
-              value: {{ .Values.global.sql.datasource.username | quote }}
+              value: {{ .Values.mysqlSetupJob.username | default .Values.global.sql.datasource.username | quote }}
             - name: MYSQL_PASSWORD
+              {{- $passwordValue := .Values.mysqlSetupJob.password.value | default .Values.global.sql.datasource.password.value }}
+              {{- if $passwordValue }}
+              value: {{ $passwordValue | quote }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.global.sql.datasource.password.secretRef }}"
-                  key: "{{ .Values.global.sql.datasource.password.secretKey }}"
+                  name: "{{ .Values.mysqlSetupJob.password.secretRef | default .Values.global.sql.datasource.password.secretRef }}"
+                  key: "{{ .Values.mysqlSetupJob.password.secretKey | default .Values.global.sql.datasource.password.secretKey }}"
+              {{- end }}
             - name: MYSQL_HOST
               value: {{ .Values.global.sql.datasource.hostForMysqlClient | quote }}
             - name: MYSQL_PORT

--- a/charts/datahub/templates/mysql-setup-job.yml
+++ b/charts/datahub/templates/mysql-setup-job.yml
@@ -56,14 +56,14 @@ spec:
             - name: MYSQL_USERNAME
               value: {{ .Values.mysqlSetupJob.username | default .Values.global.sql.datasource.username | quote }}
             - name: MYSQL_PASSWORD
-              {{- $passwordValue := .Values.mysqlSetupJob.password.value | default .Values.global.sql.datasource.password.value }}
+              {{- $passwordValue := (.Values.mysqlSetupJob.password).value | default .Values.global.sql.datasource.password.value }}
               {{- if $passwordValue }}
               value: {{ $passwordValue | quote }}
               {{- else }}
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.mysqlSetupJob.password.secretRef | default .Values.global.sql.datasource.password.secretRef }}"
-                  key: "{{ .Values.mysqlSetupJob.password.secretKey | default .Values.global.sql.datasource.password.secretKey }}"
+                  name: "{{ (.Values.mysqlSetupJob.password).secretRef | default .Values.global.sql.datasource.password.secretRef }}"
+                  key: "{{ (.Values.mysqlSetupJob.password).secretKey | default .Values.global.sql.datasource.password.secretKey }}"
               {{- end }}
             - name: MYSQL_HOST
               value: {{ .Values.global.sql.datasource.hostForMysqlClient | quote }}

--- a/charts/datahub/templates/postgresql-setup-job.yml
+++ b/charts/datahub/templates/postgresql-setup-job.yml
@@ -56,14 +56,14 @@ spec:
             - name: POSTGRES_USERNAME
               value: {{ .Values.postgresqlSetupJob.username | default .Values.global.sql.datasource.username | quote }}
             - name: POSTGRES_PASSWORD
-              {{- $passwordValue := .Values.postgresqlSetupJob.password.value | default .Values.global.sql.datasource.password.value }}
+              {{- $passwordValue := (.Values.postgresqlSetupJob.password).value | default .Values.global.sql.datasource.password.value }}
               {{- if $passwordValue }}
               value: {{ $passwordValue | quote }}
               {{- else }}
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.postgresqlSetupJob.password.secretRef | default .Values.global.sql.datasource.password.secretRef }}"
-                  key: "{{ .Values.postgresqlSetupJob.password.secretKey | default .Values.global.sql.datasource.password.secretKey }}"
+                  name: "{{ (.Values.postgresqlSetupJob.password).secretRef | default .Values.global.sql.datasource.password.secretRef }}"
+                  key: "{{ (.Values.postgresqlSetupJob.password).secretKey | default .Values.global.sql.datasource.password.secretKey }}"
               {{- end }}
             - name: POSTGRES_HOST
               value: {{ .Values.global.sql.datasource.hostForpostgresqlClient | quote }}

--- a/charts/datahub/templates/postgresql-setup-job.yml
+++ b/charts/datahub/templates/postgresql-setup-job.yml
@@ -54,12 +54,17 @@ spec:
           imagePullPolicy: {{ .Values.postgresqlSetupJob.imagePullPolicy | default "Always" }}
           env:
             - name: POSTGRES_USERNAME
-              value: {{ .Values.global.sql.datasource.username | quote }}
+              value: {{ .Values.postgresqlSetupJob.username | default .Values.global.sql.datasource.username | quote }}
             - name: POSTGRES_PASSWORD
+              {{- $passwordValue := .Values.postgresqlSetupJob.password.value | default .Values.global.sql.datasource.password.value }}
+              {{- if $passwordValue }}
+              value: {{ $passwordValue | quote }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.global.sql.datasource.password.secretRef }}"
-                  key: "{{ .Values.global.sql.datasource.password.secretKey }}"
+                  name: "{{ .Values.postgresqlSetupJob.password.secretRef | default .Values.global.sql.datasource.password.secretRef }}"
+                  key: "{{ .Values.postgresqlSetupJob.password.secretKey | default .Values.global.sql.datasource.password.secretKey }}"
+              {{- end }}
             - name: POSTGRES_HOST
               value: {{ .Values.global.sql.datasource.hostForpostgresqlClient | quote }}
             - name: POSTGRES_PORT

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -175,7 +175,7 @@ global:
         secretKey: mysql-root-password
       # --------------OR----------------
       # value: password
-      
+
       ## Use below for usage of PostgreSQL instead of MySQL
       # host: "prerequisites-postgresql:5432"
       # hostForpostgresqlClient: "prerequisites-postgresql"

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -10,8 +10,8 @@ datahub-gms:
   #   datasource:
   #     username: "gms-login"
   #     password:
-  #       secretRef: sql-secret
-  #       secretKey: sql-password
+  #       secretRef: gms-secret
+  #       secretKey: gms-password
 
 datahub-frontend:
   enabled: true
@@ -85,8 +85,8 @@ mysqlSetupJob:
   # Optionally set a set-up job specific login (defaults to global login)
   # username: "mysqlSetupJob-login"
   # password:
-  #   secretRef: sql-secret
-  #   secretKey: sql-password
+  #   secretRef: mysqlSetupJob-secret
+  #   secretKey: mysqlSetupJob-password
 
 postgresqlSetupJob:
   enabled: false
@@ -101,8 +101,8 @@ postgresqlSetupJob:
   # Optionally set a set-up job specific login (defaults to global login)
   # username: "postgresqlSetupJob-login"
   # password:
-  #   secretRef: sql-secret
-  #   secretKey: sql-password
+  #   secretRef: postgresqlSetupJob-secret
+  #   secretKey: postgresqlSetupJob-password
 
 datahubUpgrade:
   enabled: true
@@ -173,7 +173,9 @@ global:
       password:
         secretRef: mysql-secrets
         secretKey: mysql-root-password
-
+      # --------------OR----------------
+      # value: password
+      
       ## Use below for usage of PostgreSQL instead of MySQL
       # host: "prerequisites-postgresql:5432"
       # hostForpostgresqlClient: "prerequisites-postgresql"
@@ -185,7 +187,7 @@ global:
       #   secretRef: postgresql-secrets
       #   secretKey: postgres-password
       # --------------OR----------------
-      #   value: "password"
+      #   value: password
 
   datahub:
     gms:

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -5,6 +5,13 @@ datahub-gms:
   image:
     repository: linkedin/datahub-gms
     tag: "v0.9.2"
+  # Optionally set a GMS specific SQL login (defaults to global login)
+  # sql:
+  #   datasource:
+  #     username: "gms-login"
+  #     password:
+  #       secretRef: sql-secret
+  #       secretKey: sql-password
 
 datahub-frontend:
   enabled: true
@@ -75,6 +82,11 @@ mysqlSetupJob:
   securityContext:
     runAsUser: 1000
   podAnnotations: {}
+  # Optionally set a set-up job specific login (defaults to global login)
+  # username: "gms-login"
+  # password:
+  #   secretRef: sql-secret
+  #   secretKey: sql-password
 
 postgresqlSetupJob:
   enabled: false
@@ -86,6 +98,11 @@ postgresqlSetupJob:
   securityContext:
     runAsUser: 1000
   podAnnotations: {}
+  # Optionally set a set-up job specific login (defaults to global login)
+  # username: "gms-login"
+  # password:
+  #   secretRef: sql-secret
+  #   secretKey: sql-password
 
 datahubUpgrade:
   enabled: true
@@ -167,6 +184,8 @@ global:
       # password:
       #   secretRef: postgresql-secrets
       #   secretKey: postgres-password
+      # --------------OR----------------
+      #   value: "password"
 
   datahub:
     gms:

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -83,7 +83,7 @@ mysqlSetupJob:
     runAsUser: 1000
   podAnnotations: {}
   # Optionally set a set-up job specific login (defaults to global login)
-  # username: "gms-login"
+  # username: "mysqlSetupJob-login"
   # password:
   #   secretRef: sql-secret
   #   secretKey: sql-password
@@ -99,7 +99,7 @@ postgresqlSetupJob:
     runAsUser: 1000
   podAnnotations: {}
   # Optionally set a set-up job specific login (defaults to global login)
-  # username: "gms-login"
+  # username: "postgresqlSetupJob-login"
   # password:
   #   secretRef: sql-secret
   #   secretKey: sql-password


### PR DESCRIPTION
## Overview 
This PR extends the existing configuration for the SQL database in two ways:

1. Allows the SQL set-up jobs to run using a different username and password to that used by the GMS. This allows users to specify a login account with a more permissive set of permissions for the set-up jobs (which requires essentially owner perms) than the logic account used by the GMS (which only requires traditional read-write perms).
2. Allows specifying the login password for the SQL backings using a string value. This is specifically important for users interacting with vault manipulating webhooks to inject their vault-saved credentials, which doesn't pair nicely with using k8s secrets.

This PR is backwards compatible to existing configuration approach (importantly not changing any of the default values).

## Example Use
The values file can now optionally contain something like this:
```
datahub-gms:
  sql:
    datasource:
      username: "User 1"
      password:
        value: "string that will be used by webhook"
```
and 
```
postgresqlSetupJob:
  enabled: true
  username: "User 2"
  password:
    value: "a different string that will be used by webhook"
```
which will mean that the gms will be logged in as 'User 1' using a password injected by a webhook, and the set-up job will be logged in as 'User 2' using a different injected password.

## Checklist
- [✔️] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [✔️] Links to related issues (if applicable)
- [✔️ ] Tests for the changes have been added/updated (if applicable)
- [✔️] Docs related to the changes have been added/updated (if applicable)
