### PR TITLE
fix(kafka): increase kafka chart version due to kraft enabled error

### DIFF
--- a/charts/prerequisites/Chart.yaml
+++ b/charts/prerequisites/Chart.yaml
@@ -35,7 +35,7 @@ dependencies:
     condition: cp-helm-charts.enabled
   # This chart deploys a community version of kafka
   - name: kafka
-    version: 22.1.3
+    version: 22.1.6
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: kafka.enabled
 maintainers:

--- a/charts/prerequisites/Chart.yaml
+++ b/charts/prerequisites/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for packages that Datahub depends on
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.2
+version: 0.1.3
 dependencies:
   - name: elasticsearch
     version: 7.17.3


### PR DESCRIPTION
This MR fixes used kafka helm chart due to error when using kraft and helm drift detection

related issue: https://github.com/acryldata/datahub-helm/issues/377 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
