### PR TITLE
feat: values for PSQL db name, elastic prefix

### DIFF
--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -179,6 +179,10 @@ postgresqlSetupJob:
     # - name: my-image-name
     #   image: my-image
     #   imagePullPolicy: Always
+  # Optionally set a specific database using extraEnvs
+  # extraEnvs: []
+    # - name: "DATAHUB_DB_NAME"
+    #  value: "dh"
 
 ## No code data migration
 datahubUpgrade:
@@ -220,6 +224,10 @@ datahubUpgrade:
       # - name: my-image-name
       #   image: my-image
       #   imagePullPolicy: Always
+    # Optionally set a specific PostgreSQL database name using extraEnvs
+    # extraEnvs:
+    #   - name: "DATAHUB_DB_NAME"
+    #    value: "dh"
 
 ## Runs system update processes
 ## Includes: Elasticsearch Indices Creation/Reindex (See global.elasticsearch.index for additional configuration)
@@ -257,6 +265,8 @@ global:
     skipcheck: "false"
     insecure: "false"
     useSSL: "false"
+    # If you want to specify index prefixes use indexPrefix
+    # indexPrefix: "dh"
 
     ## The following section controls when and how reindexing of elasticsearch indices are performed
     index:
@@ -387,6 +397,12 @@ global:
       #   secretKey: postgres-password
       # --------------OR----------------
       #   value: password
+      
+      # If you want to use specific PostgreSQL database use extraEnvs
+      # extraEnvs:
+      #  - name: "DATAHUB_DB_NAME"
+      #    value: "dh"    
+
 
   datahub:
     version: v0.10.2

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -181,8 +181,8 @@ postgresqlSetupJob:
     #   imagePullPolicy: Always
   # Optionally set a specific database using extraEnvs
   # extraEnvs: []
-    # - name: "DATAHUB_DB_NAME"
-    #  value: "dh"
+  #   - name: "DATAHUB_DB_NAME"
+  #     value: "dh"
 
 ## No code data migration
 datahubUpgrade:


### PR DESCRIPTION
## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)

1. Found and fixed an issue during rollout (PSQL db in connection string ignoring during rollout and PSQL setup job creates "datahub" database instead specific, also failed dataHub upgrade job).
2. Added value for elastic search index prefix (already present in helm chart).
All are checked in local env (minikube) and with AWS-managed services.