### PR TITLE
fix: secretkey for systemClientSecret in values.yaml file

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.160
+version: 0.2.161
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.10.0

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -382,7 +382,7 @@ global:
       systemClientId: "__datahub_system"
       systemClientSecret:
         secretRef: "datahub-auth-secrets"
-        secretKey: "token_service_signing_key"
+        secretKey: "system_client_secret"
       tokenService:
         signingKey:
           secretRef: "datahub-auth-secrets"


### PR DESCRIPTION
Updated correct `secretKey` from `datahub-auth-secrets` for `systemClientSecret` in values.yaml file reported in #279 
Updated Chart version
## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
