### PR TITLE
Allow nodeSelector and tolerations to be applied to all components globally

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,33 +4,33 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.22
+version: 0.3.23
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.12.1
 dependencies:
   - name: datahub-gms
-    version: 0.2.161
+    version: 0.2.162
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.2.153
+    version: 0.2.154
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer
-    version: 0.2.155
+    version: 0.2.156
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.2.157
+    version: 0.2.158
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron
-    version: 0.2.138
+    version: 0.2.139
     repository: file://./subcharts/datahub-ingestion-cron
     condition: datahub-ingestion-cron.enabled
   - name: acryl-datahub-actions
-    version: 0.2.142
+    version: 0.2.143
     repository: file://./subcharts/acryl-datahub-actions
     condition: acryl-datahub-actions.enabled
 maintainers:

--- a/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.142
+version: 0.2.143
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.0.11

--- a/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
@@ -172,7 +172,7 @@ spec:
         {{- with .Values.extraSidecars }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with default .Values.global.nodeSelector .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -180,7 +180,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with default .Values.global.tolerations .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.153
+version: 0.2.154
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.11.0

--- a/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
@@ -265,7 +265,7 @@ spec:
         {{- with .Values.extraSidecars }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with default .Values.global.nodeSelector .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -273,7 +273,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with default .Values.global.tolerations .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for LinkedIn DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.161
+version: 0.2.162
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.11.0

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -402,7 +402,7 @@ spec:
         {{- with .Values.extraSidecars }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with default .Values.global.nodeSelector .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -410,7 +410,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with default .Values.global.tolerations .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/datahub/subcharts/datahub-ingestion-cron/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.138
+version: 0.2.139
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.11.0

--- a/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
@@ -75,17 +75,17 @@ spec:
               {{- toYaml .extraSidecars | nindent 10 }}
             {{- end }}
           restartPolicy: {{ default "OnFailure" .restartPolicy }}
-          {{- if .nodeSelector }}
+          {{- with default .Values.global.nodeSelector .nodeSelector }}
           nodeSelector:
-            {{- toYaml .nodeSelector | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .affinity }}
           affinity:
             {{- toYaml .affinity | nindent 12 }}
           {{- end }}
-          {{- if .tolerations }}
+          {{- with default .Values.global.tolerations .tolerations }}
           tolerations:
-            {{- toYaml .tolerations | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           volumes:
             - name: recipe

--- a/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.155
+version: 0.2.156
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.11.0

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -273,7 +273,7 @@ spec:
         {{- with .Values.extraSidecars }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with default .Values.global.nodeSelector .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -281,7 +281,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with default .Values.global.tolerations .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.157
+version: 0.2.158
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.11.0

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
@@ -286,7 +286,7 @@ spec:
         {{- with .Values.extraSidecars }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with default .Values.global.nodeSelector .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -294,7 +294,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with default .Values.global.tolerations .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-cleanup-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-cleanup-job-template.yml
@@ -82,7 +82,7 @@ spec:
             {{- with .Values.datahubUpgrade.cleanupJob.extraSidecars }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with .Values.datahubUpgrade.nodeSelector }}
+          {{- with default .Values.global.nodeSelector .Values.datahubUpgrade.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -90,7 +90,7 @@ spec:
           affinity:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.datahubUpgrade.tolerations }}
+          {{- with default .Values.global.tolerations .Values.datahubUpgrade.tolerations }}
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-nocode-migration-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-nocode-migration-job.yml
@@ -100,7 +100,7 @@ spec:
         {{- with .Values.datahubUpgrade.extraSidecars }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.datahubUpgrade.nodeSelector }}
+      {{- with default .Values.global.nodeSelector .Values.datahubUpgrade.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 12 }}
       {{- end }}
@@ -108,7 +108,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 12 }}
       {{- end }}
-      {{- with .Values.datahubUpgrade.tolerations }}
+      {{- with default .Values.global.tolerations .Values.datahubUpgrade.tolerations }}
       tolerations:
         {{- toYaml . | nindent 12 }}
       {{- end }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
@@ -98,7 +98,7 @@ spec:
             {{- with .Values.datahubUpgrade.restoreIndices.extraSidecars }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with .Values.datahubUpgrade.nodeSelector }}
+          {{- with default .Values.global.nodeSelector .Values.datahubUpgrade.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -106,7 +106,7 @@ spec:
           affinity:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.datahubUpgrade.tolerations }}
+          {{- with default .Values.global.tolerations .Values.datahubUpgrade.tolerations }}
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
@@ -130,7 +130,7 @@ spec:
         {{- with .Values.datahubSystemUpdate.extraSidecars }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.datahubSystemUpdate.nodeSelector }}
+      {{- with default .Values.global.nodeSelector .Values.datahubSystemUpdate.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 12 }}
       {{- end }}
@@ -138,7 +138,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 12 }}
       {{- end }}
-      {{- with .Values.datahubSystemUpdate.tolerations }}
+      {{- with default .Values.global.tolerations .Values.datahubSystemUpdate.tolerations }}
       tolerations:
         {{- toYaml . | nindent 12 }}
       {{- end }}

--- a/charts/datahub/templates/elasticsearch-setup-job.yml
+++ b/charts/datahub/templates/elasticsearch-setup-job.yml
@@ -97,7 +97,7 @@ spec:
         {{- with .Values.elasticsearchSetupJob.extraSidecars }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.elasticsearchSetupJob.nodeSelector }}
+      {{- with default .Values.global.nodeSelector .Values.elasticsearchSetupJob.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -105,7 +105,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.elasticsearchSetupJob.tolerations }}
+      {{- with default .Values.global.tolerations .Values.elasticsearchSetupJob.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/datahub/templates/kafka-setup-job.yml
+++ b/charts/datahub/templates/kafka-setup-job.yml
@@ -136,7 +136,7 @@ spec:
         {{- with .Values.kafkaSetupJob.extraSidecars }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.kafkaSetupJob.nodeSelector }}
+      {{- with default .Values.global.nodeSelector .Values.kafkaSetupJob.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -144,7 +144,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.kafkaSetupJob.tolerations }}
+      {{- with default .Values.global.tolerations .Values.kafkaSetupJob.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/datahub/templates/mysql-setup-job.yml
+++ b/charts/datahub/templates/mysql-setup-job.yml
@@ -90,7 +90,7 @@ spec:
         {{- with .Values.mysqlSetupJob.extraSidecars }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.mysqlSetupJob.nodeSelector }}
+      {{- with default .Values.global.nodeSelector .Values.mysqlSetupJob.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -98,7 +98,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.mysqlSetupJob.tolerations }}
+      {{- with default .Values.global.tolerations .Values.mysqlSetupJob.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/datahub/templates/postgresql-setup-job.yml
+++ b/charts/datahub/templates/postgresql-setup-job.yml
@@ -90,7 +90,7 @@ spec:
         {{- with .Values.postgresqlSetupJob.extraSidecars }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.postgresqlSetupJob.nodeSelector }}
+      {{- with default .Values.global.nodeSelector .Values.postgresqlSetupJob.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -98,7 +98,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.postgresqlSetupJob.tolerations }}
+      {{- with default .Values.global.tolerations .Values.postgresqlSetupJob.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
Allow `nodeSelector` and `tolerations` to be applied to all Datahub components globally. Any global defaults can be overridden on each subchart individually.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
