### PR TITLE
fix(gms): always add METADATA_CHANGE_LOG_KAFKA_CONSUMER_GROUP_ID environment variable to to GMS

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,13 +4,13 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.13
+version: 0.5.14
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.0.0
 dependencies:
   - name: datahub-gms
-    version: 0.2.179
+    version: 0.2.180
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.179
+version: 0.2.180
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.0.0

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -304,12 +304,12 @@ spec:
             - name: DATAHUB_UPGRADE_HISTORY_KAFKA_CONSUMER_GROUP_ID
               value: {{ .Values.global.kafka.consumer_groups.datahub_upgrade_history_kafka_consumer_group_id.gms | default (printf "%s-%s" .Release.Name "duhe-consumer-job-client-gms") }}
             {{- end }}
+            - name: METADATA_CHANGE_LOG_KAFKA_CONSUMER_GROUP_ID
+              value: {{ .Values.global.kafka.consumer_groups.metadata_change_log_kafka_consumer_group_id }}
             {{- if not .Values.global.datahub_standalone_consumers_enabled }}
             {{- with .Values.global.kafka.consumer_groups }}
             - name: DATAHUB_USAGE_EVENT_KAFKA_CONSUMER_GROUP_ID
               value: {{ .datahub_usage_event_kafka_consumer_group_id }}
-            - name: METADATA_CHANGE_LOG_KAFKA_CONSUMER_GROUP_ID
-              value: {{ .metadata_change_log_kafka_consumer_group_id }}
             - name: PLATFORM_EVENT_KAFKA_CONSUMER_GROUP_ID
               value: {{ .platform_event_kafka_consumer_group_id }}
             - name: METADATA_CHANGE_EVENT_KAFKA_CONSUMER_GROUP_ID


### PR DESCRIPTION
Similar top #519, the consumer group of the MCE consumer must also be added to GMS, otherwise the Kafka throttle sensor does not work in case the consumer group was changed.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
