### PR TITLE
fix: lifecycle values template mapping

### DIFF
--- a/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
@@ -49,7 +49,8 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          lifecycle: {{ .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml .Values.lifecycle | nindent 12 }}
           ports:
             - name: http
               containerPort: 9002


### PR DESCRIPTION
The template for frontend wasn't mapping correctly the lifecycle values: 
```yaml
          lifecycle: map[postStart:map[exec:map[command:[sh -c...]]]]
```

Using the toYaml function fixes it:
```yaml
          lifecycle:
            postStart:
              exec:
                command: "sh -c..."
```



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
