### PR TITLE
Release Charts for DataHub v0.10.1

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,10 +4,10 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.160
+version: 0.2.161
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.10.0
+appVersion: 0.10.1
 dependencies:
   - name: datahub-gms
     version: 0.2.146

--- a/charts/datahub/templates/datahub-auth-secrets.yml
+++ b/charts/datahub/templates/datahub-auth-secrets.yml
@@ -1,3 +1,4 @@
+{{- if .Values.global.datahub.metadata_service_authentication.enabled -}}
 {{- $secret := lookup "v1" "Secret" .Release.Namespace "datahub-auth-secrets" -}}
 {{- $data := $secret.data | default dict -}}
 {{- with .Values.global.datahub.metadata_service_authentication.provisionSecrets }}
@@ -20,4 +21,5 @@ data:
   {{- end }}
 
 {{- end }}
+{{- end -}}
 {{- end -}}

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -344,7 +344,7 @@ global:
       #   value: password
 
   datahub:
-    version: v0.10.0
+    version: v0.10.1
     gms:
       port: "8080"
       nodePort: "30001"


### PR DESCRIPTION
# Summary
- Bumps chart datahub version to 0.10.1 to match latest release 
- Makes `datahub-auth-secrets` creation dependant on whether metadata service authentication has been enabled or not.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
