### PR TITLE
feat: Openshift compatibility

### DIFF
--- a/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
@@ -35,8 +35,10 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "acryl-datahub-actions.serviceAccountName" . }}
+      {{- if .Values.global.enableSecurityContext }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
       volumes:
       {{- with .Values.global.credentialsAndCertsSecrets }}
         - name: datahub-certs-dir
@@ -62,8 +64,10 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.global.enableSecurityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           image: {{ include "datahub.image" (dict "imageRegistry" .Values.global.imageRegistry "version" .Values.global.datahub.version "image" .Values.image) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
@@ -37,8 +37,10 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "datahub-frontend.serviceAccountName" . }}
+      {{- if .Values.global.enableSecurityContext }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
       volumes:
         {{- with .Values.global.credentialsAndCertsSecrets }}
         - name: datahub-certs-dir
@@ -64,8 +66,10 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.global.enableSecurityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           image: {{ include "datahub.image" (dict "imageRegistry" .Values.global.imageRegistry "version" .Values.global.datahub.version "image" .Values.image) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.image.command }}

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -42,8 +42,10 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "datahub-gms.serviceAccountName" . }}
+      {{- if .Values.global.enableSecurityContext }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
       volumes:
         {{- with .Values.global.credentialsAndCertsSecrets }}
         - name: datahub-certs-dir
@@ -68,8 +70,10 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.global.enableSecurityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           image: {{ include "datahub.image" (dict "imageRegistry" .Values.global.imageRegistry "version" .Values.global.datahub.version "image" .Values.image) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.image.command }}

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -38,8 +38,10 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "datahub-mae-consumer.serviceAccountName" . }}
+      {{- if .Values.global.enableSecurityContext }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
       volumes:
         {{- with .Values.global.credentialsAndCertsSecrets }}
         - name: datahub-certs-dir
@@ -59,8 +61,10 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.global.enableSecurityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           image: {{ include "datahub.image" (dict "imageRegistry" .Values.global.imageRegistry "version" .Values.global.datahub.version "image" .Values.image) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.image.command }}

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
@@ -42,8 +42,10 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "datahub-mce-consumer.serviceAccountName" . }}
+      {{- if .Values.global.enableSecurityContext }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
       volumes:
         {{- if .Values.global.credentialsAndCertsSecrets }}
         - name: datahub-certs-dir
@@ -63,8 +65,10 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.global.enableSecurityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           image: {{ include "datahub.image" (dict "imageRegistry" .Values.global.imageRegistry "version" .Values.global.datahub.version "image" .Values.image) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.image.command }}

--- a/charts/datahub/templates/elasticsearch-setup-job.yml
+++ b/charts/datahub/templates/elasticsearch-setup-job.yml
@@ -41,8 +41,10 @@ spec:
         {{- toYaml . | nindent 8}}
       {{- end }}
       restartPolicy: Never
+      {{- if .Values.global.enableSecurityContext }}
       securityContext:
         {{- toYaml .Values.elasticsearchSetupJob.podSecurityContext | nindent 8 }}
+      {{- end }}
       {{- with .Values.elasticsearchSetupJob.extraInitContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}
@@ -92,8 +94,10 @@ spec:
           {{- with .Values.elasticsearchSetupJob.extraEnvs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.global.enableSecurityContext }}
           securityContext:
             {{- toYaml .Values.elasticsearchSetupJob.securityContext | nindent 12 }}
+          {{- end }}
           volumeMounts:
           {{- with .Values.elasticsearchSetupJob.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}

--- a/charts/datahub/templates/kafka-setup-job.yml
+++ b/charts/datahub/templates/kafka-setup-job.yml
@@ -33,8 +33,10 @@ spec:
       serviceAccountName: {{ . }}
     {{- end }}
       restartPolicy: Never
+      {{- if .Values.global.enableSecurityContext }}
       securityContext:
         {{- toYaml .Values.kafkaSetupJob.podSecurityContext | nindent 8 }}
+      {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -129,8 +131,10 @@ spec:
           {{- with .Values.kafkaSetupJob.extraEnvs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.global.enableSecurityContext }}
           securityContext:
             {{- toYaml .Values.kafkaSetupJob.securityContext | nindent 12 }}
+          {{- end }}
           volumeMounts:
           {{- if .Values.global.credentialsAndCertsSecrets }}
             - name: datahub-certs-dir

--- a/charts/datahub/templates/mysql-setup-job.yml
+++ b/charts/datahub/templates/mysql-setup-job.yml
@@ -41,8 +41,10 @@ spec:
         {{- toYaml . | nindent 8}}
       {{- end }}
       restartPolicy: Never
+      {{- if .Values.global.enableSecurityContext }}
       securityContext:
         {{- toYaml .Values.mysqlSetupJob.podSecurityContext | nindent 8 }}
+      {{- end }}
       {{- with .Values.mysqlSetupJob.extraInitContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}
@@ -85,8 +87,10 @@ spec:
           {{- with .Values.mysqlSetupJob.extraEnvs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.global.enableSecurityContext }}
           securityContext:
             {{- toYaml .Values.mysqlSetupJob.securityContext | nindent 12 }}
+          {{- end }}
           volumeMounts:
           {{- with .Values.mysqlSetupJob.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}

--- a/charts/datahub/templates/postgresql-setup-job.yml
+++ b/charts/datahub/templates/postgresql-setup-job.yml
@@ -41,8 +41,10 @@ spec:
         {{- toYaml . | nindent 8}}
       {{- end }}
       restartPolicy: Never
+      {{- if .Values.global.enableSecurityContext }}
       securityContext:
         {{- toYaml .Values.postgresqlSetupJob.podSecurityContext | nindent 8 }}
+      {{- end }}
       {{- with .Values.postgresqlSetupJob.extraInitContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}
@@ -85,8 +87,10 @@ spec:
           {{- with .Values.postgresqlSetupJob.extraEnvs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.global.enableSecurityContext }}
           securityContext:
             {{- toYaml .Values.postgresqlSetupJob.securityContext | nindent 12 }}
+          {{- end }}
           volumeMounts:
           {{- with .Values.postgresqlSetupJob.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -409,6 +409,9 @@ datahubSystemUpdate:
   extraInitContainers: []
 
 global:
+  # Openshift needs to take over the SecurityContext
+  # With this option we can disable it in the charts to leave to Openshift
+  enableSecurityContext: true
   strict_mode: true
   graph_service_impl: elasticsearch
   datahub_analytics_enabled: true


### PR DESCRIPTION
Openshift needs to take over securityContext.

This PR creates a new value that disables security context handling by the chart.


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
