### PR TITLE
feat(ingress): make ingress pathType configurable

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.4.31
+version: 0.4.32
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.14.1

--- a/charts/datahub/subcharts/datahub-frontend/templates/ingress.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/ingress.yaml
@@ -2,6 +2,7 @@
 {{- $fullName := include "datahub-frontend.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $ingressApiVersion := include "datahub-frontend.ingress.apiVersion" . -}}
+{{- $ingressPathType := .Values.ingress.pathType -}}
 apiVersion: {{ template "datahub-frontend.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -37,7 +38,7 @@ spec:
         {{- range .redirectPaths }}
           - path: {{ .path }}
             {{- if eq $ingressApiVersion "networking.k8s.io/v1" }}
-            pathType: ImplementationSpecific
+            pathType: {{ $ingressPathType }}
             backend:
               service:
                 name: {{ .name }}
@@ -56,7 +57,7 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             {{- if eq $ingressApiVersion "networking.k8s.io/v1" }}
-            pathType: ImplementationSpecific
+            pathType: {{ $ingressPathType }}
             backend:
               service:
                 name: {{ $fullName }}

--- a/charts/datahub/subcharts/datahub-frontend/values.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/values.yaml
@@ -78,6 +78,7 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+  pathType: ImplementationSpecific
 
 auth:
   sessionTTLHours: "24"

--- a/charts/datahub/subcharts/datahub-gms/templates/ingress.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/ingress.yaml
@@ -2,6 +2,7 @@
 {{- $fullName := printf "%s-%s" .Release.Name "datahub-gms"}}
 {{- $svcPort := .Values.global.datahub.gms.port -}}
 {{- $ingressApiVersion := include "datahub-gms.ingress.apiVersion" . -}}
+{{- $ingressPathType := .Values.ingress.pathType -}}
 apiVersion: {{ template "datahub-gms.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -37,7 +38,7 @@ spec:
         {{- range .redirectPaths }}
           - path: {{ .path }}
             {{- if eq $ingressApiVersion "networking.k8s.io/v1" }}
-            pathType: ImplementationSpecific
+            pathType: {{ $ingressPathType }}
             backend:
               service:
                 name: {{ .name }}
@@ -56,7 +57,7 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             {{- if eq $ingressApiVersion "networking.k8s.io/v1" }}
-            pathType: ImplementationSpecific
+            pathType: {{ $ingressPathType }}
             backend:
               service:
                 name: {{ $fullName }}

--- a/charts/datahub/subcharts/datahub-gms/values.yaml
+++ b/charts/datahub/subcharts/datahub-gms/values.yaml
@@ -76,6 +76,7 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+  pathType: ImplementationSpecific
 
 # Extra labels for Deployment
 extraLabels: {}


### PR DESCRIPTION
k8s supports different values for `pathType` for ingresses, as [documented here](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types). Make the ingress pathType configurable for the gms and frontend charts so that users can set different values based on their ingress deployment strategy.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
