### PR TITLE
feat: enable sidecar configuration

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.163
+version: 0.2.164
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.10.2

--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -10,27 +10,27 @@ version: 0.2.163
 appVersion: 0.10.2
 dependencies:
   - name: datahub-gms
-    version: 0.2.146
+    version: 0.2.147
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.2.136
+    version: 0.2.137
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer
-    version: 0.2.142
+    version: 0.2.143
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.2.144
+    version: 0.2.145
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron
-    version: 0.2.131
+    version: 0.2.132
     repository: file://./subcharts/datahub-ingestion-cron
     condition: datahub-ingestion-cron.enabled
   - name: acryl-datahub-actions
-    version: 0.2.135
+    version: 0.2.136
     repository: file://./subcharts/acryl-datahub-actions
     condition: acryl-datahub-actions.enabled
 maintainers:

--- a/charts/datahub/README.md
+++ b/charts/datahub/README.md
@@ -39,6 +39,7 @@ helm install datahub datahub/datahub --values <<path-to-values-file>>
 | datahubUpgrade.securityContext | object | `{}` | Container security context for datahubUpgrade jobs |
 | datahubUpgrade.podAnnotations | object | `{}` | Pod annotations for datahubUpgrade jobs |
 | datahubUpgrade.restoreIndices.resources | object | '{}' | Kube Resource definitions for the datahub upgrade job 'restore indices' |
+| datahubUpgrade.restoreIndices.extraSidecars | list | `[]` | Add additional sidecar containers to the job pod |
 | elasticsearchSetupJob.enabled | bool | `true` | Enable setup job for elasicsearch |
 | elasticsearchSetupJob.image.repository | string | `"linkedin/datahub-elasticsearch-setup"` | Image repository for elasticsearchSetupJob |
 | elasticsearchSetupJob.image.tag | string | `"v0.10.0"` | Image repository for elasticsearchSetupJob |
@@ -47,6 +48,7 @@ helm install datahub datahub/datahub --values <<path-to-values-file>>
 | elasticsearchSetupJob.podSecurityContext | object | `{"fsGroup": 1000}` | Pod security context for elasticsearchSetupJob |
 | elasticsearchSetupJob.securityContext | object | `{"runAsUser": 1000}` | Container security context for elasticsearchSetupJob |
 | elasticsearchSetupJob.podAnnotations | object | `{}` | Pod annotations for elasticsearchSetupJob |
+| elasticsearchSetupJob.extraSidecars | list | `[]` | Add additional sidecar containers to the job pod |
 | kafkaSetupJob.enabled | bool | `true` | Enable setup job for kafka |
 | kafkaSetupJob.image.repository | string | `"linkedin/datahub-kafka-setup"` | Image repository for kafkaSetupJob |
 | kafkaSetupJob.image.tag | string | `"v0.10.0"` | Image repository for kafkaSetupJob |
@@ -55,6 +57,7 @@ helm install datahub datahub/datahub --values <<path-to-values-file>>
 | kafkaSetupJob.podSecurityContext | object | `{"fsGroup": 1000}` | Pod security context for kafkaSetupJob |
 | kafkaSetupJob.securityContext | object | `{"runAsUser": 1000}` | Container security context for kafkaSetupJob |
 | kafkaSetupJob.podAnnotations | object | `{}` | Pod annotations for kafkaSetupJob |
+| kafkaSetupJob.extraSidecars | list | `[]` | Add additional sidecar containers to the job pod |
 | mysqlSetupJob.enabled | bool | `false` | Enable setup job for mysql |
 | mysqlSetupJob.image.repository | string | `"acryldata/datahub-mysql-setup"` | Image repository for mysqlSetupJob |
 | mysqlSetupJob.image.tag | string | `"v0.10.0"` | Image repository for mysqlSetupJob |
@@ -63,6 +66,7 @@ helm install datahub datahub/datahub --values <<path-to-values-file>>
 | mysqlSetupJob.podSecurityContext | object | `{"fsGroup": 1000}` | Pod security context for mysqlSetupJob |
 | mysqlSetupJob.securityContext | object | `{"runAsUser": 1000}` | Container security context for mysqlSetupJob |
 | mysqlSetupJob.podAnnotations | object | `{}` | Pod annotations for mysqlSetupJob |
