### PR TITLE
chore: add the relabeling action

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -10,19 +10,19 @@ version: 0.4.25
 appVersion: 0.14.0.2
 dependencies:
   - name: datahub-gms
-    version: 0.2.172
+    version: 0.2.173
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.2.159
+    version: 0.2.160
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer
-    version: 0.2.161
+    version: 0.2.162
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.2.163
+    version: 0.2.164
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.159
+version: 0.2.160
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.13.1

--- a/charts/datahub/subcharts/datahub-frontend/templates/servicemonitor.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/servicemonitor.yaml
@@ -16,7 +16,8 @@ spec:
   endpoints:
   - port: {{ .Values.global.datahub.monitoring.portName }}
     relabelings:
-    - separator: /
+    - action: replace
+      separator: /
       sourceLabels:
       - namespace
       - pod

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.172
+version: 0.2.173
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.13.1

--- a/charts/datahub/subcharts/datahub-gms/templates/servicemonitor.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/servicemonitor.yaml
@@ -16,7 +16,8 @@ spec:
   endpoints:
   - port: {{ .Values.global.datahub.monitoring.portName }}
     relabelings:
-    - separator: /
+    - action: replace
+      separator: /
       sourceLabels:
       - namespace
       - pod

--- a/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.161
+version: 0.2.162
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.13.1

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/servicemonitor.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/servicemonitor.yaml
@@ -16,7 +16,8 @@ spec:
   endpoints:
   - port: {{ .Values.global.datahub.monitoring.portName }}
     relabelings:
-    - separator: /
+    - action: replace
+      separator: /
       sourceLabels:
       - namespace
       - pod

--- a/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.163
+version: 0.2.164
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.13.1

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/servicemonitor.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/servicemonitor.yaml
@@ -16,7 +16,8 @@ spec:
   endpoints:
   - port: {{ .Values.global.datahub.monitoring.portName }}
     relabelings:
-    - separator: /
+    - action: replace
+      separator: /
       sourceLabels:
       - namespace
       - pod


### PR DESCRIPTION
Kubernetes automatically adds the action, which makes the application always out of sync in argocd or any tool that diffs the application state with the manifest. This commit solves this issue.



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
