### PR TITLE
fix(prerequisites): disable downloading and updating of GeoIP2 database

### DIFF
--- a/charts/prerequisites/Chart.yaml
+++ b/charts/prerequisites/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for packages that Datahub depends on
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.18
+version: 0.0.19
 dependencies:
   - name: elasticsearch
     version: 7.17.3

--- a/charts/prerequisites/values.yaml
+++ b/charts/prerequisites/values.yaml
@@ -7,17 +7,20 @@ elasticsearch:
   # Or alternatively if you're running production, bring your own ElasticSearch
   replicas: 1
   minimumMasterNodes: 1
-  # Set replicas to 1 and uncomment this to allow the instance to be scheduled on
-  # a master node when deploying on a single node Minikube / Kind / etc cluster.
   antiAffinity: "soft"
 
-  # # If you are running a multi-replica cluster, comment this out
+  # If you are running a multi-replica cluster, comment this out
   clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
 
-  # # Shrink default JVM heap.
+  # Shrink default JVM heap.
   esJavaOpts: "-Xmx384m -Xms384m"
 
-  # # Allocate smaller chunks of memory per pod.
+  # Disables downloading and updating of the GeoIP2 database
+  extraEnvs:
+    - name: ingest.geoip.downloader.enabled
+      value: "false"
+
+  # Allocate smaller chunks of memory per pod.
   resources:
     requests:
       cpu: "100m"


### PR DESCRIPTION
This PR disables the download and update of the GeoIP2 database of ElasticSearch. If enabled in offline-only deployment scenarios (i.e. deployments where ElasticSearch does not have access to the internet) the ElasticSearch pod regulary prints some error messages, because it cannot connect to the host from where the GeoIP2 database is downloaded.

As far as I know we are not using the GeoIP processor anywhere in DataHub, therefore it should be safe to disable it.

```
{"type": "server", "timestamp": "2023-06-15T09:25:38,126Z", "level": "INFO", "component": "o.e.i.g.GeoIpDownloader", "cluster.name": "elasticsearch", "node.name": "elasticsearch-master-0", "message": "updating geoip databases", "cluster.uuid": "xyz", "node.id": "xyz" }
{"type": "server", "timestamp": "2023-06-15T09:25:38,126Z", "level": "INFO", "component": "o.e.i.g.GeoIpDownloader", "cluster.name": "elasticsearch", "node.name": "elasticsearch-master-0", "message": "fetching geoip databases overview from [https://geoip.elastic.co/v1/database?elastic_geoip_service_tos=agree]", "cluster.uuid": "xyz", "node.id": "xyz" }
{"type": "server", "timestamp": "2023-06-15T09:25:48,163Z", "level": "ERROR", "component": "o.e.i.g.GeoIpDownloader", "cluster.name": "elasticsearch", "node.name": "elasticsearch-master-0", "message": "exception during geoip databases update", "cluster.uuid": "xyz", "node.id": "xyz" ,
"stacktrace": ["java.net.SocketTimeoutException: Connect timed out",
"at sun.nio.ch.NioSocketImpl.timedFinishConnect(NioSocketImpl.java:546) ~[?:?]",
"at sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:597) ~[?:?]",
"at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327) ~[?:?]",
"at java.net.Socket.connect(Socket.java:633) ~[?:?]",
"at sun.security.ssl.SSLSocketImpl.connect(SSLSocketImpl.java:299) ~[?:?]",
"at sun.net.NetworkClient.doConnect(NetworkClient.java:178) ~[?:?]",
"at sun.net.www.http.HttpClient.openServer(HttpClient.java:498) ~[?:?]",
"at sun.net.www.http.HttpClient.openServer(HttpClient.java:603) ~[?:?]",
"at sun.net.www.protocol.https.HttpsClient.<init>(HttpsClient.java:266) ~[?:?]",
"at sun.net.www.protocol.https.HttpsClient.New(HttpsClient.java:380) ~[?:?]",
"at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.getNewHttpClient(AbstractDelegateHttpsURLConnection.java:189) ~[?:?]",
"at sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1242) ~[?:?]",
"at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1128) ~[?:?]",
"at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:175) ~[?:?]",
"at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1665) ~[?:?]",
"at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1589) ~[?:?]",
"at java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:529) ~[?:?]",
"at sun.net.www.protocol.https.HttpsURLConnectionImpl.getResponseCode(HttpsURLConnectionImpl.java:308) ~[?:?]",
"at org.elasticsearch.ingest.geoip.HttpClient.lambda$get$0(HttpClient.java:55) ~[ingest-geoip-7.16.2.jar:7.16.2]",
"at java.security.AccessController.doPrivileged(AccessController.java:569) ~[?:?]",
"at org.elasticsearch.ingest.geoip.HttpClient.doPrivileged(HttpClient.java:97) ~[ingest-geoip-7.16.2.jar:7.16.2]",
"at org.elasticsearch.ingest.geoip.HttpClient.get(HttpClient.java:49) ~[ingest-geoip-7.16.2.jar:7.16.2]",
"at org.elasticsearch.ingest.geoip.HttpClient.getBytes(HttpClient.java:40) ~[ingest-geoip-7.16.2.jar:7.16.2]",
"at org.elasticsearch.ingest.geoip.GeoIpDownloader.fetchDatabasesOverview(GeoIpDownloader.java:135) ~[ingest-geoip-7.16.2.jar:7.16.2]",
"at org.elasticsearch.ingest.geoip.GeoIpDownloader.updateDatabases(GeoIpDownloader.java:123) ~[ingest-geoip-7.16.2.jar:7.16.2]",
"at org.elasticsearch.ingest.geoip.GeoIpDownloader.runDownloader(GeoIpDownloader.java:260) [ingest-geoip-7.16.2.jar:7.16.2]",
"at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:718) [elasticsearch-7.16.2.jar:7.16.2]",
"at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]",
"at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]",
"at java.lang.Thread.run(Thread.java:833) [?:?]"] }
```


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
