### PR TITLE
feat: add extradeploy

### DIFF
--- a/charts/datahub/templates/_helpers.tpl
+++ b/charts/datahub/templates/_helpers.tpl
@@ -72,3 +72,23 @@ Return the appropriate apiVersion for cronjob.
 {{- print "batch/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Renders a value that contains template perhaps with scope if the scope is present.
+Usage:
+{{ include "datahub.extradeploy.render" ( dict "value" .Values.path.to.the.Value "context" $ ) }}
+{{ include "datahub.extradeploy.render" ( dict "value" .Values.path.to.the.Value "context" $ "scope" $app ) }}
+*/}}
+{{- define "datahub.extradeploy.render" -}}
+{{- $value := typeIs "string" .value | ternary .value (.value | toYaml) }}
+{{- if contains "{{" (toJson .value) }}
+  {{- if .scope }}
+      {{- tpl (cat "{{- with $.RelativeScope -}}" $value "{{- end }}") (merge (dict "RelativeScope" .scope) .context) }}
+  {{- else }}
+    {{- tpl $value .context }}
+  {{- end }}
+{{- else }}
+    {{- $value }}
+{{- end }}
+{{- end -}}

--- a/charts/datahub/templates/extra-list.yaml
+++ b/charts/datahub/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "datahub.extradeploy.render" (dict "value" . "context" $) }}
+  {{- end }}

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -772,6 +772,9 @@ global:
         #  multiplier: 10
         #  maxIntervalMs: 30000
 
+## @param extraDeploy Extra objects to deploy (value evaluated as a template)
+##
+extraDeploy: []
 #  hostAliases:
 #    - ip: "192.168.0.104"
 #      hostnames:


### PR DESCRIPTION
By defining the list of k8s resources that users need in relation to datahub in extradeploy, such as serviceAccount, role, rolebinding, and so on.
The reason is that we want to complete the creation of the token together during the deployment of datahub and write it to a k8s secret. We started with datahub's datahubSystemUpdate to execute the relevant commands.
```
        datahubSystemUpdate:
          image:
            repository: acryldata/datahub-upgrade
            command: ["/bin/sh", "-c"]
            args:
            - |
              curl -sSLo /tmp/kubectl "http://oss-cn-hangzhou-zjy-d01-a.ops.cloud.zhejianglab.com/data-and-computing/public/dl.k8s.io/release/v1.29.1/bin/linux/amd64/kubectl" &&
              chmod u+x /tmp/kubectl &&
              mkdir -p ${HOME}/bin &&
              mv -f /tmp/kubectl ${HOME}/bin/kubectl &&
              export PATH="${PATH}:${HOME}/bin" &&
              JQ_LINK=https://github.com/stedolan/jq/releases/download/jq-1.7/jq-linux64 &&
              wget $JQ_LINK -O ${HOME}/bin/jq-linux64 &&
              chmod +x ${HOME}/bin/jq-linux64 &&
              JQ_PATH="${HOME}/bin/jq-linux64" &&
              PASSWORD=$(kubectl -n datahub get secret datahub-user-secret -o jsonpath='{.data.user\.props}' | base64 -d | cut -d: -f2-) &&
              curl -k --cookie-jar /tmp/cookie.txt 'http://datahub-datahub-frontend:9002/logIn' \
                -H 'content-type: application/json' \
                --data-raw "{\"username\":\"datahub\",\"password\":\"$PASSWORD\"}" &&
              ACCESS_TOKEN=$(curl -k --cookie /tmp/cookie.txt -X POST 'http://datahub-datahub-frontend:9002/api/graphql' \
                --header 'X-DataHub-Actor: urn:li:corpuser:datahub' \
                --header 'Content-Type: application/json' \
                --data-raw '{ "query":"mutation { createAccessToken(input: { type: PERSONAL, actorUrn: \"urn:li:corpuser:datahub\", duration:NO_EXPIRY,name: \"my personal token2\" } ) { accessToken metadata { id name description} } }", "variables":{}}' | "$JQ_PATH" -r '.data.createAccessToken.accessToken') &&
              kubectl create secret generic datahub-access-token \
                --from-literal=access-token="$ACCESS_TOKEN" \
                -n datahub
          annotaions:
              helm.sh/hook: post-install
          serviceAccount:
            datahub-system-update
```
But the serviceAccount (here is 'datahub-system-update',as well as role and rolebinding) needed to execute the relevant kubectl commands needed to be created in advance of deploying datahub. 
We want these k8s objects to be configured and installed together with datahub in a values.yaml, so we use the extrdeploy function to install the required serviceAccount, role, rolebinding together.
```
extraDeploy:
  - |
    apiVersion: v1
    kind: ServiceAccount
    metadata:
      name: datahub-system-update
      namespace: datahub
  - |
    apiVersion: rbac.authorization.k8s.io/v1
    kind: Role
    metadata:
      name: secret-manager-role
      namespace: datahub
    rules:
    - apiGroups: [""]
      resources: ["secrets"]
      verbs: ["get","list", "create"]
  - |
    apiVersion: rbac.authorization.k8s.io/v1
    kind: RoleBinding
    metadata:
      name: secret-manager-rolebinding
      namespace: datahub
    subjects:
    - kind: ServiceAccount
      name: datahub-system-update       
      namespace: datahub
    roleRef:
      kind: Role
      name: secret-manager-role
      apiGroup: rbac.authorization.k8s.io
```
## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
