### PR TITLE
fix(mysql): downgrade mysql chart to 9.4.9

### DIFF
--- a/charts/prerequisites/Chart.yaml
+++ b/charts/prerequisites/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for packages that Datahub depends on
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.9
+version: 0.1.10
 dependencies:
   - name: elasticsearch
     version: 7.17.3
@@ -16,7 +16,7 @@ dependencies:
     repository: https://helm.neo4j.com/neo4j
     condition: neo4j.enabled
   - name: mysql
-    version: 9.23.0
+    version: 9.4.9
     repository: https://charts.bitnami.com/bitnami
     condition: mysql.enabled
   - name: postgresql


### PR DESCRIPTION
Newer versions of the mysql chart require the `mysql-password` key to exist in the existing secret. In order to allow for a transition period (and update existing documentation), this rollbacks the version before the breaking change in the mysql chart.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
