### PR TITLE
feat(helm): change setup jobs repository to acryldata

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.164
+version: 0.2.165
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.10.2

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -81,7 +81,7 @@ datahub-ingestion-cron:
 elasticsearchSetupJob:
   enabled: true
   image:
-    repository: linkedin/datahub-elasticsearch-setup
+    repository: acryldata/datahub-elasticsearch-setup
     # tag: "v0.10.0" # defaults to .global.datahub.version
   resources:
     limits:
@@ -104,7 +104,7 @@ elasticsearchSetupJob:
 kafkaSetupJob:
   enabled: true
   image:
-    repository: linkedin/datahub-kafka-setup
+    repository: acryldata/datahub-kafka-setup
     # tag: "v0.10.0" # defaults to .global.datahub.version
   resources:
     limits:


### PR DESCRIPTION
We already use acryldata for mysql/postgres and I use it on my personal fork as it is more maintained and frequently updates, also we in acryldata's helm chart..

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
