### PR TITLE
feat(cron): support nodeselector, affinity and toleration capabilities 

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.179
+version: 0.2.180
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.10.4
@@ -26,7 +26,7 @@ dependencies:
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron
-    version: 0.2.133
+    version: 0.2.134
     repository: file://./subcharts/datahub-ingestion-cron
     condition: datahub-ingestion-cron.enabled
   - name: acryl-datahub-actions

--- a/charts/datahub/subcharts/datahub-ingestion-cron/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.133
+version: 0.2.134
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.10.0

--- a/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
@@ -73,6 +73,10 @@ spec:
           affinity:
             {{- toYaml .affinity | nindent 12 }}
           {{- end }}
+          {{- if .tolerations }}
+          tolerations:
+            {{- toYaml .tolerations | nindent 12 }}
+          {{- end }}
           volumes:
             - name: recipe
               configMap:

--- a/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
@@ -69,6 +69,10 @@ spec:
           nodeSelector:
             {{- toYaml .nodeSelector | nindent 12 }}
           {{- end }}
+          {{- if .affinity }}
+          affinity:
+            {{- toYaml .affinity | nindent 12 }}
+          {{- end }}
           volumes:
             - name: recipe
               configMap:

--- a/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
@@ -65,6 +65,10 @@ spec:
               {{- end }}
               {{- end }}
           restartPolicy: {{ default "OnFailure" .restartPolicy }}
+          {{- if .nodeSelector }}
+          nodeSelector:
+            {{- toYaml .nodeSelector | nindent 12 }}
+          {{- end }}
           volumes:
             - name: recipe
               configMap:

--- a/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
@@ -86,6 +86,11 @@ crons: {}
     ##
     #backoffLimit:
 
+    ## Node Selector parameters for job pod.
+    #nodeSelector: {}
+    #  region: us-west-1
+    #  disk: ssd
+
 # Add extra sidecar containers to deployment pod
 extraSidecars: []
   # - name: my-image-name

--- a/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
@@ -86,13 +86,19 @@ crons: {}
     ##
     #backoffLimit:
 
-    ## Node Selector parameters for job pod.
+    ## Node Selector parameters for job pod
+    ##
     #nodeSelector: {}
     #  region: us-west-1
     #  disk: ssd
 
     ## Affinity settings for job pod
+    ##
     #affinity : {}
+
+    ## Toleration settings  for job pod
+    ##
+    #tolerations: []
 
 # Add extra sidecar containers to deployment pod
 extraSidecars: []

--- a/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
@@ -91,6 +91,9 @@ crons: {}
     #  region: us-west-1
     #  disk: ssd
 
+    ## Affinity settings for job pod
+    #affinity : {}
+
 # Add extra sidecar containers to deployment pod
 extraSidecars: []
   # - name: my-image-name


### PR DESCRIPTION
This PR enable users to configure  nodeselector, tolerations and affinity capabilities for each cron job in the datahub-ingestion-cron helm chart.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
