### PR TITLE
feat: add configuration option to enable REST API authorizations

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,33 +4,33 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.4.26
+version: 0.4.27
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.14.1
 dependencies:
   - name: datahub-gms
-    version: 0.2.172
+    version: 0.2.173
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.2.159
+    version: 0.2.160
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer
-    version: 0.2.161
+    version: 0.2.162
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.2.163
+    version: 0.2.164
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron
-    version: 0.2.145
+    version: 0.2.146
     repository: file://./subcharts/datahub-ingestion-cron
     condition: datahub-ingestion-cron.enabled
   - name: acryl-datahub-actions
-    version: 0.2.147
+    version: 0.2.148
     repository: file://./subcharts/acryl-datahub-actions
     condition: acryl-datahub-actions.enabled
 maintainers:

--- a/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.147
+version: 0.2.148
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.0.11
+appVersion: 0.1.1

--- a/charts/datahub/subcharts/acryl-datahub-actions/values.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 
 image:
   repository: acryldata/datahub-actions
-  tag: "v0.0.1"
+  tag: "v0.1.1"
   pullPolicy: IfNotPresent
   # Override the image's command & args with a new one.
   # This may be necessary for custom startup or shutdown behaviors

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.159
+version: 0.2.160
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.13.1

--- a/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
@@ -185,7 +185,7 @@ spec:
             {{- end }}
             {{- if .Values.global.kafka.topics }}
             - name: DATAHUB_TRACKING_TOPIC
-              value: {{ .Values.global.kafka.topics.datahub_usage_event_name}}
+              value: {{ .Values.global.kafka.topics.datahub_usage_event_name }}
             {{- else }}
             - name: DATAHUB_TRACKING_TOPIC
               value: "DataHubUsageEvent_v1"
@@ -200,6 +200,9 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretRef }}
                   key: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretKey }}
+            {{- else }}
+            - name: METADATA_SERVICE_AUTH_ENABLED
+              value: "false"
             {{- end }}
             - name: AUTH_SESSION_TTL_HOURS
               value: {{ .Values.auth.sessionTTLHours | quote }}

--- a/charts/datahub/subcharts/datahub-frontend/values.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/values.yaml
@@ -161,9 +161,6 @@ tolerations: []
 
 affinity: {}
 
-env:
-  JMXPORT: 1099
-
 livenessProbe:
   initialDelaySeconds: 60
   periodSeconds: 30

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.172
+version: 0.2.173
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: v0.13.1
+appVersion: v0.14.1

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -87,11 +87,11 @@ spec:
               containerPort: 4318
               protocol: TCP
           {{- end }}
-          {{- if gt .Values.replicaCount 1.0}}
+          {{- if gt .Values.replicaCount 1.0 }}
             - name: hazelcast
               containerPort: 5701
               protocol: TCP
-          {{- end}}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /health
@@ -118,13 +118,16 @@ spec:
               value: "true"
             - name: ELASTICSEARCH_QUERY_CUSTOM_CONFIG_FILE
               value: "/datahub/datahub-gms/resources/search/search_config.yml"
-            {{- end}}
-            {{- if gt .Values.replicaCount 1.0}}
+            {{- else }}
+            - name: ELASTICSEARCH_QUERY_CUSTOM_CONFIG_ENABLED
+              value: "false"
+            {{- end }}
+            {{- if gt .Values.replicaCount 1.0 }}
             - name: SEARCH_SERVICE_CACHE_IMPLEMENTATION
               value: "hazelcast"
             - name: SEARCH_SERVICE_HAZELCAST_SERVICE_NAME
               value: {{ printf "%s-%s-%s" .Release.Name (regexReplaceAll "[^-a-z0-9]+" .Values.global.datahub.version "-") "hazelcast-svc" | trunc 63 | trimSuffix "-" }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.global.datahub.systemUpdate.enabled }}
             - name: DATAHUB_UPGRADE_HISTORY_KAFKA_CONSUMER_GROUP_ID
               value: {{ printf "%s-%s" .Release.Name "duhe-consumer-job-client-gms" }}
