### PR TITLE
feat(datahub-gms): add ability to specify load balancer class

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,14 +4,14 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.6.18
+version: 0.6.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.2.0
 dependencies:
   - name: datahub-gms
-    version: 0.2.186
+    version: 0.2.187
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.186
+version: 0.2.187
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.0.0

--- a/charts/datahub/subcharts/datahub-gms/templates/service.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/service.yaml
@@ -26,5 +26,8 @@ spec:
       targetPort: {{ .Values.global.datahub.monitoring.portName }}
       protocol: TCP
     {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") (.Values.service.loadBalancerClass) }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass }}
+  {{- end }}
   selector:
     {{- include "datahub-gms.selectorLabels" . | nindent 4 }}

--- a/charts/datahub/values.schema.json
+++ b/charts/datahub/values.schema.json
@@ -149,6 +149,17 @@
             "periodSeconds",
             "failureThreshold"
           ]
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "loadBalancerClass": {
+              "type": "string"
+            }
+          }
         }
       },
       "required": [

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -30,6 +30,8 @@ datahub-gms:
   # Optionaly specify service type for datahub-gms: LoadBalancer, ClusterIP or NodePort, by default: LoadBalancer
   # service:
   #   type: ClusterIP
+  # Load balancer class for datahub-gms. Used by cloud providers to select a load balancer implementation other than the cloud provider default.
+  #   loadBalancerClass: ""
   # Optionally set a GMS specific SQL login (defaults to global login)
   # sql:
   #   datasource:


### PR DESCRIPTION
allows setting the `loadBalancerClass` property on the datahub-gms service. Useful when
using EKS Auto Mode as it does not support setting the
`service.beta.kubernetes.io/aws-load-balancer-type` annotation.



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
