### PR TITLE
feat(restoreIndices): configurable crontab schedule

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.4.9
+version: 0.4.10
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.13.2

--- a/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
@@ -10,7 +10,7 @@ metadata:
   labels:
     {{- include "datahub.labels" . | nindent 4 }}
 spec:
-  schedule: "* * * * *"
+  schedule: {{ .Values.datahubUpgrade.restoreIndices.schedule | default "0 0 * * 0" }}
   suspend: true
   concurrencyPolicy: {{ .Values.datahubUpgrade.restoreIndices.concurrencyPolicy | default "Allow" }}
   jobTemplate:

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -335,6 +335,8 @@ datahubUpgrade:
       requests:
         cpu: 300m
         memory: 256Mi
+    # Schedule of CronJob when enabled
+    schedule: "0 0 * * 0"
     # Add the concurrency Policy flexibility via values
     concurrencyPolicy: Allow
     # Add extra sidecar containers to job pod


### PR DESCRIPTION
* and set the default schedule to once per week on Sunday

Issue with the previous schedule `* * * * *` is that one pod gets started every minute when the job execution is triggered via the command in the [restore indices doc](https://datahubproject.io/docs/how/restore-indices/#kubernetes):
```bash
kubectl create job --from=cronjob/datahub-datahub-restore-indices-job-template datahub-restore-indices-adhoc
```

When the pod takes longer to run, more pods are started and continue to pile up in greater amount, causing resource issues in Kafka and in the Kubernetes cluster.


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- ~~[] Links to related issues (if applicable)~~
- ~~[] Tests for the changes have been added/updated (if applicable)~~
- [x] Docs related to the changes have been added/updated (if applicable)
