### PR TITLE
fix: make hostAliases work in datahub-ingestion-cron

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.114
+version: 0.2.115
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.9.1
@@ -26,7 +26,7 @@ dependencies:
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron
-    version: 0.2.112
+    version: 0.2.113
     repository: file://./subcharts/datahub-ingestion-cron
     condition: datahub-ingestion-cron.enabled
   - name: acryl-datahub-actions

--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron
-    version: 0.2.113
+    version: 0.2.114
     repository: file://./subcharts/datahub-ingestion-cron
     condition: datahub-ingestion-cron.enabled
   - name: acryl-datahub-actions

--- a/charts/datahub/subcharts/datahub-ingestion-cron/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.113
+version: 0.2.114
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.9.3

--- a/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
@@ -27,7 +27,8 @@ spec:
           {{- toYaml .extraInitContainers | nindent 12 }}
           {{- end }}
         {{- if .hostAliases }}
-          hostAliases: {{- include "common.tplvalues.render" (dict "value" .hostAliases "context" $) | nindent 10 }}
+          hostAliases:
+          {{- toYaml .hostAliases | nindent 12 }}
         {{- end }}
         {{- if .serviceAccountName }}
           serviceAccountName: {{ .serviceAccountName }}


### PR DESCRIPTION
This a possible fix for #200. The template `common.tplvalues.render` in https://artifacthub.io/packages/helm/bitnami/common?modal=template&template=_tplvalues.tpl handle templates too, but this versions is more simple...
 
## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
