### PR TITLE
feat: allow pulling ebean username from a secretRef a la db password

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.160
+version: 0.2.161
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.10.0

--- a/charts/datahub/README.md
+++ b/charts/datahub/README.md
@@ -101,6 +101,8 @@ helm install datahub datahub/datahub --values <<path-to-values-file>>
 | global.sql.datasource.port | string | `"3306"` | SQL database port |
 | global.sql.datasource.url | string | `"jdbc:mysql://prerequisites-mysql:3306/datahub?verifyServerCertificate=false\u0026useSSL=true"` | URL to access SQL database |
 | global.sql.datasource.username | string | `"root"` | SQL user name |
+| global.sql.datasource.username.secretRef | string | `"mysql-secrets"` | Secret that contains the MySQL username |
+| global.sql.datasource.username.secretKey | string | `"mysql-username"` | Secret key that contains the MySQL username |
 | global.sql.datasource.password.secretRef | string | `"mysql-secrets"` | Secret that contains the MySQL password |
 | global.sql.datasource.password.secretKey | string | `"mysql-password"` | Secret key that contains the MySQL password |
 | global.sql.datasource.password.value | string | `"mysql-password"` | Alternative to using the secret above, uses raw string value instead |
@@ -111,6 +113,8 @@ helm install datahub datahub/datahub --values <<path-to-values-file>>
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | datahub-gms.sql.datasource.username | string | `root` | SQL username for GMS (overrides global value) |
+| datahub-gms.sql.datasource.username.secretRef | string | `"mysql-secrets"` | Secret that contains the GMS SQL username (overrides global value) |
+| datahub-gms.sql.datasource.username.secretKey | string | `"mysql-username"` | Secret key that contains the GMS SQL username (overrides global value) |
 | datahub-gms.sql.datasource.password.secretRef | string | `"mysql-secrets"` | Secret that contains the GMS SQL password (overrides global value) |
 | datahub-gms.sql.datasource.password.secretKey | string | `"mysql-password"` | Secret key that contains the GMS SQL password (overrides global value) |
 | datahub-gms.sql.datasource.password.value | string | `"mysql-password"` | Alternative to using the secret above, uses raw string value for GMS SQL login (overrides global value) |

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -118,7 +118,15 @@ spec:
             - name: DATAHUB_ANALYTICS_ENABLED
               value: "{{ .Values.global.datahub_analytics_enabled }}"
             - name: EBEAN_DATASOURCE_USERNAME
-              value: {{ (.Values.sql).datasource.username | default .Values.global.sql.datasource.username | quote }}
+              {{- $usernameSecretRef := (.Values.sql).datasource.username.secretRef | default .Values.global.sql.datasource.username.secretRef }}
+              {{- if $usernameSecretRef }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $usernameSecretRef }}
+                  key: "{{ (.Values.sql).datasource.username.secretKey | default .Values.global.sql.datasource.username.secretKey }}"
+              {{- else }}
+              value:  {{ (.Values.sql).datasource.username | default .Values.global.sql.datasource.username | quote }}
+              {{- end }}
             - name: EBEAN_DATASOURCE_PASSWORD
               {{- $passwordValue := (.Values.sql).datasource.password.value | default .Values.global.sql.datasource.password.value }}
               {{- if $passwordValue }}

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
@@ -117,7 +117,15 @@ spec:
             - name: ENTITY_REGISTRY_CONFIG_PATH
               value: /datahub/datahub-mce-consumer/resources/entity-registry.yml
             - name: EBEAN_DATASOURCE_USERNAME
-              value: {{ (.Values.sql).datasource.username | default .Values.global.sql.datasource.username | quote }}
+              {{- $usernameSecretRef := (.Values.sql).datasource.username.secretRef | default .Values.global.sql.datasource.username.secretRef }}
+              {{- if $usernameSecretRef }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $usernameSecretRef }}
+                  key: "{{ (.Values.sql).datasource.username.secretKey | default .Values.global.sql.datasource.username.secretKey }}"
+              {{- else }}
+              value:  {{ (.Values.sql).datasource.username | default .Values.global.sql.datasource.username | quote }}
+              {{- end }}
             - name: EBEAN_DATASOURCE_PASSWORD
               {{- $passwordValue := (.Values.sql).datasource.password.value | default .Values.global.sql.datasource.password.value }}
               {{- if $passwordValue }}

--- a/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
+++ b/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
@@ -14,7 +14,15 @@ Return the env variables for upgrade jobs
 - name: DATAHUB_MAE_CONSUMER_PORT
   value: "{{ .Values.global.datahub.mae_consumer.port }}"
 - name: EBEAN_DATASOURCE_USERNAME
-  value: {{ (.Values.sql).datasource.username | default .Values.global.sql.datasource.username | quote }}
+  {{- $usernameSecretRef := (.Values.sql).datasource.username.secretRef | default .Values.global.sql.datasource.username.secretRef }}
+  {{- if $usernameSecretRef }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $usernameSecretRef }}
+      key: "{{ (.Values.sql).datasource.username.secretKey | default .Values.global.sql.datasource.username.secretKey }}"
+  {{- else }}
+  value:  {{ (.Values.sql).datasource.username | default .Values.global.sql.datasource.username | quote }}
+  {{- end }}
 - name: EBEAN_DATASOURCE_PASSWORD
   {{- $passwordValue := (.Values.sql).datasource.password.value | default .Values.global.sql.datasource.password.value }}
   {{- if $passwordValue }}


### PR DESCRIPTION
Our storage team manages and distributes both our username and password via secrets, which led us to introduce this patch on our end. It would be great if we can get it merged into the project, let me know if you need me to add anything

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
