### PR TITLE
fix(mysql): update mysql image tag

### DIFF
--- a/charts/prerequisites/Chart.yaml
+++ b/charts/prerequisites/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for packages that Datahub depends on
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.12
+version: 0.1.13
 dependencies:
   - name: elasticsearch
     version: 7.17.3
@@ -20,7 +20,7 @@ dependencies:
     repository: https://helm.neo4j.com/neo4j
     condition: neo4j.enabled
   - name: mysql
-    version: 9.4.9
+    version: 9.4.9  # Remove image.tag from values.yaml on next upgrade
     repository: https://charts.bitnami.com/bitnami
     condition: mysql.enabled
   - name: postgresql

--- a/charts/prerequisites/values.yaml
+++ b/charts/prerequisites/values.yaml
@@ -113,6 +113,8 @@ neo4j:
 
 mysql:
   enabled: true
+  image:
+    tag: 8.0.32-debian-11-r26
   auth:
     # For better security, add mysql-secrets k8s secret with mysql-root-password, mysql-replication-password and mysql-password
     existingSecret: mysql-secrets


### PR DESCRIPTION
The default mysql image tag for the `bitnami/mysql` chart version `9.4.9` only supports `linux/amd64`. This change updates the tag to the latest [8.0.32-debian-11](https://hub.docker.com/layers/bitnami/mysql/8.0.32-debian-11-r26/images/sha256-fe61e6d10c4bbfc0c010fac1dd1d6ca808943246142efa08cc7bb07f6a928c2c?context=explore) release which additionally supports `linux/arm64`.

Fixes issue #481 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
