### PR TITLE
fix(restore-indices): restore indices should use global datastore values

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.136
+version: 0.2.140
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.9.6.1

--- a/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
@@ -72,6 +72,24 @@ spec:
                 - "-a"
                 - "batchDelayMs={{ .Values.datahubUpgrade.batchDelayMs }}"
               env:
+                - name: EBEAN_DATASOURCE_USERNAME
+                  value: {{ (.Values.sql).datasource.username | default .Values.global.sql.datasource.username | quote }}
+                - name: EBEAN_DATASOURCE_PASSWORD
+                  {{- $passwordValue := (.Values.sql).datasource.password.value | default .Values.global.sql.datasource.password.value }}
+                  {{- if $passwordValue }}
+                  value: {{ $passwordValue | quote }}
+                  {{- else }}
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ (.Values.sql).datasource.password.secretRef | default .Values.global.sql.datasource.password.secretRef }}"
+                      key: "{{ (.Values.sql).datasource.password.secretKey | default .Values.global.sql.datasource.password.secretKey }}"
+                  {{- end }}
+                - name: EBEAN_DATASOURCE_HOST
+                  value: "{{ .Values.global.sql.datasource.host }}"
+                - name: EBEAN_DATASOURCE_URL
+                  value: "{{ .Values.global.sql.datasource.url }}"
+                - name: EBEAN_DATASOURCE_DRIVER
+                  value: "{{ .Values.global.sql.datasource.driver }}"
                 {{- include "datahub.upgrade.env" . | nindent 16}}
               {{- with .Values.datahubUpgrade.extraEnvs }}
                 {{- toYaml . | nindent 16 }}


### PR DESCRIPTION

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
