### PR TITLE
fix: let username be an object in json schema

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.6.14
+version: 0.6.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/values.schema.json
+++ b/charts/datahub/values.schema.json
@@ -2009,7 +2009,26 @@
                   "type": "string"
                 },
                 "username": {
-                  "type": "string"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secretRef": {
+                          "type": "string"
+                        },
+                        "secretKey": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef",
+                        "secretKey"
+                      ]
+                    }
+                  ]
                 },
                 "password": {
                   "type": "object",


### PR DESCRIPTION
Helm chart template is already setup to allow fetching global.sql.datasource.username from k8s secrets, but the json validator schema blocks it. This update fixes json schema


stale issue: https://github.com/acryldata/datahub-helm/issues/531
partially duplicate of this stale PR: https://github.com/acryldata/datahub-helm/pull/586
readme is already okay: https://github.com/acryldata/datahub-helm/blob/de3ba01544aba58c95de7e4a611648884b9bf677/charts/datahub/README.md?plain=1#L159-L161

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