@@ -179,7 +182,7 @@ spec:
             - name: KAFKA_PRODUCER_COMPRESSION_TYPE
               value: "{{ . }}"
             {{- end }}
-            {{- with .Values.global.kafka.consumer.stopContainerOnDeserializationError}}
+            {{- with .Values.global.kafka.consumer.stopContainerOnDeserializationError }}
             - name: KAFKA_CONSUMER_STOP_ON_DESERIALIZATION_ERROR
               value: "{{ . }}"
             {{- end }}
@@ -311,14 +314,17 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretRef }}
                   key: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretKey }}
+            - name: REST_API_AUTHORIZATION_ENABLED
+              value: {{ .Values.global.datahub.metadata_service_authentication.restApi.authorization.enabled | quote }}
             {{- if .Values.global.datahub.metadata_service_authentication.view.authorization.enabled }}
             - name: VIEW_AUTHORIZATION_ENABLED
               value: "true"
-            {{- if .Values.global.datahub.metadata_service_authentication.view.authorization.recommendations.peerGroupEnabled }}
             - name: VIEW_AUTHORIZATION_RECOMMENDATIONS_PEER_GROUP_ENABLED
-              value: "true"
+              value: {{ .Values.global.datahub.metadata_service_authentication.view.authorization.recommendations.peerGroupEnabled | quote }}
             {{- end }}
-            {{- end }}
+            {{- else }}
+            - name: METADATA_SERVICE_AUTH_ENABLED
+              value: "false"
             {{- end }}
             {{- if .Values.global.datahub.managed_ingestion.enabled }}
             - name: UI_INGESTION_ENABLED
@@ -336,10 +342,8 @@ spec:
             - name: UI_INGESTION_DEFAULT_CLI_VERSION
               value: "{{ .Values.global.datahub.managed_ingestion.defaultCliVersion }}"
             {{- end }}
-            {{- if .Values.global.datahub.enable_retention }}
             - name: ENTITY_SERVICE_ENABLE_RETENTION
-              value: "true"
-            {{- end }}
+              value: {{ .Values.global.datahub.enable_retention | quote }}
             - name: ELASTICSEARCH_QUERY_MAX_TERM_BUCKET_SIZE
               value: {{ .Values.global.elasticsearch.search.maxTermBucketSize | quote }}
             - name: ELASTICSEARCH_QUERY_EXACT_MATCH_EXCLUSIVE
@@ -399,7 +403,7 @@ spec:
             {{- end }}
             {{- if .versioned.enabled }}
             - name: MCP_VERSIONED_THROTTLE_ENABLED
-              value: 'true'
+              value: "true"
             {{- with .versioned.threshold }}
             - name: MCP_VERSIONED_THRESHOLD
               value: {{ . | quote }}
@@ -423,7 +427,7 @@ spec:
             {{- end }}
             {{- if .timeseries.enabled }}
             - name: MCP_TIMESERIES_THROTTLE_ENABLED
-              value: 'true'
+              value: "true"
             {{- with .timeseries.threshold }}
             - name: MCP_TIMESERIES_THRESHOLD
               value: {{ . | quote }}

