### PR TITLE
Bump kafka chart to 26.11.2 that uses kafka 3.6.1

### DIFF
--- a/charts/prerequisites/Chart.yaml
+++ b/charts/prerequisites/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for packages that Datahub depends on
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.7
+version: 0.1.8
 dependencies:
   - name: elasticsearch
     version: 7.17.3
@@ -35,7 +35,7 @@ dependencies:
     condition: cp-helm-charts.enabled
   # This chart deploys a community version of kafka
   - name: kafka
-    version: 22.1.6
+    version: 26.11.2
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: kafka.enabled
 maintainers:

--- a/charts/prerequisites/values.yaml
+++ b/charts/prerequisites/values.yaml
@@ -1,7 +1,8 @@
 # Default configuration for pre-requisites to get you started
 # Copy this file and update to the configuration of choice
 elasticsearch:
-  enabled: true # set this to false, if you want to provide your own ES instance.
+  # set this to false, if you want to provide your own ES instance.
+  enabled: true
 
   # If you're running in production, set this to 3 and comment out antiAffinity below
   # Or alternatively if you're running production, bring your own ElasticSearch
@@ -117,7 +118,8 @@ cp-helm-charts:
   cp-schema-registry:
     enabled: false
     kafka:
-      bootstrapServers: "prerequisites-kafka:9092" # <<release-name>>-kafka:9092
+      # <<release-name>>-kafka:9092
+      bootstrapServers: "prerequisites-kafka:9092"
   cp-kafka:
     enabled: false
   cp-zookeeper:

--- a/charts/prerequisites/values.yaml
+++ b/charts/prerequisites/values.yaml
@@ -145,6 +145,9 @@ kafka:
     replicaCount: 0
   broker:
     replicaCount: 1
+    # The new minId for broker is 100. If we don't override this, the broker will have id 100
+    # and cannot load the partitions. So we set minId to 0 to be backwards compatible
+    minId: 0
     # These server properties are no longer exposed as parameters in the bitnami kafka chart since 24.0.0
     # They need to be passed in through extraConfig. See below for reference
     # https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-2400

--- a/charts/prerequisites/values.yaml
+++ b/charts/prerequisites/values.yaml
@@ -1,7 +1,7 @@
 # Default configuration for pre-requisites to get you started
 # Copy this file and update to the configuration of choice
 elasticsearch:
-  enabled: true   # set this to false, if you want to provide your own ES instance.
+  enabled: true # set this to false, if you want to provide your own ES instance.
 
   # If you're running in production, set this to 3 and comment out antiAffinity below
   # Or alternatively if you're running production, bring your own ElasticSearch
@@ -103,13 +103,13 @@ gcloud-sqlproxy:
     # use port 3306 for MySQL, or other port you set for your SQL instance.
     instances:
       # GCP Cloud SQL instance id
-    - instance: ""
-      # GCP project where the instance exists.
-      project: ""
-      # GCP region where the instance exists.
-      region: ""
-      # Port number for the proxy to expose for this instance.
-      port: 3306
+      - instance: ""
+        # GCP project where the instance exists.
+        project: ""
+        # GCP region where the instance exists.
+        region: ""
+        # Port number for the proxy to expose for this instance.
+        port: 3306
 
 cp-helm-charts:
   enabled: false
@@ -117,7 +117,7 @@ cp-helm-charts:
   cp-schema-registry:
     enabled: false
     kafka:
-      bootstrapServers: "prerequisites-kafka:9092"  # <<release-name>>-kafka:9092
+      bootstrapServers: "prerequisites-kafka:9092" # <<release-name>>-kafka:9092
   cp-kafka:
     enabled: false
   cp-zookeeper:
@@ -134,7 +134,23 @@ cp-helm-charts:
 # Bitnami version of Kafka that deploys open source Kafka https://artifacthub.io/packages/helm/bitnami/kafka
 kafka:
   enabled: true
-  maxMessageBytes: "5242880"
+  listeners:
+    client:
+      protocol: PLAINTEXT
+    interbroker:
+      protocol: PLAINTEXT
+  controller:
+    replicaCount: 0
+  broker:
+    replicaCount: 1
+    # These server properties are no longer exposed as parameters in the bitnami kafka chart since 24.0.0
+    # They need to be passed in through extraConfig. See below for reference
+    # https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-2400
+    extraConfig: |
+      message.max.bytes=5242880
+      default.replication.factor=1
+      offsets.topic.replication.factor=1
+      transaction.state.log.replication.factor=1
   kraft:
     enabled: false
   zookeeper:


### PR DESCRIPTION
Most of the changes address the major change to the Kafka chart in `24.0.0`. See below for reference.
https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-2400

1. The chart now has two statefulsets and their settings fall under the `controller` and `broker` section respectively. 
2. The default `replicaCount` for `controller` is `1` and for `broker` is `0`. So we need to override them
3. The default protocol for client and inter broker listeners are both `SASL_PLAINTEXT`. So we need to override them to `PLAINTEXT` to be backward compatible
4. Many of the server properties are no longer exposed as chart parameters and need to be passed in via the `extraConfig` parameter.

Testing: 
1. Deployed a brand new install of prerequisites and datahub chart in a GKE cluster. All components started successfully and execution of an ingestion also succeeded.
2. Upgraded an existing cluster that was running datahub `0.12.0` and prerequisites chart `0.1.4`. Afterwards, all components started successfully. Note that both GMS and datahub-actions pods need to be restarted so that they can connect to the correct kafka headless endpoints.