+| mysqlSetupJob.extraSidecars | list | `[]` | Add additional sidecar containers to the job pod |
 | postgresqlSetupJob.enabled | bool | `false` | Enable setup job for postgresql |
 | postgresqlSetupJob.image.repository | string | `"acryldata/datahub-postgres-setup"` | Image repository for postgresqlSetupJob |
 | postgresqlSetupJob.image.tag | string | `"v0.10.0"` | Image repository for postgresqlSetupJob |
@@ -71,6 +75,8 @@ helm install datahub datahub/datahub --values <<path-to-values-file>>
 | postgresqlSetupJob.podSecurityContext | object | `{"fsGroup": 1000}` | Pod security context for mysqlSetupJob |
 | postgresqlSetupJob.securityContext | object | `{"runAsUser": 1000}` | Container security context for mysqlSetupJob |
 | postgresqlSetupJob.podAnnotations | object | `{}` | Pod annotations for mysqlSetupJob |
+| postgresqlSetupJob.extraSidecars | list | `[]` | Add additional sidecar containers to the job pod |
+| datahubSystemUpdate.extraSidecars | list | `[]` | Add additional sidecar containers to the job pod |
 | global.strict_mode | boolean | true | Enables validations in helm charts to ensure features work as expected. Recommended NOT TO CHANGE. |
 | global.datahub_standalone_consumers_enabled | boolean | true | Enable standalone consumers for kafka |
 | global.datahub_analytics_enabled | boolean | true | Enable datahub usage analytics |

--- a/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.135
+version: 0.2.136
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.0.11

--- a/charts/datahub/subcharts/acryl-datahub-actions/README.md
+++ b/charts/datahub/subcharts/acryl-datahub-actions/README.md
@@ -12,6 +12,7 @@ Current chart version is `0.0.3`
 | exporters.jmx.enabled | boolean | false |  |
 | extraLabels | object | `{}` | Extra labels for deployment configuration |
 | extraEnvs | Extra [environment variables][] which will be appended to the `env:` definition for the container | `[]` |
+| extraSidecars | list | `[]` | Add additional sidecar containers to the deployment pod(s) |
 | extraVolumes | Templatable string of additional `volumes` to be passed to the `tpl` function | "" |
 | extraVolumeMounts | Templatable string of additional `volumeMounts` to be passed to the `tpl` function | "" |
 | fullnameOverride | string | `"acryl-datahub-actions"` |  |

--- a/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
@@ -121,7 +121,7 @@ spec:
                   name: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretRef }}
                   key: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretKey }}
             {{- end }}
-           {{- if .Values.extraEnvs }}
+          {{- if .Values.extraEnvs }}
             {{ toYaml .Values.extraEnvs | nindent 12 }}
           {{- end }}
           volumeMounts:
