### PR TITLE
fix: move default tag to global.datahub.version

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,17 +4,17 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.120
+version: 0.2.121
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.9.1
 dependencies:
   - name: datahub-gms
-    version: 0.2.120
+    version: 0.2.121
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.2.120
+    version: 0.2.121
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.120
+version: 0.2.121
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.9.3

--- a/charts/datahub/subcharts/datahub-frontend/values.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/values.yaml
@@ -8,7 +8,7 @@ revisionHistoryLimit: 10
 
 image:
   repository: linkedin/datahub-frontend-react
-  tag: "head"
+  tag:
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -199,6 +199,7 @@ global:
       server: "broker:9092"
 
   datahub:
+    version: head
     gms:
       port: "8080"
     appVersion: "1.0"

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for LinkedIn DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.120
+version: 0.2.121
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.9.3

--- a/charts/datahub/subcharts/datahub-gms/values.yaml
+++ b/charts/datahub/subcharts/datahub-gms/values.yaml
@@ -9,7 +9,7 @@ revisionHistoryLimit: 10
 image:
   repository: linkedin/datahub-gms
   pullPolicy: IfNotPresent
-  tag: head
+  tag:
 
 imagePullSecrets: []
 nameOverride: ""
@@ -151,6 +151,7 @@ global:
         secretKey: "mysql-password"
 
   datahub:
+    version: head
     monitoring:
       enablePrometheus: false
       enableJMXPort: false


### PR DESCRIPTION
image.tag in datahub-gms and datahub-fronted shadowed the global.datahub.version from the top datahub chart, so the resulting image was head.

The change #212 is incomplete. image.tag in https://github.com/acryldata/datahub-helm/blob/1c48990081a14009296cfbffb487f6c52d0418ea/charts/datahub/subcharts/datahub-frontend/values.yaml#L9-L11 and
https://github.com/acryldata/datahub-helm/blob/1c48990081a14009296cfbffb487f6c52d0418ea/charts/datahub/subcharts/datahub-gms/values.yaml#L9-L12
shadows global.datahub.version https://github.com/acryldata/datahub-helm/blob/1c48990081a14009296cfbffb487f6c52d0418ea/charts/datahub/values.yaml#L193-L194 in 
https://github.com/acryldata/datahub-helm/blob/1c48990081a14009296cfbffb487f6c52d0418ea/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml#L50 and https://github.com/acryldata/datahub-helm/blob/1c48990081a14009296cfbffb487f6c52d0418ea/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml#L54
This PR fixes that.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
