### PR TITLE
feat(sql): allow providing username from secret for sql setup jobs

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.9
+version: 0.3.10
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.11.0

--- a/charts/datahub/templates/mysql-setup-job.yml
+++ b/charts/datahub/templates/mysql-setup-job.yml
@@ -53,7 +53,15 @@ spec:
           imagePullPolicy: {{ .Values.mysqlSetupJob.image.pullPolicy | default "IfNotPresent" }}
           env:
             - name: MYSQL_USERNAME
-              value: {{ .Values.mysqlSetupJob.username | default .Values.global.sql.datasource.username | quote }}
+              {{- $usernameValue := (.Values.mysqlSetupJob).username | default .Values.global.sql.datasource.username }}
+              {{- if and (kindIs "string" $usernameValue) $usernameValue }}
+              value: {{ $usernameValue | quote }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ ($usernameValue).secretRef | default .Values.global.sql.datasource.username.secretRef }}"
+                  key: "{{ ($usernameValue).secretKey | default .Values.global.sql.datasource.username.secretKey }}"
+              {{- end }}
             - name: MYSQL_PASSWORD
               {{- $passwordValue := (.Values.mysqlSetupJob.password).value | default .Values.global.sql.datasource.password.value }}
               {{- if $passwordValue }}

--- a/charts/datahub/templates/postgresql-setup-job.yml
+++ b/charts/datahub/templates/postgresql-setup-job.yml
@@ -53,7 +53,15 @@ spec:
           imagePullPolicy: {{ .Values.postgresqlSetupJob.image.pullPolicy | default "Always" }}
           env:
             - name: POSTGRES_USERNAME
-              value: {{ .Values.postgresqlSetupJob.username | default .Values.global.sql.datasource.username | quote }}
+              {{- $usernameValue := (.Values.postgresqlSetupJob).username | default .Values.global.sql.datasource.username }}
+              {{- if and (kindIs "string" $usernameValue) $usernameValue }}
+              value: {{ $usernameValue | quote }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ ($usernameValue).secretRef | default .Values.global.sql.datasource.username.secretRef }}"
+                  key: "{{ ($usernameValue).secretKey | default .Values.global.sql.datasource.username.secretKey }}"
+              {{- end }}
             - name: POSTGRES_PASSWORD
               {{- $passwordValue := (.Values.postgresqlSetupJob.password).value | default .Values.global.sql.datasource.password.value }}
               {{- if $passwordValue }}


### PR DESCRIPTION
This adds the functionality from #291 to the MySQL and PostgreSQL setup jobs

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [X] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
