### PR TITLE
Bump ElasticSearch chart version to support PDB from policy/v1

### DIFF
--- a/charts/prerequisites/Chart.yaml
+++ b/charts/prerequisites/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 version: 0.0.11
 dependencies:
   - name: elasticsearch
-    version: 7.16.2
+    version: 7.17.1
     repository: https://helm.elastic.co
     condition: elasticsearch.enabled
   # This chart deploys an enterprise version of neo4j that requires commercial license


### PR DESCRIPTION
v1.17.1 ElasticSearch charts is compatible with k8s >= 1.25.0 
https://github.com/elastic/helm-charts/pull/1420

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
