### PR TITLE
fix(datahub-upgrade): Add system auth credentials to datahub upgrade jobs

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.112
+version: 0.2.113
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.9.1

--- a/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
+++ b/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
@@ -26,6 +26,13 @@ Return the env variables for upgrade jobs
   value: "{{ .Values.global.sql.datasource.url }}"
 - name: EBEAN_DATASOURCE_DRIVER
   value: "{{ .Values.global.sql.datasource.driver }}"
+- name: DATAHUB_SYSTEM_CLIENT_ID
+  value: {{ .Values.global.datahub.metadata_service_authentication.systemClientId }}
+- name: DATAHUB_SYSTEM_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretRef }}
+      key: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretKey }}
 - name: KAFKA_BOOTSTRAP_SERVER
   value: "{{ .Values.global.kafka.bootstrap.server }}"
 - name: KAFKA_SCHEMAREGISTRY_URL


### PR DESCRIPTION
Adds system auth credentials to datahub upgrade jobs. This is used to set GMS to read-only mode for upgrade processes.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
