### PR TITLE
fiz(hazelcast): replace all invalid chars

### DIFF
--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -113,7 +113,7 @@ spec:
             - name: SEARCH_SERVICE_CACHE_IMPLEMENTATION
               value: "hazelcast"
             - name: SEARCH_SERVICE_HAZELCAST_SERVICE_NAME
-              value: {{ printf "%s-%s-%s" .Release.Name (regexReplaceAll "\\W+" .Values.global.datahub.version "-") "hazelcast-svc" | trunc 63 | trimSuffix "-" }}
+              value: {{ printf "%s-%s-%s" .Release.Name (regexReplaceAll "[^-a-z0-9]+" .Values.global.datahub.version "-") "hazelcast-svc" | trunc 63 | trimSuffix "-" }}
             {{- end}}
             {{- if .Values.global.datahub.systemUpdate.enabled }}
             - name: DATAHUB_UPGRADE_HISTORY_KAFKA_CONSUMER_GROUP_ID

--- a/charts/datahub/subcharts/datahub-gms/templates/hazelcastService.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/hazelcastService.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s-%s" .Release.Name (regexReplaceAll "\\W+" .Values.global.datahub.version "-") "hazelcast-svc" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s-%s" .Release.Name (regexReplaceAll "[^-a-z0-9]+" .Values.global.datahub.version "-") "hazelcast-svc" | trunc 63 | trimSuffix "-" }}
 spec:
   clusterIP: None
   ports:


### PR DESCRIPTION
This is fixing the following error where `_` character is not being replaced and still being invalid.

```

Error: UPGRADE FAILED: failed to create resource: Service "pre-0-11-0_2-0-0-hazelcast-svc" is invalid: metadata.name: Invalid value: "pre-0-11-0_2-0-0-hazelcast-svc": a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')
```

The fix replaces all invalid chars, that is `[^-a-z0-9]+`


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
