### PR TITLE
fix: remove duplicated EBEAN env vars on datahub-upgrade jobs (#269)

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.154
+version: 0.2.155
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.10.0

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
@@ -66,23 +66,11 @@ spec:
             - "-u"
             - "SystemUpdate"
           env:
-            {{- with .Values.global.kafka.topics }}
-            - name: DATAHUB_UPGRADE_HISTORY_TOPIC_NAME
-              value: {{ .datahub_upgrade_history_topic_name }}
-            {{- end }}
             - name: DATAHUB_REVISION
               value: {{ .Release.Revision | quote }}
             {{- include "datahub.upgrade.env" . | nindent 12}}
             - name: DATAHUB_ANALYTICS_ENABLED
               value: {{ .Values.global.datahub_analytics_enabled | quote }}
-            - name: ENTITY_REGISTRY_CONFIG_PATH
-              value: /datahub/datahub-gms/resources/entity-registry.yml
-            - name: KAFKA_BOOTSTRAP_SERVER
-              value: "{{ .Values.global.kafka.bootstrap.server }}"
-            {{- with .Values.global.kafka.schemaregistry.url }}
-            - name: KAFKA_SCHEMAREGISTRY_URL
-              value: "{{ . }}"
-            {{- end }}
             {{- with .Values.global.kafka.schemaregistry.type }}
             - name: SCHEMA_REGISTRY_TYPE
               value: "{{ . }}"
@@ -94,33 +82,6 @@ spec:
             - name: AWS_GLUE_SCHEMA_REGISTRY_NAME
               value: "{{ . }}"
             {{- end }}
-            {{- end }}
-            - name: ELASTICSEARCH_HOST
-              value: "{{ .Values.global.elasticsearch.host }}"
-            - name: ELASTICSEARCH_PORT
-              value: "{{ .Values.global.elasticsearch.port }}"
-            - name: SKIP_ELASTICSEARCH_CHECK
-              value: "{{ .Values.global.elasticsearch.skipcheck }}"
-            {{- with .Values.global.elasticsearch.useSSL }}
-            - name: ELASTICSEARCH_USE_SSL
-              value: {{ . | quote }}
-            {{- end }}
-            {{- with .Values.global.elasticsearch.auth }}
-            - name: ELASTICSEARCH_USERNAME
-              value: {{ .username }}
-            - name: ELASTICSEARCH_PASSWORD
-              {{- if .password.value }}
-              value: {{ .password.value | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .password.secretRef }}"
-                  key: "{{ .password.secretKey }}"
-              {{- end }}
-            {{- end }}
-            {{- with .Values.global.elasticsearch.indexPrefix }}
-            - name: INDEX_PREFIX
-              value: {{ . }}
             {{- end }}
             - name: ELASTICSEARCH_BUILD_INDICES_CLONE_INDICES
               value: {{ .Values.global.elasticsearch.index.upgrade.cloneIndices | quote }}
@@ -147,36 +108,6 @@ spec:
             {{- with .Values.global.elasticsearch.index.upgrade.allowDocCountMismatch }}
             - name: ELASTICSEARCH_BUILD_INDICES_ALLOW_DOC_COUNT_MISMATCH
               value: {{ . | quote }}
-            {{- end }}
-            - name: GRAPH_SERVICE_IMPL
-              value: {{ .Values.global.graph_service_impl }}
-            {{- if eq .Values.global.graph_service_impl "neo4j" }}
-            - name: NEO4J_HOST
-              value: "{{ .Values.global.neo4j.host }}"
-            - name: NEO4J_URI
-              value: "{{ .Values.global.neo4j.uri }}"
-            - name: NEO4J_USERNAME
-              value: "{{ .Values.global.neo4j.username }}"
-            - name: NEO4J_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.global.neo4j.password.secretRef }}"
-                  key: "{{ .Values.global.neo4j.password.secretKey }}"
-            {{- end }}
-            {{- if .Values.global.springKafkaConfigurationOverrides }}
-            {{- range $configName, $configValue := .Values.global.springKafkaConfigurationOverrides }}
-            - name: SPRING_KAFKA_PROPERTIES_{{ $configName | replace "." "_" | upper }}
-              value: {{ $configValue | quote }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.global.credentialsAndCertsSecrets }}
-            {{- range $envVarName, $envVarValue := .Values.global.credentialsAndCertsSecrets.secureEnv }}
-            - name: SPRING_KAFKA_PROPERTIES_{{ $envVarName | replace "." "_" | upper }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $.Values.global.credentialsAndCertsSecrets.name }}
-                  key: {{ $envVarValue }}
-            {{- end }}
             {{- end }}
           {{- with .Values.datahubSystemUpdate.extraEnvs }}
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
Fixes: [https://github.com/acryldata/datahub-helm/issues/261](https://github.com/acryldata/datahub-helm/issues/261)

More duplicate env variables than just `EBEAN_*` are reported. This PR will remove any others left here after patch #269

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
