### PR TITLE
feat(elasticsearch): allow plain text password

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-# This is the version number of the application being deployed. This version number should be
 version: 0.2.151
+# This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.10.0
 dependencies:

--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,25 +4,25 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.150
 # This is the version number of the application being deployed. This version number should be
+version: 0.2.151
 # incremented each time you make changes to the application.
 appVersion: 0.10.0
 dependencies:
   - name: datahub-gms
-    version: 0.2.140
+    version: 0.2.141
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.2.135
+    version: 0.2.136
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer
-    version: 0.2.138
+    version: 0.2.139
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.2.138
+    version: 0.2.139
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron

--- a/charts/datahub/README.md
+++ b/charts/datahub/README.md
@@ -130,6 +130,7 @@ helm install datahub datahub/datahub --values <<path-to-values-file>>
 | global.elasticsearch.auth.username | string | `""` | Elasticsearch username |
 | global.elasticsearch.auth.password.secretRef | string | `""` | Secret that contains the elasticsearch password |
 | global.elasticsearch.auth.password.secretKey | string | `""` | Secret key that contains the elasticsearch password |
+| global.elasticsearch.auth.password.value | string | `""` | Alternative to using the secret above, uses raw string value instead |
 | global.kafka.schemaregistry.type | string | `"KAFKA"` | Type of schema registry (KAFKA or AWS_GLUE) |
 | global.kafka.schemaregistry.glue.region | string | `""` | Region of the AWS Glue schema registry |
 | global.kafka.schemaregistry.glue.registry | string | `""` | Name of the AWS Glue schema registry |

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.135
+version: 0.2.136
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.10.0

--- a/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
@@ -133,10 +133,14 @@ spec:
             - name: ELASTIC_CLIENT_USERNAME
               value: {{ .username }}
             - name: ELASTIC_CLIENT_PASSWORD
+              {{- if .password.value }}
+              value: {{ .password.value | quote }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: "{{ .password.secretRef }}"
                   key: "{{ .password.secretKey }}"
+              {{- end }}
             {{- end }}
             {{- with .Values.global.elasticsearch.indexPrefix }}
             - name: ELASTIC_INDEX_PREFIX

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for LinkedIn DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.140
+version: 0.2.141
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.10.0

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -163,10 +163,14 @@ spec:
             - name: ELASTICSEARCH_USERNAME
               value: {{ .username }}
             - name: ELASTICSEARCH_PASSWORD
+              {{- if .password.value }}
+              value: {{ .password.value | quote }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: "{{ .password.secretRef }}"
                   key: "{{ .password.secretKey }}"
+              {{- end }}
             {{- end }}
             {{- with .Values.global.elasticsearch.indexPrefix }}
             - name: INDEX_PREFIX

--- a/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.138
+version: 0.2.139
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.10.0

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -132,10 +132,14 @@ spec:
             - name: ELASTICSEARCH_USERNAME
               value: {{ .username }}
             - name: ELASTICSEARCH_PASSWORD
+              {{- if .password.value }}
+              value: {{ .password.value | quote }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: "{{ .password.secretRef }}"
                   key: "{{ .password.secretKey }}"
+              {{- end }}
             {{- end }}
             {{- with .Values.global.elasticsearch.indexPrefix }}
             - name: INDEX_PREFIX

--- a/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.138
+version: 0.2.139
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.10.0

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
@@ -144,10 +144,14 @@ spec:
             - name: ELASTICSEARCH_USERNAME
               value: {{ .username }}
             - name: ELASTICSEARCH_PASSWORD
+              {{- if .password.value }}
+              value: {{ .password.value | quote }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: "{{ .password.secretRef }}"
                   key: "{{ .password.secretKey }}"
+              {{- end }}
             {{- end }}
             {{- with .Values.global.elasticsearch.indexPrefix }}
             - name: INDEX_PREFIX

--- a/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
+++ b/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
@@ -59,10 +59,14 @@ Return the env variables for upgrade jobs
 - name: ELASTICSEARCH_USERNAME
   value: {{ .username }}
 - name: ELASTICSEARCH_PASSWORD
+  {{- if .password.value }}
+  value: {{ .password.value | quote }}
+  {{- else }}
   valueFrom:
     secretKeyRef:
       name: "{{ .password.secretRef }}"
       key: "{{ .password.secretKey }}"
+  {{- end }}
 {{- end }}
 {{- with .Values.global.elasticsearch.indexPrefix }}
 - name: INDEX_PREFIX

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
@@ -127,10 +127,14 @@ spec:
             - name: ELASTICSEARCH_USERNAME
               value: {{ .username }}
             - name: ELASTICSEARCH_PASSWORD
+              {{- if .password.value }}
+              value: {{ .password.value | quote }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: "{{ .password.secretRef }}"
                   key: "{{ .password.secretKey }}"
+              {{- end }}
             {{- end }}
             {{- with .Values.global.elasticsearch.indexPrefix }}
             - name: INDEX_PREFIX

--- a/charts/datahub/templates/elasticsearch-setup-job.yml
+++ b/charts/datahub/templates/elasticsearch-setup-job.yml
@@ -69,10 +69,14 @@ spec:
             - name: ELASTICSEARCH_USERNAME
               value: {{ .username }}
             - name: ELASTICSEARCH_PASSWORD
+              {{- if .password.value }}
+              value: {{ .password.value | quote }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: "{{ .password.secretRef }}"
                   key: "{{ .password.secretKey }}"
+              {{- end }}
             {{- end }}
             {{- with .Values.global.elasticsearch.indexPrefix }}
             - name: INDEX_PREFIX


### PR DESCRIPTION
Fixes #262. Allows users to put passwords in the following format:

```
  elasticsearch:
    auth:
      username: abc123
      password:
        value: es-plaintextpassword
```

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