--- a/charts/datahub/subcharts/datahub-gms/templates/hazelcastService.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/hazelcastService.yaml
@@ -1,4 +1,4 @@
-{{- if gt .Values.replicaCount 1.0}}
+{{- if gt .Values.replicaCount 1.0 }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,4 +13,4 @@ spec:
   selector:
     app.kubernetes.io/name: {{- include "datahub-gms.name" . | nindent 6 }}
   type: ClusterIP
-{{- end}}
+{{- end }}

--- a/charts/datahub/subcharts/datahub-gms/values.yaml
+++ b/charts/datahub/subcharts/datahub-gms/values.yaml
@@ -34,7 +34,6 @@ serviceMonitor:
   create: false
   extraLabels: {}
 
-
 podAnnotations: {}
   # co.elastic.logs/enabled: "true"
 
@@ -231,6 +230,10 @@ global:
       # systemClientSecret:
       #  secretRef: <secret-ref>
       #  secretKey: <secret-key>
+      restApi:
+        authorization:
+          # enables authorization of reads, writes, and deletes on REST APIs
+          enabled: true
       view:
         authorization:
           # search/view authorization filters

--- a/charts/datahub/subcharts/datahub-ingestion-cron/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.145
+version: 0.2.146
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: v0.13.1
+appVersion: v0.14.1

--- a/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
@@ -8,7 +8,7 @@ metadata:
   name: "{{ $baseName }}-{{ $jobName }}"
   labels: {{- $labels | nindent 4 }}
 spec:
-  schedule: {{ default "0 0 * * *" .schedule | quote}}
+  schedule: {{ default "0 0 * * *" .schedule | quote }}
   concurrencyPolicy: {{ default "Allow" .concurrencyPolicy }}
   successfulJobsHistoryLimit: {{ default 3 .successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ default 1 .failedJobsHistoryLimit }}
@@ -50,7 +50,7 @@ spec:
             {{- if .extraVolumeMounts }}
               {{- toYaml .extraVolumeMounts | nindent 14 }}
             {{- end }}
-            command: ["/bin/sh", "-c", {{ default $defaultCommand .command }} ]
+            command: ["/bin/sh", "-c", {{ default $defaultCommand .command }}]
             {{- if .securityContext }}
             securityContext:
               {{- toYaml .securityContext | nindent 14 }}
@@ -58,17 +58,17 @@ spec:
             env:
               {{- if .env }}
               {{- range $key,$value := .env }}
-              - name: {{ $key | quote}}
-                value: {{ $value | quote}}
+              - name: {{ $key | quote }}
+                value: {{ $value | quote }}
               {{- end }}
               {{- end }}
               {{- if .envFromSecrets }}
               {{- range $key,$value := .envFromSecrets }}
-              - name: {{ $key | quote}}
+              - name: {{ $key | quote }}
                 valueFrom:
                   secretKeyRef:
-                    name: {{ $value.secret | quote}}
-                    key: {{ $value.key | quote}}
+                    name: {{ $value.secret | quote }}
+                    key: {{ $value.key | quote }}
               {{- end }}
               {{- end }}
             {{- if .extraSidecars }}

--- a/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.161
+version: 0.2.162
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: v0.13.1
+appVersion: v0.14.1

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -212,6 +212,9 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretRef }}
                   key: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretKey }}
+            {{- else }}
+            - name: METADATA_SERVICE_AUTH_ENABLED
+              value: "false"
             {{- end }}
             {{- if .Values.global.datahub.managed_ingestion.enabled }}
             - name: UI_INGESTION_ENABLED

--- a/charts/datahub/subcharts/datahub-mae-consumer/values.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/values.yaml
@@ -120,9 +120,6 @@ tolerations: []
 
 affinity: {}
 
-env:
-  JMXPORT: 1099
-
 livenessProbe:
   initialDelaySeconds: 60
   periodSeconds: 30

--- a/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.163
+version: 0.2.164
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: v0.13.1
+appVersion: v0.14.1

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
@@ -234,6 +234,9 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretRef }}
                   key: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretKey }}
+            {{- else }}
+            - name: METADATA_SERVICE_AUTH_ENABLED
+              value: "false"
             {{- end }}
             {{- if .Values.global.springKafkaConfigurationOverrides }}
             {{- range $configName, $configValue := .Values.global.springKafkaConfigurationOverrides }}
@@ -277,7 +280,7 @@ spec:
             {{- end }}
             {{- if .versioned.enabled }}
             - name: MCP_VERSIONED_THROTTLE_ENABLED
