### PR TITLE
fix(ingestion-cron): remove duplicate shell command in cron chart

### DIFF
--- a/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
@@ -23,7 +23,7 @@ crons: {}
     #  fileName:
 
     ## Command to be executed
-    #command: ["datahub ingest -c <recipe.fileName>"]
+    #command: "datahub ingest -c <recipe.fileName>"
 
     ## Deployment pod host aliases
     ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/

--- a/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
@@ -23,7 +23,7 @@ crons: {}
     #  fileName:
 
     ## Command to be executed
-    #command: ["/bin/sh", "-c", "datahub ingest -c <recipe.fileName>"]
+    #command: ["datahub ingest -c <recipe.fileName>"]
 
     ## Deployment pod host aliases
     ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/


### PR DESCRIPTION
This PR fixes issue mentioned at https://github.com/acryldata/datahub-helm/issues/389 .The duplicate shell command is removed from values.yaml since it is already present in cron.yaml template. Thanks @jimsmith for reporting and figuring out the root cause.
## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
