### PR TITLE
feat: support loadBalancerSourceRanges in datahub-frontend

### DIFF
--- a/charts/datahub/subcharts/datahub-frontend/README.md
+++ b/charts/datahub/subcharts/datahub-frontend/README.md
@@ -54,6 +54,7 @@ Current chart version is `0.2.0`
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
 | service.port | int | `9001` |  |
+| service.loadBalancerSourceRanges | list | `[]` | If `service.type=LoadBalancer` (default), this creates a CIDR-based source range allow-list for the resulting load balancer |
 | service.nodePort | int | `""` |  |
 | service.type | string | `"LoadBalancer"` |  |
 | serviceAccount.annotations | object | `{}` |  |

--- a/charts/datahub/subcharts/datahub-frontend/templates/service.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/service.yaml
@@ -28,3 +28,9 @@ spec:
     {{- end }}
   selector:
     {{- include "datahub-frontend.selectorLabels" . | nindent 4 }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .Values.service.loadBalancerSourceRanges }}
+    - {{ $cidr }}
+  {{- end }}
+  {{- end }}

--- a/charts/datahub/subcharts/datahub-frontend/values.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/values.yaml
@@ -48,6 +48,7 @@ service:
   # Internal load balancer or various other annotation support in AWS
   annotations: {}
     # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+  loadBalancerSourceRanges: []
 
 serviceMonitor:
   create: false


### PR DESCRIPTION
## Checklist
- [ x ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ x ] Links to related issues (if applicable)
- [ x ] Tests for the changes have been added/updated (if applicable)
- [ x ] Docs related to the changes have been added/updated (if applicable)

This MR enables configuration of [loadBalancerSourceRanges](https://kubernetes.io/docs/concepts/services-networking/service/) in the service object of the datahub-frontend subchart. We'll default to empty set, which omits `.spec.loadBalancerSourceRanges` entirely (current behavior). If both `.Values.service=LoadBalancer` and an array is provided to `.Values.service.loadBalancerSourceRanges`, iterate over the list to configure the desired allow-list on the resulting loadbalancer.