### PR TITLE
feat(cron): Adding more parameters to ingestion-cron

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.176
+version: 0.2.177
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.10.4

--- a/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
@@ -9,8 +9,12 @@ metadata:
   labels: {{- $labels | nindent 4 }}
 spec:
   schedule: {{ default "0 0 * * *" .schedule | quote}}
+  concurrencyPolicy: {{ default "Allow" .concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ default 3 .successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ default 1 .failedJobsHistoryLimit }}
   jobTemplate:
     spec:
+      backoffLimit: {{ default 6 $val.backoffLimit }}
       template:
         {{- with $val.podAnnotations }}
         metadata:
@@ -60,7 +64,7 @@ spec:
                     key: {{ $value.key | quote}}
               {{- end }}
               {{- end }}
-          restartPolicy: OnFailure
+          restartPolicy: {{ default "OnFailure" .restartPolicy }}
           volumes:
             - name: recipe
               configMap:

--- a/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
@@ -66,6 +66,26 @@ crons: {}
     ##
     #podAnnotations: {}
 
+    ## Add your own restartPolicy
+    ##
+    #restartPolicy:
+
+    ## Add your own concurrencyPolicy
+    ##
+    #concurrencyPolicy:
+
+    ## Add your own failedJobsHistoryLimit
+    ##
+    #failedJobsHistoryLimit:
+
+    ## Add your own successfulJobsHistoryLimit
+    ##
+    #successfulJobsHistoryLimit:
+
+    ## Add your own backoffLimit
+    ##
+    #backoffLimit:
+
 # Add extra sidecar containers to deployment pod
 extraSidecars: []
   # - name: my-image-name


### PR DESCRIPTION
This PR enabling to users to set up different parameters of the cronjob/job in the ingestion process. In particular, we will be able to configure the following parameters:
- `concurrencyPolicy`
- `successfulJobsHistoryLimit `
- `failedJobsHistoryLimit `
- `backoffLimit `
- `restartPolicy`

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
