### PR TITLE
chore(secrets): use configurable refs instead of fixed names

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.165
+version: 0.2.170
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.10.3

--- a/charts/datahub/templates/datahub-auth-secrets.yml
+++ b/charts/datahub/templates/datahub-auth-secrets.yml
@@ -1,5 +1,6 @@
 {{- if .Values.global.datahub.metadata_service_authentication.enabled -}}
-{{- $secret := lookup "v1" "Secret" .Release.Namespace "datahub-auth-secrets" -}}
+{{- $secretRef := .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretRef | required "secretRef required" -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace $secretRef -}}
 {{- $data := $secret.data | default dict -}}
 {{- with .Values.global.datahub.metadata_service_authentication.provisionSecrets }}
 
@@ -7,7 +8,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "datahub-auth-secrets"
+  name: {{ $secretRef }}
 type: Opaque
 data:
   {{- if .autoGenerate }}

--- a/charts/datahub/templates/datahub-encryption-secrets.yml
+++ b/charts/datahub/templates/datahub-encryption-secrets.yml
@@ -1,4 +1,6 @@
-{{- $secret := lookup "v1" "Secret" .Release.Namespace "datahub-encryption-secrets" -}}
+{{- $secretRef := .Values.global.datahub.encryptionKey.secretRef | required "secretRef required" -}}
+{{- $secretKey := .Values.global.datahub.encryptionKey.secretKey | required "secretKey required" -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace $secretRef -}}
 {{- $data := $secret.data | default dict -}}
 {{- with .Values.global.datahub.encryptionKey.provisionSecret }}
 
@@ -6,11 +8,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "datahub-encryption-secrets"
+  name: {{ $secretRef }}
 type: Opaque
-data: 
+data:
   {{- if .autoGenerate }}
-  encryption_key_secret: {{ get $data "encryption_key_secret" | default (randAlphaNum 20 | b64enc | quote) }}
+  encryption_key_secret: {{ get $data $secretKey | default (randAlphaNum 20 | b64enc | quote) }}
   {{- else }}
   encryption_key_secret: {{ .secretValues.encryptionKey | b64enc | quote }}
   {{- end }}


### PR DESCRIPTION
This is enabling (we could say even fix 😅 ) the support for configurable `secretRef` here https://github.com/acryldata/datahub-helm/blob/3678c86f5c925662828442f405b5b2e769c960d2/charts/datahub/values.yaml#L526 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
