### PR TITLE
docs: Updated mysql secret generation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ separately on-prem or leveraged as managed services.
 Assuming kubectl context points to the correct kubernetes cluster, first create kubernetes secrets that contain MySQL and Neo4j passwords. 
 
 ```(shell)
-kubectl create secret generic mysql-secrets --from-literal=mysql-root-password=datahub \
-											--from-literal=mysql-replication-password=datahub \
-											--from-literal=mysql-password=datahub
+kubectl create secret generic mysql-secrets --from-literal=mysql-root-password=datahub --from-literal=mysql-password=datahub
 kubectl create secret generic neo4j-secrets --from-literal=neo4j-password=datahub --from-literal=NEO4J_AUTH=neo4j/datahub
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ separately on-prem or leveraged as managed services.
 Assuming kubectl context points to the correct kubernetes cluster, first create kubernetes secrets that contain MySQL and Neo4j passwords. 
 
 ```(shell)
-kubectl create secret generic mysql-secrets --from-literal=mysql-root-password=datahub
+kubectl create secret generic mysql-secrets --from-literal=mysql-root-password=datahub \
+											--from-literal=mysql-replication-password=datahub \
+											--from-literal=mysql-password=datahub
 kubectl create secret generic neo4j-secrets --from-literal=neo4j-password=datahub --from-literal=NEO4J_AUTH=neo4j/datahub
 ```
 


### PR DESCRIPTION
By the change of mysql helm chart version the provided secret must contain at least three keys:
- mysql-root-password
- mysql-replication-password
- mysql-password

Otherwise mysql chart won't install.
More information: https://artifacthub.io/packages/helm/bitnami/mysql#mysql-common-parameters



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
