### PR TITLE
feat(gas): remove release name from service's name

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.2.142
 appVersion: 0.9.6.1
 dependencies:
   - name: datahub-gms
-    version: 0.2.133
+    version: 0.2.134
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend

--- a/charts/datahub/subcharts/datahub-gms/templates/service.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "datahub-gms" }}
+  name: {{ include "datahub-gms.fullname" . }}
   labels:
     {{- include "datahub-gms.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}


### PR DESCRIPTION

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)


### Context

I am using datahub as a subchart in one of my charts and I am overriding the fullname for more reliable deployment without relying on the release name of the parent chart, but I have noticed that datahub-gms the only subchart that uses release name for the service name and it makes my parent chart unreliable.

please address this PR as urgent and important to merge