### PR TITLE
bugfix: datahub-upgrade use datasource password value if set

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.118
+version: 0.2.119
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.9.1

--- a/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
+++ b/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
@@ -16,10 +16,14 @@ Return the env variables for upgrade jobs
 - name: EBEAN_DATASOURCE_USERNAME
   value: "{{ .Values.global.sql.datasource.username }}"
 - name: EBEAN_DATASOURCE_PASSWORD
+  {{- if .Values.global.sql.datasource.password.value }}
+  value: {{ .Values.global.sql.datasource.password.value | quote }}
+  {{- else }}
   valueFrom:
     secretKeyRef:
       name: "{{ .Values.global.sql.datasource.password.secretRef }}"
       key: "{{ .Values.global.sql.datasource.password.secretKey }}"
+  {{- end }}
 - name: EBEAN_DATASOURCE_HOST
   value: "{{ .Values.global.sql.datasource.host }}"
 - name: EBEAN_DATASOURCE_URL


### PR DESCRIPTION
The datahub-upgrade job is looking for a `mysql-secret` even if `global.sql.datasource.password.value` is set.

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
