### PR TITLE
fix(mae-consumer): Fix helm syntax usage.

### DIFF
--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           env:
             - name: PRE_PROCESS_HOOKS_UI_ENABLED
-              value: { { or .Values.global.datahub.reProcessUIEventHooks (not .Values.global.datahub.preProcessHooksUIEnabled) | quote } }
+              value: {{ or .Values.global.datahub.reProcessUIEventHooks (not .Values.global.datahub.preProcessHooksUIEnabled) | quote }}
             - name: ENTITY_VERSIONING_ENABLED
               value: {{ .Values.global.datahub.entityVersioning.enabled | quote }}
             - name: SHOW_SEARCH_FILTERS_V2


### PR DESCRIPTION
<fix>[mae-consumer]: The syntax use of helm template value was wrong.

Trying to deploy the the latest datahub helm chart with our argo instance we came upon the following configuration error.



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
