### PR TITLE
Fix OIDC username claim not overridable for azure

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.19
+version: 0.3.20
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.12.1
@@ -14,7 +14,7 @@ dependencies:
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.2.151
+    version: 0.2.152
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.151
+version: 0.2.152
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.11.0

--- a/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
@@ -220,15 +220,15 @@ spec:
             {{- end }}
             - name: AUTH_OIDC_BASE_URL
               value: https://{{ (first $.Values.ingress.hosts).host }}
+            - name: AUTH_OIDC_USER_NAME_CLAIM
+              value: {{ .user_name_claim | default "email" }}
+            - name: AUTH_OIDC_USER_NAME_CLAIM_REGEX
+              value: {{ .user_name_claim_regex | default "([^@]+)" }}
             {{- if eq .provider "google" }}
             - name: AUTH_OIDC_DISCOVERY_URI
               value: https://accounts.google.com/.well-known/openid-configuration
             - name: AUTH_OIDC_SCOPE
               value: {{ .scope | default "openid profile email" }}
-            - name: AUTH_OIDC_USER_NAME_CLAIM
-              value: {{ .user_name_claim | default "email" }}
-            - name: AUTH_OIDC_USER_NAME_CLAIM_REGEX
-              value: {{ .user_name_claim_regex | default "([^@]+)" }}
             {{- else if eq .provider "okta" }}
             - name: AUTH_OIDC_DISCOVERY_URI
               value: https://{{ .oktaDomain }}/.well-known/openid-configuration


### PR DESCRIPTION
Fix Issue https://github.com/acryldata/datahub-helm/issues/414 where only google OIDC Username claim and regexp were overridable. This was incorrect, and should have never been the case, this is especially important for azure since some Entra ID deployments do not specify email addresses in the OIDC token.



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
