### PR TITLE
feat: allow for overriding job annotations and adding init containers

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.175
+version: 0.2.176
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.10.4

--- a/charts/datahub/templates/datahub-auth-secrets.yml
+++ b/charts/datahub/templates/datahub-auth-secrets.yml
@@ -9,6 +9,10 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretRef }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   {{- if .autoGenerate }}

--- a/charts/datahub/templates/datahub-encryption-secrets.yml
+++ b/charts/datahub/templates/datahub-encryption-secrets.yml
@@ -9,6 +9,10 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretRef }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   {{- if .autoGenerate }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-nocode-migration-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-nocode-migration-job.yml
@@ -49,9 +49,9 @@ spec:
       restartPolicy: Never
       securityContext:
         {{- toYaml .Values.datahubUpgrade.podSecurityContext | nindent 8 }}
-      initContainers:
       {{- with .Values.datahubUpgrade.extraInitContainers }}
-        {{- toYaml . | nindent 12 }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: datahub-upgrade-job

--- a/charts/datahub/templates/datahub-upgrade/datahub-nocode-migration-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-nocode-migration-job.yml
@@ -5,12 +5,10 @@ metadata:
   name: {{ .Release.Name }}-nocode-migration-job
   labels:
     {{- include "datahub.labels" . | nindent 4 }}
+  {{- with .Values.datahubUpgrade.annotations }}
   annotations:
-    # This is what defines this resource as a hook. Without this line, the
-    # job is considered part of the release.
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "-2"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   template:
     {{- if or .Values.global.podLabels .Values.datahubUpgrade.podAnnotations}}

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
@@ -5,12 +5,10 @@ metadata:
   name: {{ .Release.Name }}-datahub-system-update-job
   labels:
     {{- include "datahub.labels" . | nindent 4 }}
+  {{- with .Values.datahubSystemUpdate.annotations }}
   annotations:
-    # This is what defines this resource as a hook. Without this line, the
-    # job is considered part of the release.
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-4"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   template:
     {{- if or .Values.global.podLabels .Values.datahubSystemUpdate.podAnnotations}}

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
@@ -49,9 +49,9 @@ spec:
       restartPolicy: Never
       securityContext:
         {{- toYaml .Values.datahubSystemUpdate.podSecurityContext | nindent 8 }}
-      initContainers:
       {{- with .Values.datahubSystemUpdate.extraInitContainers }}
-        {{- toYaml . | nindent 12 }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: datahub-system-update-job

--- a/charts/datahub/templates/elasticsearch-setup-job.yml
+++ b/charts/datahub/templates/elasticsearch-setup-job.yml
@@ -43,6 +43,10 @@ spec:
       restartPolicy: Never
       securityContext:
         {{- toYaml .Values.elasticsearchSetupJob.podSecurityContext | nindent 8 }}
+      {{- with .Values.elasticsearchSetupJob.extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: elasticsearch-setup-job
           image: "{{ .Values.elasticsearchSetupJob.image.repository }}:{{ required "Global or specific tag is required" ( .Values.elasticsearchSetupJob.image.tag | default .Values.global.datahub.version) }}"

--- a/charts/datahub/templates/elasticsearch-setup-job.yml
+++ b/charts/datahub/templates/elasticsearch-setup-job.yml
@@ -5,12 +5,10 @@ metadata:
   name: {{ .Release.Name }}-elasticsearch-setup-job
   labels:
     {{- include "datahub.labels" . | nindent 4 }}
+  {{- with .Values.elasticsearchSetupJob.annotations }}
   annotations:
-    # This is what defines this resource as a hook. Without this line, the
-    # job is considered part of the release.
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   template:
     {{- if or .Values.global.podLabels .Values.elasticsearchSetupJob.podAnnotations }}

--- a/charts/datahub/templates/kafka-setup-job.yml
+++ b/charts/datahub/templates/kafka-setup-job.yml
@@ -49,6 +49,10 @@ spec:
       {{- with .Values.kafkaSetupJob.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kafkaSetupJob.extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: kafka-setup-job
           image: "{{ .Values.kafkaSetupJob.image.repository }}:{{ required "Global or specific tag is required" ( .Values.kafkaSetupJob.image.tag | default .Values.global.datahub.version) }}"

--- a/charts/datahub/templates/kafka-setup-job.yml
+++ b/charts/datahub/templates/kafka-setup-job.yml
@@ -5,12 +5,10 @@ metadata:
   name: {{ .Release.Name }}-kafka-setup-job
   labels:
     {{- include "datahub.labels" . | nindent 4 }}
+  {{- with .Values.kafkaSetupJob.annotations }}
   annotations:
-    # This is what defines this resource as a hook. Without this line, the
-    # job is considered part of the release.
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   template:
     {{- if or .Values.global.podLabels .Values.kafkaSetupJob.podAnnotations }}

--- a/charts/datahub/templates/mysql-setup-job.yml
+++ b/charts/datahub/templates/mysql-setup-job.yml
@@ -43,6 +43,10 @@ spec:
       restartPolicy: Never
       securityContext:
         {{- toYaml .Values.mysqlSetupJob.podSecurityContext | nindent 8 }}
+      {{- with .Values.mysqlSetupJob.extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: mysql-setup-job
           image: "{{ .Values.mysqlSetupJob.image.repository }}:{{ required "Global or specific tag is required" ( .Values.mysqlSetupJob.image.tag | default .Values.global.datahub.version) }}"

--- a/charts/datahub/templates/mysql-setup-job.yml
+++ b/charts/datahub/templates/mysql-setup-job.yml
@@ -5,12 +5,10 @@ metadata:
   name: {{ .Release.Name }}-mysql-setup-job
   labels:
     {{- include "datahub.labels" . | nindent 4 }}
+  {{- with .Values.mysqlSetupJob.annotations }}
   annotations:
-    # This is what defines this resource as a hook. Without this line, the
-    # job is considered part of the release.
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   template:
     {{- if or .Values.global.podLabels .Values.mysqlSetupJob.podAnnotations }}

--- a/charts/datahub/templates/postgresql-setup-job.yml
+++ b/charts/datahub/templates/postgresql-setup-job.yml
@@ -5,12 +5,10 @@ metadata:
   name: {{ .Release.Name }}-postgresql-setup-job
   labels:
     {{- include "datahub.labels" . | nindent 4 }}
+  {{- with .Values.postgresqlSetupJob.annotations }}
   annotations:
-    # This is what defines this resource as a hook. Without this line, the
-    # job is considered part of the release.
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   template:
     {{- if or .Values.global.podLabels .Values.postgresqlSetupJob.podAnnotations }}

--- a/charts/datahub/templates/postgresql-setup-job.yml
+++ b/charts/datahub/templates/postgresql-setup-job.yml
@@ -43,6 +43,10 @@ spec:
       restartPolicy: Never
       securityContext:
         {{- toYaml .Values.postgresqlSetupJob.podSecurityContext | nindent 8 }}
+      {{- with .Values.postgresqlSetupJob.extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: postgresql-setup-job
           image: "{{ .Values.postgresqlSetupJob.image.repository }}:{{ required "Global or specific tag is required" (.Values.postgresqlSetupJob.image.tag | default .Values.global.datahub.version) }}"

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -100,6 +100,12 @@ elasticsearchSetupJob:
     fsGroup: 1000
   securityContext:
     runAsUser: 1000
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation
   podAnnotations: {}
   # Add extra sidecar containers to job pod
   extraSidecars: []
@@ -123,6 +129,12 @@ kafkaSetupJob:
     fsGroup: 1000
   securityContext:
     runAsUser: 1000
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation
   podAnnotations: {}
   # Add extra sidecar containers to job pod
   extraSidecars: []
@@ -146,6 +158,12 @@ mysqlSetupJob:
     fsGroup: 1000
   securityContext:
     runAsUser: 1000
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation
   podAnnotations: {}
   # Optionally set a set-up job specific login (defaults to global login)
   # username: "mysqlSetupJob-login"
@@ -174,6 +192,12 @@ postgresqlSetupJob:
     fsGroup: 1000
   securityContext:
     runAsUser: 1000
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation
   podAnnotations: {}
   # Optionally set a set-up job specific login (defaults to global login)
   # username: "postgresqlSetupJob-login"
@@ -205,6 +229,12 @@ datahubUpgrade:
     # fsGroup: 1000
   securityContext: {}
     # runAsUser: 1000
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "-2"
+    helm.sh/hook-delete-policy: before-hook-creation
   podAnnotations: {}
   # Add extra sidecar containers to job pod
   extraSidecars: []
@@ -252,6 +282,12 @@ datahubSystemUpdate:
     # fsGroup: 1000
   securityContext: {}
     # runAsUser: 1000
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-4"
+    helm.sh/hook-delete-policy: before-hook-creation
   podAnnotations: {}
   resources:
     limits:
@@ -537,6 +573,7 @@ global:
       provisionSecret:
         enabled: true
         autoGenerate: true
+        annotations: {}
       # Only specify if autoGenerate set to false
       #  secretValues:
       #    encryptionKey: <encryption key value>
@@ -562,6 +599,7 @@ global:
       provisionSecrets:
         enabled: true
         autoGenerate: true
+        annotations: {}
       # Only specify if autoGenerate set to false
       #  secretValues:
       #    secret: <secret value>

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -96,6 +96,7 @@ elasticsearchSetupJob:
     requests:
       cpu: 300m
       memory: 256Mi
+  extraInitContainers: []
   podSecurityContext:
     fsGroup: 1000
   securityContext:
@@ -125,6 +126,7 @@ kafkaSetupJob:
     requests:
       cpu: 300m
       memory: 768Mi
+  extraInitContainers: []
   podSecurityContext:
     fsGroup: 1000
   securityContext:
@@ -154,6 +156,7 @@ mysqlSetupJob:
     requests:
       cpu: 300m
       memory: 256Mi
+  extraInitContainers: []
   podSecurityContext:
     fsGroup: 1000
   securityContext:
@@ -188,6 +191,7 @@ postgresqlSetupJob:
     requests:
       cpu: 300m
       memory: 256Mi
+  extraInitContainers: []
   podSecurityContext:
     fsGroup: 1000
   securityContext:
@@ -271,6 +275,7 @@ datahubUpgrade:
     # extraEnvs:
     #   - name: "DATAHUB_DB_NAME"
     #    value: "dh"
+  extraInitContainers: []
 
 ## Runs system update processes
 ## Includes: Elasticsearch Indices Creation/Reindex (See global.elasticsearch.index for additional configuration)
@@ -301,6 +306,7 @@ datahubSystemUpdate:
     # - name: my-image-name
     #   image: my-image
     #   imagePullPolicy: Always
+  extraInitContainers: []
 
 global:
   strict_mode: true


### PR DESCRIPTION
The use of pre-install hooks can be problematic when resources need to be available before the hooks run, but can't be safely destroyed and recreated (like secrets). We are using the helm chart as a dependency in our chart which also deploys a postgres database using the postgres operator. Since it isn't possible to deploy the database as a hook as either you would never be able to update it or it will get destroyed and recreated on upgrades, we need the ability to change the hook annotations for the setup and migration jobs. This would allow us to run the jobs as `post-install` hooks, along with init containers that will wait until the database is ready for connections.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204702566859781