### PR TITLE
feat(prerequisites): add optional OpenSearch chart with default configuration

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.4.16
+version: 0.4.17
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.13.2

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -148,6 +148,10 @@ elasticsearchSetupJob:
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: before-hook-creation
   podAnnotations: {}
+  # If you want to use OpenSearch instead of ElasticSearch add the USE_AWS_ELASTICSEARCH environment variable below
+  # extraEnvs:
+  #   - name: USE_AWS_ELASTICSEARCH
+  #     value: "true"
   # Add extra sidecar containers to job pod
   extraSidecars: []
     # - name: my-image-name
@@ -412,6 +416,8 @@ global:
 
   elasticsearch:
     host: "elasticsearch-master"
+    # If you want to use OpenSearch instead of ElasticSearch use different hostname below
+    # host: "opensearch-cluster-master"
     port: "9200"
     skipcheck: "false"
     insecure: "false"

--- a/charts/prerequisites/Chart.yaml
+++ b/charts/prerequisites/Chart.yaml
@@ -4,12 +4,16 @@ description: A Helm chart for packages that Datahub depends on
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.10
+version: 0.1.11
 dependencies:
   - name: elasticsearch
     version: 7.17.3
     repository: https://helm.elastic.co
     condition: elasticsearch.enabled
+  - name: opensearch
+    version: 2.18.0
+    repository: https://opensearch-project.github.io/helm-charts
+    condition: opensearch.enabled
   # This chart deploys an enterprise or community version of neo4j
   - name: neo4j
     version: 5.11.0

--- a/charts/prerequisites/values.yaml
+++ b/charts/prerequisites/values.yaml
@@ -12,13 +12,13 @@ elasticsearch:
   # a master node when deploying on a single node Minikube / Kind / etc cluster.
   antiAffinity: "soft"
 
-  # # If you are running a multi-replica cluster, comment this out
+  # If you are running a multi-replica cluster, comment this out
   clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
 
-  # # Shrink default JVM heap.
+  # Shrink default JVM heap.
   esJavaOpts: "-Xmx512m -Xms512m"
 
-  # # Allocate smaller chunks of memory per pod.
+  # Allocate smaller chunks of memory per pod.
   resources:
     requests:
       cpu: "100m"
@@ -27,13 +27,50 @@ elasticsearch:
       cpu: "1000m"
       memory: "1024M"
 
-  # # Request smaller persistent volumes.
+  # Request smaller persistent volumes.
   # volumeClaimTemplate:
   #   accessModes: ["ReadWriteOnce"]
   #   storageClassName: "standard"
   #   resources:
   #     requests:
   #       storage: 100M
+
+opensearch:
+  enabled: false
+
+  # If you're running in production, set this to false, replicas to 3 and uncomment antiAffinity below
+  # Or alternatively if you're running production, bring your own OpenSearch
+  singleNode: true
+  # replicas: 3
+  # antiAffinity: "hard"
+
+  # By default security is enabled for OpenSearch, disable it here.
+  config:
+    opensearch.yml: |
+      plugins:
+        security:
+          disabled: true
+
+  extraEnvs:
+    - name: DISABLE_INSTALL_DEMO_CONFIG
+      value: "true"
+
+  image:
+    tag: "2.11.0"
+
+  # opensearchJavaOpts: "-Xmx512M -Xms512M"
+
+  # resources:
+  #   requests:
+  #     cpu: "1000m"
+  #     memory: "100Mi"
+
+  # Request smaller persistent volumes.
+  # persistence:
+  #   storageClass: "standard"
+  #   accessModes:
+  #     - ReadWriteOnce
+  #   size: 100M
 
 # Official neo4j chart, supports both community and enterprise editions
 # see https://neo4j.com/docs/operations-manual/current/kubernetes/ for more information


### PR DESCRIPTION
As the OpenSearch client libraries are already used for some time and as there will be probably no support for Elasticsearch 8+ "soon" (see also: https://datahubspace.slack.com/archives/CV2KB471C/p1706027299777929?thread_ts=1703747966.285459&cid=CV2KB471C) it is probably time to also have the OpenSearch Helm chart as part of the prerequisites chart (at least as an optional dependency).

To have a similar configuration as Elasticsearch some default configuration is necessary (e.g. in OpenSearch security is enabled by default).

I have used the latest version for the OpenSearch chart (2.18.0), however in the default configuration the tag for the image is overwritten to version 2.11.0 - this is exactly the version which is used as part of the [Docker Compose files](https://github.com/datahub-project/datahub/blob/6fdf2f73540a46369dd6636411ae960a6812c110/docker/profiles/docker-compose.prerequisites.yml#L314) and/or the [automated tests](https://github.com/datahub-project/datahub/blob/6fdf2f73540a46369dd6636411ae960a6812c110/metadata-io/src/test/java/io/datahubproject/test/search/OpenSearchTestContainer.java#L10). This combination works, as we use it more or less productively.


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
