### PR TITLE
Update charts to include search and browse env variable flags

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,13 +4,13 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.177
+version: 0.2.178
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.10.4
 dependencies:
   - name: datahub-gms
-    version: 0.2.149
+    version: 0.2.150
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
@@ -18,11 +18,11 @@ dependencies:
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer
-    version: 0.2.145
+    version: 0.2.146
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.2.147
+    version: 0.2.149
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for LinkedIn DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.149
+version: 0.2.150
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.10.0

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -97,6 +97,12 @@ spec:
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           env:
+            - name: SHOW_SEARCH_FILTERS_V2
+              value: {{ .Values.global.datahub.search_and_browse.show_search_v2 | quote }}
+            - name: SHOW_BROWSE_V2
+              value: {{ .Values.global.datahub.search_and_browse.show_browse_v2 | quote }}
+            - name: BACKFILL_BROWSE_PATHS_V2
+              value: {{ .Values.global.datahub.search_and_browse.backfill_browse_v2 | quote }}
             {{- if .Values.global.elasticsearch.search.custom.enabled }}
             - name: ELASTICSEARCH_QUERY_CUSTOM_CONFIG_ENABLED
               value: "true"

--- a/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.145
+version: 0.2.146
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.10.0

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -83,6 +83,12 @@ spec:
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           env:
+            - name: SHOW_SEARCH_FILTERS_V2
+              value: {{ .Values.global.datahub.search_and_browse.show_search_v2 | quote }}
+            - name: SHOW_BROWSE_V2
+              value: {{ .Values.global.datahub.search_and_browse.show_browse_v2 | quote }}
+            - name: BACKFILL_BROWSE_PATHS_V2
+              value: {{ .Values.global.datahub.search_and_browse.backfill_browse_v2 | quote }}
             {{- if .Values.global.datahub.systemUpdate.enabled }}
             - name: DATAHUB_UPGRADE_HISTORY_KAFKA_CONSUMER_GROUP_ID
               value: {{ printf "%s-%s" .Release.Name "duhe-consumer-job-client-mcl" }}

--- a/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.147
+version: 0.2.149
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.10.0

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
@@ -87,6 +87,12 @@ spec:
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           env:
+            - name: SHOW_SEARCH_FILTERS_V2
+              value: {{ .Values.global.datahub.search_and_browse.show_search_v2 | quote }}
+            - name: SHOW_BROWSE_V2
+              value: {{ .Values.global.datahub.search_and_browse.show_browse_v2 | quote }}
+            - name: BACKFILL_BROWSE_PATHS_V2
+              value: {{ .Values.global.datahub.search_and_browse.backfill_browse_v2 | quote }}
             {{- if .Values.global.datahub.systemUpdate.enabled }}
             - name: DATAHUB_UPGRADE_HISTORY_KAFKA_CONSUMER_GROUP_ID
               value: {{ printf "%s-%s" .Release.Name "duhe-consumer-job-client-mcp" }}

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -618,6 +618,12 @@ global:
     ## Enables diff mode for graph writes, uses a different code path that produces a diff from previous to next to write relationships instead of wholesale deleting edges and reading
     enableGraphDiffMode: true
 
+    ## Values specific to the unified search and browse feature.
+    search_and_browse:
+      show_search_v2: true # If on, show the new search filters experience as of v0.10.5
+      show_browse_v2: true # If on, show the new browse experience as of v0.10.5
+      backfill_browse_v2: true # If on, run the backfill upgrade job that generates default browse paths for relevant entities
+
 #  hostAliases:
 #    - ip: "192.168.0.104"
 #      hostnames:

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -620,9 +620,9 @@ global:
 
     ## Values specific to the unified search and browse feature.
     search_and_browse:
-      show_search_v2: true # If on, show the new search filters experience as of v0.10.5
-      show_browse_v2: true # If on, show the new browse experience as of v0.10.5
-      backfill_browse_v2: true # If on, run the backfill upgrade job that generates default browse paths for relevant entities
+      show_search_v2: true  # If on, show the new search filters experience as of v0.10.5
+      show_browse_v2: true  # If on, show the new browse experience as of v0.10.5
+      backfill_browse_v2: true  # If on, run the backfill upgrade job that generates default browse paths for relevant entities
 
 #  hostAliases:
 #    - ip: "192.168.0.104"


### PR DESCRIPTION
There are 3 new env variable flags that relate to the new unified search and browse experience that I'm adding to our helm charts here. The new unified search and browse experience goes out with the v0.10.5 release so these variables are necessary to get in for folks.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