@@ -139,7 +139,9 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-
+        {{- with .Values.extraSidecars }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/datahub/subcharts/acryl-datahub-actions/values.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/values.yaml
@@ -50,6 +50,12 @@ extraVolumeMounts: []
 
 extraInitContainers: []
 
+# Add extra sidecar containers to deployment pod
+extraSidecars: []
+  # - name: my-image-name
+  #   image: my-image
+  #   imagePullPolicy: Always
+
 resources: {}
 
 nodeSelector: {}

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.136
+version: 0.2.137
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.10.0

--- a/charts/datahub/subcharts/datahub-frontend/README.md
+++ b/charts/datahub/subcharts/datahub-frontend/README.md
@@ -14,6 +14,7 @@ Current chart version is `0.2.0`
 | exporters.jmx.enabled | boolean | false |  |
 | extraLabels | object | `{}` | Extra labels for deployment configuration |
 | extraEnvs | Extra [environment variables][] which will be appended to the `env:` definition for the container | `[]` |
+| extraSidecars | list | `[]` | Add additional sidecar containers to the deployment pod(s) |
 | extraVolumes | Templatable string of additional `volumes` to be passed to the `tpl` function | "" |
 | extraVolumeMounts | Templatable string of additional `volumeMounts` to be passed to the `tpl` function | "" |
 | fullnameOverride | string | `"datahub-frontend"` |  |

--- a/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
@@ -219,7 +219,9 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-
+        {{- with .Values.extraSidecars }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/datahub/subcharts/datahub-frontend/values.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/values.yaml
@@ -110,6 +110,12 @@ extraVolumeMounts: []
 
 extraInitContainers: []
 
+# Add extra sidecar containers to deployment pod
+extraSidecars: []
+  # - name: my-image-name
+  #   image: my-image
+  #   imagePullPolicy: Always
+
 lifecycle: {}
   # To add a new user to datahub in JAAS config without mounting the user.props file
   # postStart:

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for LinkedIn DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.146
+version: 0.2.147
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.10.0

--- a/charts/datahub/subcharts/datahub-gms/README.md
+++ b/charts/datahub/subcharts/datahub-gms/README.md
@@ -11,6 +11,7 @@ Current chart version is `0.2.0`
 | affinity | object | `{}` |  |
 | extraLabels | object | `{}` | Extra labels for deployment configuration |
 | extraEnvs | Extra [environment variables][] which will be appended to the `env:` definition for the container | `[]` |
+| extraSidecars | list | `[]` | Add additional sidecar containers to the deployment pod(s) |
 | extraVolumes | Templatable string of additional `volumes` to be passed to the `tpl` function | "" |
 | extraVolumeMounts | Templatable string of additional `volumeMounts` to be passed to the `tpl` function | "" |
 | fullnameOverride | string | `"datahub-gms-deployment"` |  |

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -336,7 +336,9 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-
+        {{- with .Values.extraSidecars }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/datahub/subcharts/datahub-gms/values.yaml
+++ b/charts/datahub/subcharts/datahub-gms/values.yaml
@@ -92,6 +92,12 @@ extraVolumeMounts: []
 
 extraInitContainers: []
 
+# Add extra sidecar containers to deployment pod
+extraSidecars: []
+  # - name: my-image-name
+  #   image: my-image
+  #   imagePullPolicy: Always
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/datahub/subcharts/datahub-ingestion-cron/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.131
+version: 0.2.132
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.10.0

--- a/charts/datahub/subcharts/datahub-ingestion-cron/README.md
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/README.md
@@ -27,3 +27,4 @@ A Helm chart for datahub's metadata-ingestion framework with kerberos authentica
 | crons.extraInitContainers | object | `{}` | Init containers to add to the cronjob container |
 | crons.serviceAccountName | string | | Service account name used for the cronjob container |
 | crons.podAnnotations | object | `{}` | Annotations to add to the pods |
+| extraSidecars | list | `[]` | Add additional sidecar containers to the deployment pod(s) |

--- a/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
@@ -68,8 +68,8 @@ spec:
           {{- if .extraVolumes }}
             {{- toYaml .extraVolumes | nindent 12 }}
           {{- end }}
-        {{- with .Values.extraSidecars }}
-          {{- toYaml . | nindent 10 }}
+        {{- if .extraSidecars }}
+          {{- toYaml .extraSidecars | nindent 10 }}
         {{- end }}
 ---
 {{- end }}

--- a/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
@@ -11,11 +11,11 @@ spec:
   schedule: {{ default "0 0 * * *" .schedule | quote}}
   jobTemplate:
     spec:
-      template:        
+      template:
         {{- with $val.podAnnotations }}
         metadata:
           annotations:
-            {{- toYaml . | nindent 12 }}    
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         spec:
         {{- with $.Values.imagePullSecrets }}
@@ -68,5 +68,8 @@ spec:
           {{- if .extraVolumes }}
             {{- toYaml .extraVolumes | nindent 12 }}
           {{- end }}
+        {{- with .Values.extraSidecars }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
 ---
 {{- end }}

--- a/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
@@ -58,6 +58,13 @@ crons: {}
     ## Add your own pod annotations.
     ##
     #podAnnotations: {}
+
+# Add extra sidecar containers to deployment pod
+extraSidecars: []
+  # - name: my-image-name
+  #   image: my-image
+  #   imagePullPolicy: Always
+
 global:
   datahub:
     version: head

--- a/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
@@ -51,6 +51,13 @@ crons: {}
     ##
     #extraInitContainers: {}
 
+    ## Add extra sidecar containers to job pod
+    ##
+    # extraSidecars: []
+    # - name: my-image-name
+    #  image: my-image
+    #  imagePullPolicy: Always
+
     ## If you want to specify your own service account, set its name like so.
     ##
     #serviceAccountName: "my-cron-service"

--- a/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.142
+version: 0.2.143
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.10.0

--- a/charts/datahub/subcharts/datahub-mae-consumer/README.md
+++ b/charts/datahub/subcharts/datahub-mae-consumer/README.md
@@ -12,6 +12,7 @@ Current chart version is `0.2.0`
 | exporters.jmx.enabled | boolean | false |  |
 | extraLabels | object | `{}` | Extra labels for deployment configuration |
 | extraEnvs | Extra [environment variables][] which will be appended to the `env:` definition for the container | `[]` |
+| extraSidecars | list | `[]` | Add additional sidecar containers to the deployment pod(s) |
 | extraVolumes | Templatable string of additional `volumes` to be passed to the `tpl` function | "" |
 | extraVolumeMounts | Templatable string of additional `volumeMounts` to be passed to the `tpl` function | "" |
 | fullnameOverride | string | `"datahub-mae-consumer"` |  |

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -230,7 +230,9 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-
+        {{- with .Values.extraSidecars }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/datahub/subcharts/datahub-mae-consumer/values.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/values.yaml
@@ -84,6 +84,12 @@ extraVolumeMounts: []
 
 extraInitContainers: []
 
+# Add extra sidecar containers to deployment pod
+extraSidecars: []
+  # - name: my-image-name
+  #   image: my-image
+  #   imagePullPolicy: Always
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.144
+version: 0.2.145
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.10.0

--- a/charts/datahub/subcharts/datahub-mce-consumer/README.md
+++ b/charts/datahub/subcharts/datahub-mce-consumer/README.md
@@ -12,6 +12,7 @@ Current chart version is `0.2.0`
 | exporters.jmx.enabled | boolean | false |  |
 | extraLabels | object | `{}` | Extra labels for deployment configuration |
 | extraEnvs | Extra [environment variables][] which will be appended to the `env:` definition for the container | `[]` |
+| extraSidecars | list | `[]` | Add additional sidecar containers to the deployment pod(s) |
 | extraVolumes | Templatable string of additional `volumes` to be passed to the `tpl` function | "" |
 | extraVolumeMounts | Templatable string of additional `volumeMounts` to be passed to the `tpl` function | "" |
 | fullnameOverride | string | `""` |  |

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
@@ -235,7 +235,9 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-
+        {{- with .Values.extraSidecars }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/datahub/subcharts/datahub-mce-consumer/values.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/values.yaml
@@ -85,6 +85,12 @@ extraVolumeMounts: []
 
 extraInitContainers: []
 
+# Add extra sidecar containers to deployment pod
+extraSidecars: []
+  # - name: my-image-name
+  #   image: my-image
+  #   imagePullPolicy: Always
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/datahub/templates/datahub-upgrade/datahub-cleanup-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-cleanup-job-template.yml
@@ -77,6 +77,9 @@ spec:
                 requests:
                   cpu: 300m
                   memory: 256Mi
+            {{- with .Values.datahubUpgrade.cleanupJob.extraSidecars }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.datahubUpgrade.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-nocode-migration-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-nocode-migration-job.yml
@@ -94,7 +94,7 @@ spec:
               cpu: 300m
               memory: 256Mi
         {{- with .Values.datahubUpgrade.extraSidecars }}
-          {{- toYaml . | nindent 12 }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.datahubUpgrade.nodeSelector }}
       nodeSelector:

--- a/charts/datahub/templates/datahub-upgrade/datahub-nocode-migration-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-nocode-migration-job.yml
@@ -93,6 +93,9 @@ spec:
             requests:
               cpu: 300m
               memory: 256Mi
+        {{- with .Values.datahubUpgrade.extraSidecars }}
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
       {{- with .Values.datahubUpgrade.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 12 }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
@@ -88,6 +88,9 @@ spec:
               {{- end }}
               resources:
                 {{- toYaml .Values.datahubUpgrade.restoreIndices.resources | nindent 16}}
+            {{- with .Values.datahubUpgrade.restoreIndices.extraSidecars }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.datahubUpgrade.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
@@ -124,6 +124,9 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.datahubSystemUpdate.resources | nindent 12 }}
+        {{- with .Values.datahubSystemUpdate.extraSidecars }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.datahubSystemUpdate.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 12 }}

--- a/charts/datahub/templates/elasticsearch-setup-job.yml
+++ b/charts/datahub/templates/elasticsearch-setup-job.yml
@@ -95,6 +95,9 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.elasticsearchSetupJob.resources | nindent 12 }}
+        {{- with .Values.elasticsearchSetupJob.extraSidecars }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.elasticsearchSetupJob.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/datahub/templates/kafka-setup-job.yml
+++ b/charts/datahub/templates/kafka-setup-job.yml
@@ -123,6 +123,9 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.kafkaSetupJob.resources | nindent 12 }}
+        {{- with .Values.kafkaSetupJob.extraSidecars }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.kafkaSetupJob.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/datahub/templates/mysql-setup-job.yml
+++ b/charts/datahub/templates/mysql-setup-job.yml
@@ -80,6 +80,9 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.mysqlSetupJob.resources | nindent 12 }}
+        {{- with .Values.mysqlSetupJob.extraSidecars }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.mysqlSetupJob.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/datahub/templates/postgresql-setup-job.yml
+++ b/charts/datahub/templates/postgresql-setup-job.yml
@@ -80,6 +80,9 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.postgresqlSetupJob.resources | nindent 12 }}
+        {{- with .Values.postgresqlSetupJob.extraSidecars }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.postgresqlSetupJob.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -95,6 +95,11 @@ elasticsearchSetupJob:
   securityContext:
     runAsUser: 1000
   podAnnotations: {}
+  # Add extra sidecar containers to job pod
+  extraSidecars: []
+    # - name: my-image-name
+    #   image: my-image
+    #   imagePullPolicy: Always
 
 kafkaSetupJob:
   enabled: true
@@ -113,6 +118,11 @@ kafkaSetupJob:
   securityContext:
     runAsUser: 1000
   podAnnotations: {}
+  # Add extra sidecar containers to job pod
+  extraSidecars: []
+    # - name: my-image-name
+    #   image: my-image
+    #   imagePullPolicy: Always
 
 mysqlSetupJob:
   enabled: true
@@ -136,6 +146,11 @@ mysqlSetupJob:
   # password:
   #   secretRef: mysqlSetupJob-secret
   #   secretKey: mysqlSetupJob-password
+  # Add extra sidecar containers to job pod
+  extraSidecars: []
+    # - name: my-image-name
+    #   image: my-image
+    #   imagePullPolicy: Always
 
 postgresqlSetupJob:
   enabled: false
@@ -159,6 +174,11 @@ postgresqlSetupJob:
   # password:
   #   secretRef: postgresqlSetupJob-secret
   #   secretKey: postgresqlSetupJob-password
+  # Add extra sidecar containers to job pod
+  extraSidecars: []
+    # - name: my-image-name
+    #   image: my-image
+    #   imagePullPolicy: Always
 
 ## No code data migration
 datahubUpgrade:
@@ -184,6 +204,11 @@ datahubUpgrade:
       requests:
         cpu: 300m
         memory: 256Mi
+    # Add extra sidecar containers to job pod
+    extraSidecars: []
+      # - name: my-image-name
+      #   image: my-image
+      #   imagePullPolicy: Always
 
 ## Runs system update processes
 ## Includes: Elasticsearch Indices Creation/Reindex (See global.elasticsearch.index for additional configuration)
@@ -203,6 +228,11 @@ datahubSystemUpdate:
     requests:
       cpu: 300m
       memory: 256Mi
+  # Add extra sidecar containers to job pod
+  extraSidecars: []
+    # - name: my-image-name
+    #   image: my-image
+    #   imagePullPolicy: Always
 
 global:
   strict_mode: true

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -196,6 +196,17 @@ datahubUpgrade:
   securityContext: {}
     # runAsUser: 1000
   podAnnotations: {}
+  # Add extra sidecar containers to job pod
+  extraSidecars: []
+    # - name: my-image-name
+    #   image: my-image
+    #   imagePullPolicy: Always
+  cleanupJob:
+    # Add extra sidecar containers to job pod
+    extraSidecars: []
+      # - name: my-image-name
+      #   image: my-image
+      #   imagePullPolicy: Always
   restoreIndices:
     resources:
       limits:


### PR DESCRIPTION
Many use cases require running sidecar containers next to the main container, .e.g, for logging or using a proxy. This PR exposes an interface to enable users to configure sidecar containers in all subchart pods and most jobs.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
