### PR TITLE
feat(neo4j-password): be able to deploy without neo4j secret

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.142
+version: 0.2.143
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.9.6.1

--- a/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
+++ b/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
@@ -78,10 +78,14 @@ Return the env variables for upgrade jobs
 - name: NEO4J_USERNAME
   value: "{{ .Values.global.neo4j.username }}"
 - name: NEO4J_PASSWORD
+  {{- if .Values.global.neo4j.password.value }}
+  value: {{ .Values.global.neo4j.password.value | quote }}
+  {{- else }}
   valueFrom:
     secretKeyRef:
       name: "{{ .Values.global.neo4j.password.secretRef }}"
       key: "{{ .Values.global.neo4j.password.secretKey }}"
+  {{- end }}
 {{- end }}
 {{- if .Values.global.springKafkaConfigurationOverrides }}
 {{- range $configName, $configValue := .Values.global.springKafkaConfigurationOverrides }}

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -273,6 +273,8 @@ global:
     password:
       secretRef: neo4j-secrets
       secretKey: neo4j-password
+    # --------------OR----------------
+    # value: password
 
   sql:
     datasource:


### PR DESCRIPTION
## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)


### Context

Currently I am trying to deploy datahub with helmfile and I am doing multiple tests and recreating namespaces and changing environments, I don't want to manually create a neo4j secret each deployment, and I don't believe it should be forced.

This feature will let me create a simple value config to be able to deploy without thinking of creating secrets previously.