### PR TITLE
Allow json Validator schema use of k8s secrets for sql setupjob

### DIFF
--- a/charts/datahub/values.schema.json
+++ b/charts/datahub/values.schema.json
@@ -1994,22 +1994,110 @@
               "type": "object",
               "properties": {
                 "host": {
-                  "type": "string"
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "title": "Direct Hostname"
+                    },
+                    {
+                      "type": "object",
+                      "title": "Host from Secret",
+                      "properties": {
+                        "secretRef": {
+                          "type": "string"
+                        },
+                        "secretKey": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef",
+                        "secretKey"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
                 },
                 "hostForMysqlClient": {
-                  "type": "string"
-                },
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "title": "Direct MySQL Host"
+                    },
+                    {
+                      "type": "object",
+                      "title": "MySQL Host from Secret",
+                      "properties": {
+                        "secretRef": {
+                          "type": "string"
+                        },
+                        "secretKey": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef",
+                        "secretKey"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                },                
                 "port": {
                   "type": "string"
                 },
                 "url": {
-                  "type": "string"
-                },
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "title": "Direct URL"
+                    },
+                    {
+                      "type": "object",
+                      "title": "URL from Secret",
+                      "properties": {
+                        "secretRef": {
+                          "type": "string"
+                        },
+                        "secretKey": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef",
+                        "secretKey"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                },                
                 "driver": {
                   "type": "string"
                 },
                 "username": {
-                  "type": "string"
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "title": "Direct Username"
+                    },
+                    {
+                      "type": "object",
+                      "title": "Username from Secret",
+                      "properties": {
+                        "secretRef": {
+                          "type": "string"
+                        },
+                        "secretKey": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef",
+                        "secretKey"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
                 },
                 "password": {
                   "type": "object",


### PR DESCRIPTION
Todays helm chart templates is setup to allow fetching global.sql.datasource values from k8s secrets, but the json validator schema blocks it. This update to the json validator schema will allow fetching the values from a k8s secret.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
