### PR TITLE
fix(docs): fix prerequisites README

### DIFF
--- a/charts/prerequisites/README.md
+++ b/charts/prerequisites/README.md
@@ -12,5 +12,5 @@ helm install datahub datahub/datahub-prerequisites
 
 If the default configuration is not applicable, you can update the values listed below in a `values.yaml` file and run
 ```
-helm install datahub datahub/datahub-prerequisites --values <<path-to-values-file>>
+helm install prerequisites datahub/datahub-prerequisites --values <<path-to-values-file>>
 ```


### PR DESCRIPTION
The incorrect prerequisites docs should match the top level README