-              value: 'true'
+              value: "true"
             {{- with .versioned.threshold }}
             - name: MCP_VERSIONED_THRESHOLD
               value: {{ . | quote }}
@@ -301,7 +304,7 @@ spec:
             {{- end }}
             {{- if .timeseries.enabled }}
             - name: MCP_TIMESERIES_THROTTLE_ENABLED
-              value: 'true'
+              value: "true"
             {{- with .timeseries.threshold }}
             - name: MCP_TIMESERIES_THRESHOLD
               value: {{ . | quote }}

--- a/charts/datahub/subcharts/datahub-mce-consumer/values.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/values.yaml
@@ -121,9 +121,6 @@ tolerations: []
 
 affinity: {}
 
-env:
-  JMXPORT: 1099
-
 livenessProbe:
   initialDelaySeconds: 60
   periodSeconds: 30

--- a/charts/datahub/templates/datahub-upgrade/datahub-cleanup-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-cleanup-job-template.yml
@@ -65,7 +65,7 @@ spec:
               args: [ "-u", "NoCodeDataMigrationCleanup" ]
               {{- end }}
               env:
-                {{- include "datahub.upgrade.env" . | nindent 16}}
+                {{- include "datahub.upgrade.env" . | nindent 16 }}
                 {{- if .Values.global.datahub.metadata_service_authentication.enabled }}
                 - name: DATAHUB_SYSTEM_CLIENT_ID
                   value: {{ .Values.global.datahub.metadata_service_authentication.systemClientId }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-nocode-migration-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-nocode-migration-job.yml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 spec:
   template:
-    {{- if or .Values.global.podLabels .Values.datahubUpgrade.podAnnotations}}
+    {{- if or .Values.global.podLabels .Values.datahubUpgrade.podAnnotations }}
     metadata:
     {{- with .Values.datahubUpgrade.podAnnotations }}
       annotations:
@@ -44,7 +44,7 @@ spec:
             secretName: {{ .name }}
         {{- end }}
       {{- with .Values.datahubUpgrade.extraVolumes }}
-        {{- toYaml . | nindent 8}}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: Never
       securityContext:
@@ -74,7 +74,7 @@ spec:
             - "dbType={{ .Values.datahubUpgrade.noCodeDataMigration.sqlDbType }}"
           {{- end }}
           env:
-            {{- include "datahub.upgrade.env" . | nindent 12}}
+            {{- include "datahub.upgrade.env" . | nindent 12 }}
             {{- if .Values.global.datahub.metadata_service_authentication.enabled }}
             - name: DATAHUB_SYSTEM_CLIENT_ID
               value: {{ .Values.global.datahub.metadata_service_authentication.systemClientId }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
@@ -77,7 +77,7 @@ spec:
                 - "batchDelayMs={{ .Values.datahubUpgrade.batchDelayMs }}"
               {{- end }}
               env:
-                {{- include "datahub.upgrade.env" . | nindent 16}}
+                {{- include "datahub.upgrade.env" . | nindent 16 }}
                 {{- if .Values.global.datahub.metadata_service_authentication.enabled }}
                 - name: DATAHUB_SYSTEM_CLIENT_ID
                   value: {{ .Values.global.datahub.metadata_service_authentication.systemClientId }}
@@ -101,7 +101,7 @@ spec:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
               resources:
-                {{- toYaml .Values.datahubUpgrade.restoreIndices.resources | nindent 16}}
+                {{- toYaml .Values.datahubUpgrade.restoreIndices.resources | nindent 16 }}
             {{- with .Values.datahubUpgrade.restoreIndices.extraSidecars }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 spec:
   template:
-    {{- if or .Values.global.podLabels .Values.datahubSystemUpdate.podAnnotations}}
+    {{- if or .Values.global.podLabels .Values.datahubSystemUpdate.podAnnotations }}
     metadata:
     {{- with .Values.datahubSystemUpdate.podAnnotations }}
       annotations:
@@ -44,7 +44,7 @@ spec:
             secretName: {{ .name }}
         {{- end }}
       {{- with .Values.datahubSystemUpdate.extraVolumes }}
-        {{- toYaml . | nindent 8}}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: Never
       securityContext:
@@ -75,7 +75,7 @@ spec:
           env:
             - name: DATAHUB_REVISION
               value: {{ .Release.Revision | quote }}
-            {{- include "datahub.upgrade.env" . | nindent 12}}
+            {{- include "datahub.upgrade.env" . | nindent 12 }}
             - name: DATAHUB_ANALYTICS_ENABLED
               value: {{ .Values.global.datahub_analytics_enabled | quote }}
             {{- if eq .Values.global.kafka.schemaregistry.type "INTERNAL" }}
@@ -178,7 +178,7 @@ metadata:
   {{- end }}
 spec:
   template:
-    {{- if or .Values.global.podLabels .Values.datahubSystemUpdate.podAnnotations}}
+    {{- if or .Values.global.podLabels .Values.datahubSystemUpdate.podAnnotations }}
     metadata:
     {{- with .Values.datahubSystemUpdate.podAnnotations }}
       annotations:
@@ -211,7 +211,7 @@ spec:
             secretName: {{ .name }}
         {{- end }}
       {{- with .Values.datahubSystemUpdate.extraVolumes }}
-        {{- toYaml . | nindent 8}}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: Never
       securityContext:
@@ -237,7 +237,7 @@ spec:
           env:
             - name: DATAHUB_REVISION
               value: {{ .Release.Revision | quote }}
-            {{- include "datahub.upgrade.env" . | nindent 12}}
+            {{- include "datahub.upgrade.env" . | nindent 12 }}
             - name: DATAHUB_ANALYTICS_ENABLED
               value: {{ .Values.global.datahub_analytics_enabled | quote }}
             {{- if eq .Values.global.kafka.schemaregistry.type "INTERNAL" }}

--- a/charts/datahub/templates/elasticsearch-setup-job.yml
+++ b/charts/datahub/templates/elasticsearch-setup-job.yml
@@ -38,7 +38,7 @@ spec:
     {{- end }}
       volumes:
       {{- with .Values.elasticsearchSetupJob.extraVolumes }}
-        {{- toYaml . | nindent 8}}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: Never
       securityContext:

--- a/charts/datahub/templates/mysql-setup-job.yml
+++ b/charts/datahub/templates/mysql-setup-job.yml
@@ -38,7 +38,7 @@ spec:
     {{- end }}
       volumes:
       {{- with .Values.mysqlSetupJob.extraVolumes }}
-        {{- toYaml . | nindent 8}}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: Never
       securityContext:

--- a/charts/datahub/templates/postgresql-setup-job.yml
+++ b/charts/datahub/templates/postgresql-setup-job.yml
@@ -38,7 +38,7 @@ spec:
     {{- end }}
       volumes:
       {{- with .Values.postgresqlSetupJob.extraVolumes }}
-        {{- toYaml . | nindent 8}}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: Never
       securityContext:


### PR DESCRIPTION
To make it a bit more transparent - I was not aware of it - that there are parts of the REST API which are not secured by default (of course you have to be authenticated, but each authenticated user is authorized by default to use these endpoints), this PR adds a new configuration option similar to the view authorization which allows to enable REST API authorizations. Technically this is already possible today using extra environment variables - the intention here is only to make it more transparent.

As the REST API authorizations were not enabled by default in the past (and are [not enabled by default](https://github.com/datahub-project/datahub/blob/6fdf2f73540a46369dd6636411ae960a6812c110/metadata-service/configuration/src/main/resources/application.yaml#L47) in the metadata-service image), the configuration option is also not enabled by default - however this might be a point which could be discussed (i.e. security first -> why should be the REST API authorization not be enabled by default?).

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
