### PR TITLE
fix: add missing service account in acryl-datahub-actions

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.154
+version: 0.2.155
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.10.0
@@ -30,7 +30,7 @@ dependencies:
     repository: file://./subcharts/datahub-ingestion-cron
     condition: datahub-ingestion-cron.enabled
   - name: acryl-datahub-actions
-    version: 0.2.133
+    version: 0.2.134
     repository: file://./subcharts/acryl-datahub-actions
     condition: acryl-datahub-actions.enabled
 maintainers:

--- a/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.133
+version: 0.2.134
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.0.11

--- a/charts/datahub/subcharts/acryl-datahub-actions/templates/serviceaccount.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "acryl-datahub-actions.serviceAccountName" . }}
+  labels:
+    {{- include "acryl-datahub-actions.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}


### PR DESCRIPTION
The `acryl-datahub-actions` subchart offers an option to create a service account:
https://github.com/acryldata/datahub-helm/blob/25fd3c5cc7a8885a0c1bf6958bdbd4549e9771a3/charts/datahub/subcharts/acryl-datahub-actions/values.yaml#L15-L22

but the implementation is missing. This PR adds the `serviceAccount` template.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
