### PR TITLE
fix(helm): add ability to set AUTH_OIDC_BASE_URL independent of ingress

### DIFF
--- a/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
@@ -191,8 +191,10 @@ spec:
             {{- else }}
               value: {{ .clientSecret }}
             {{- end }}
+            {{- if $.Values.ingress.enabled }}
             - name: AUTH_OIDC_BASE_URL
               value: https://{{ (first $.Values.ingress.hosts).host }}
+            {{- end }}
             {{- if eq .provider "google" }}
             - name: AUTH_OIDC_DISCOVERY_URI
               value: https://accounts.google.com/.well-known/openid-configuration


### PR DESCRIPTION
fixes [#312](https://github.com/acryldata/datahub-helm/issues/312)
Adds ability to set AUTH_OIDC_BASE_URL independent of ingress.hosts.host if ingress is disabled. AUTH_OIDC_BASE_URL can instead be set using extraEnvs.

