### PR TITLE
Feat: Add Basic Auth For Using Confluent Kafka Schema Registry API

### DIFF
--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -677,3 +677,4 @@ global:
 #    ssl.truststore.type: JKS
 #    ssl.protocol: TLS
 #    ssl.endpoint.identification.algorithm:
+#    basic.auth.user.info:

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -666,7 +666,7 @@ global:
 #      ssl.keystore.password: datahub.linkedin.com.KeyStorePass
 #      ssl.truststore.password: datahub.linkedin.com.TrustStorePass
 #      kafkastore.ssl.truststore.password: datahub.linkedin.com.TrustStorePass
-#
+# 
 #  springKafkaConfigurationOverrides:
 #    ssl.keystore.location: /mnt/datahub/certs/datahub.linkedin.com.keystore.jks
 #    ssl.truststore.location: /mnt/datahub/certs/datahub.linkedin.com.truststore.jks
@@ -677,4 +677,5 @@ global:
 #    ssl.truststore.type: JKS
 #    ssl.protocol: TLS
 #    ssl.endpoint.identification.algorithm:
+#    basic.auth.credentials.source: USER_INFO
 #    basic.auth.user.info:

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -666,7 +666,7 @@ global:
 #      ssl.keystore.password: datahub.linkedin.com.KeyStorePass
 #      ssl.truststore.password: datahub.linkedin.com.TrustStorePass
 #      kafkastore.ssl.truststore.password: datahub.linkedin.com.TrustStorePass
-# 
+#
 #  springKafkaConfigurationOverrides:
 #    ssl.keystore.location: /mnt/datahub/certs/datahub.linkedin.com.keystore.jks
 #    ssl.truststore.location: /mnt/datahub/certs/datahub.linkedin.com.truststore.jks


### PR DESCRIPTION

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)


For Using Confluent Kafka (Schema Registry), We have to set 2 values.
* basic.auth.credentials.source -> USER_INFO
* basic.auth.user.info

If we do not fill in these two values, we cannot input any information such as Ingestion even though the kafkasetup job was successful. 
```
Caused by: io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException: Unauthorized; error code: 401
```
So I think It is confused, so I think it should be written into the default values. Thanks!