### PR TITLE
Document global.elasticsearch.useSSL in values.yaml

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.115
+version: 0.2.116
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.9.1

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -138,6 +138,7 @@ global:
     port: "9200"
     skipcheck: "false"
     insecure: "false"
+    useSSL: "false"
 
   kafka:
     bootstrap:


### PR DESCRIPTION
`global.elasticsearch.useSSL` isn't documented in `values.yaml`.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
