### PR TITLE
Revert "feat(PFP-102): Make Elasticsearch use 1 master node by defaul…

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ You should get a result similar to below.
 ```
 NAME                                               READY   STATUS      RESTARTS   AGE
 elasticsearch-master-0                             1/1     Running     0          62m
+elasticsearch-master-1                             1/1     Running     0          62m
+elasticsearch-master-2                             1/1     Running     0          62m
 prerequisites-cp-schema-registry-cf79bfccf-kvjtv   2/2     Running     1          63m
 prerequisites-kafka-0                              1/1     Running     2          62m
 prerequisites-mysql-0                              1/1     Running     1          62m
@@ -106,6 +108,8 @@ datahub-elasticsearch-setup-job-8dz6b              0/1     Completed   0        
 datahub-kafka-setup-job-6blcj                      0/1     Completed   0          4m40s
 datahub-mysql-setup-job-b57kc                      0/1     Completed   0          4m7s
 elasticsearch-master-0                             1/1     Running     0          97m
+elasticsearch-master-1                             1/1     Running     0          97m
+elasticsearch-master-2                             1/1     Running     0          97m
 prerequisites-cp-schema-registry-cf79bfccf-kvjtv   2/2     Running     1          99m
 prerequisites-kafka-0                              1/1     Running     2          97m
 prerequisites-mysql-0                              1/1     Running     1          97m

--- a/charts/prerequisites/Chart.yaml
+++ b/charts/prerequisites/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for packages that Datahub depends on
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.15
+version: 0.0.14
 dependencies:
   - name: elasticsearch
     version: 7.17.3

--- a/charts/prerequisites/values.yaml
+++ b/charts/prerequisites/values.yaml
@@ -2,17 +2,14 @@
 # Copy this file and update to the configuration of choice
 elasticsearch:
   enabled: true   # set this to false, if you want to provide your own ES instance.
-
-  # If you're running in production, set this to 3 and comment out antiAffinity below
-  # Or alternatively if you're running production, bring your own ElasticSearch
-  replicas: 1
+  replicas: 3
   minimumMasterNodes: 1
   # Set replicas to 1 and uncomment this to allow the instance to be scheduled on
   # a master node when deploying on a single node Minikube / Kind / etc cluster.
-  antiAffinity: "soft"
+  # antiAffinity: "soft"
 
-  # # If you are running a multi-replica cluster, comment this out
-  clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
+  # # If your running a single replica cluster add the following helm value
+  # clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
 
   # # Shrink default JVM heap.
   esJavaOpts: "-Xmx384m -Xms384m"


### PR DESCRIPTION
…t (#283)"

This reverts commit a4d7cb9a8729f1229d7cd5bc5af80473547aeffb.

https://github.com/acryldata/datahub-helm/actions/runs/4603053520 failed and I want to fix it.  

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
