### PR TITLE
feat(neo4j): update neo4j chart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,8 +31,7 @@ jobs:
       - name: Add Helm repos
         run: |
           helm repo add elasticsearch https://helm.elastic.co
-          helm repo add neo4j https://neo4j-contrib.github.io/neo4j-helm
-          helm repo add neo4j-community https://equinor.github.io/helm-charts/charts
+          helm repo add neo4j https://helm.neo4j.com/neo4j
           helm repo add mysql https://charts.bitnami.com/bitnami
           helm repo add cp-helm-charts https://confluentinc.github.io/cp-helm-charts
           helm repo add kafka https://charts.bitnami.com/bitnami

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Assuming kubectl context points to the correct kubernetes cluster, first create 
 
 ```(shell)
 kubectl create secret generic mysql-secrets --from-literal=mysql-root-password=datahub
-kubectl create secret generic neo4j-secrets --from-literal=neo4j-password=datahub
+kubectl create secret generic neo4j-secrets --from-literal=neo4j-password=datahub --from-literal=NEO4J_AUTH=neo4j/datahub
 ```
 
 The above commands sets the passwords to "datahub" as an example. Change to any password of choice. 
@@ -79,7 +79,7 @@ elasticsearch-master-0                             1/1     Running     0        
 prerequisites-cp-schema-registry-cf79bfccf-kvjtv   2/2     Running     1          63m
 prerequisites-kafka-0                              1/1     Running     2          62m
 prerequisites-mysql-0                              1/1     Running     1          62m
-prerequisites-neo4j-community-0                    1/1     Running     0          52m
+prerequisites-neo4j-0                              1/1     Running     0          52m
 prerequisites-zookeeper-0                          1/1     Running     0          62m
 ```
 
@@ -109,7 +109,7 @@ elasticsearch-master-0                             1/1     Running     0        
 prerequisites-cp-schema-registry-cf79bfccf-kvjtv   2/2     Running     1          99m
 prerequisites-kafka-0                              1/1     Running     2          97m
 prerequisites-mysql-0                              1/1     Running     1          97m
-prerequisites-neo4j-community-0                    1/1     Running     0          88m
+prerequisites-neo4j-0                              1/1     Running     0          88m
 prerequisites-zookeeper-0                          1/1     Running     0          97m
 ```
 

--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.185
+version: 0.2.186
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.10.5

--- a/charts/datahub/quickstart-values-with-neo4j.yaml
+++ b/charts/datahub/quickstart-values-with-neo4j.yaml
@@ -87,8 +87,8 @@ global:
       url: "http://prerequisites-cp-schema-registry:8081"
 
   neo4j:
-    host: "prerequisites-neo4j-community:7474"
-    uri: "bolt://prerequisites-neo4j-community"
+    host: "prerequisites-neo4j:7474"
+    uri: "bolt://prerequisites-neo4j"
     username: "neo4j"
     password:
       secretRef: neo4j-secrets

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -498,8 +498,8 @@ global:
       #   registry: datahub
 
   neo4j:
-    host: "prerequisites-neo4j-community:7474"
-    uri: "bolt://prerequisites-neo4j-community"
+    host: "prerequisites-neo4j:7474"
+    uri: "bolt://prerequisites-neo4j"
     username: "neo4j"
     password:
       secretRef: neo4j-secrets

--- a/charts/prerequisites/Chart.yaml
+++ b/charts/prerequisites/Chart.yaml
@@ -4,22 +4,17 @@ description: A Helm chart for packages that Datahub depends on
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.18
+version: 0.1.1
 dependencies:
   - name: elasticsearch
     version: 7.17.3
     repository: https://helm.elastic.co
     condition: elasticsearch.enabled
-  # This chart deploys an enterprise version of neo4j that requires commercial license
+  # This chart deploys an enterprise or community version of neo4j
   - name: neo4j
-    version: 4.2.2-1
-    repository: https://neo4j-contrib.github.io/neo4j-helm/
+    version: 5.11.0
+    repository: https://helm.neo4j.com/neo4j
     condition: neo4j.enabled
-  # This chart deploys a community version of neo4j
-  - name: neo4j-community
-    version: 1.2.5
-    repository: https://equinor.github.io/helm-charts/charts/
-    condition: neo4j-community.enabled
   - name: mysql
     version: 9.1.8
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami

--- a/charts/prerequisites/values.yaml
+++ b/charts/prerequisites/values.yaml
@@ -34,24 +34,40 @@ elasticsearch:
   #     requests:
   #       storage: 100M
 
-# Official neo4j chart uses the Neo4j Enterprise Edition which requires a license
+# Official neo4j chart, supports both community and enterprise editions
+# see https://neo4j.com/docs/operations-manual/current/kubernetes/ for more information
+# source: https://github.com/neo4j/helm-charts
 neo4j:
-  enabled: false  # set this to true, if you have a license for the enterprise edition
-  acceptLicenseAgreement: "yes"
-  defaultDatabase: "graph.db"
-  neo4jPassword: "datahub"
-  # For better security, add password to neo4j-secrets k8s secret and uncomment below
-  # existingPasswordSecret: neo4j-secrets
-  core:
-    standalone: true
+  enabled: true 
+  nameOverride: neo4j
+  neo4j:
+    name: neo4j
+    edition: "community"
+    acceptLicenseAgreement: "yes"
+    defaultDatabase: "graph.db"
+    password: "datahub"
+    # For better security, add password to neo4j-secrets k8s secret with  neo4j-username neo4j-passwordn and NEO4J_AUTH and uncomment below
+    # NEO4J_AUTH: should be composed like so: {Username}/{Password}
+    # passwordFromSecret: neo4j-secrets
 
-# Deploys neo4j community version. Only supports single node
-neo4j-community:
-  enabled: false   # set this to true, if you want to run neo4j community edition
-  acceptLicenseAgreement: "yes"
-  defaultDatabase: "graph.db"
-  # For better security, add neo4j-secrets k8s secret with neo4j-password and uncomment below
-  existingPasswordSecret: neo4j-secrets
+  # Set security context for pod
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 7474
+    runAsGroup: 7474
+    fsGroup: 7474
+    fsGroupChangePolicy: "Always"
+
+  # Disallow privilegeEscalation on container level
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+
+  # Create a volume for neo4j, SSD storage is recommended
+  volumes: {}
+    # data:
+    #   mode: "dynamic"
+    #   dynamic:
+    #     storageClassName: managed-csi-premium
 
 mysql:
   enabled: true

--- a/charts/prerequisites/values.yaml
+++ b/charts/prerequisites/values.yaml
@@ -38,7 +38,7 @@ elasticsearch:
 # see https://neo4j.com/docs/operations-manual/current/kubernetes/ for more information
 # source: https://github.com/neo4j/helm-charts
 neo4j:
-  enabled: true 
+  enabled: true
   nameOverride: neo4j
   neo4j:
     name: neo4j


### PR DESCRIPTION
Update neo4j to the latest chart version supplied by the neo4j organisation. The new chart offers build in support for enterprise and comunity deployments. This also improves security by exposing the podSecurityContext and containerSecurityContext to the user.

BREAKING CHANGE:

Removal of neo4j-comunity chart and values
Change neo4j parameters are now under neo4j.neo4j
Rename neo4jPassword to password
Rename existingPasswordSecret to passwordFromSecret Change passwordFromSecret expects: neo4j-password and NEO4J_AUTH keys Require PersistentVolume from values

Closes: https://github.com/acryldata/datahub-helm/issues/364



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
