### PR TITLE
fix(config) Set search and browse flags default off

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.178
+version: 0.2.179
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.10.4

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -620,9 +620,9 @@ global:
 
     ## Values specific to the unified search and browse feature.
     search_and_browse:
-      show_search_v2: true  # If on, show the new search filters experience as of v0.10.5
-      show_browse_v2: true  # If on, show the new browse experience as of v0.10.5
-      backfill_browse_v2: true  # If on, run the backfill upgrade job that generates default browse paths for relevant entities
+      show_search_v2: false  # If on, show the new search filters experience as of v0.10.5
+      show_browse_v2: false  # If on, show the new browse experience as of v0.10.5
+      backfill_browse_v2: false  # If on, run the backfill upgrade job that generates default browse paths for relevant entities
 
 #  hostAliases:
 #    - ip: "192.168.0.104"


### PR DESCRIPTION
Sets search and browse flags off by default so we can button other things up first.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
