### PR TITLE
feat(basepath): Add support to specify the basepath used by the frontend and GMS

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,26 +4,26 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.6.21
+version: 0.6.22
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.2.0
 dependencies:
   - name: datahub-gms
-    version: 0.2.187
+    version: 0.2.188
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.2.164
+    version: 0.2.165
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer
-    version: 0.2.166
+    version: 0.2.167
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.2.170
+    version: 0.2.171
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron
@@ -31,7 +31,7 @@ dependencies:
     repository: file://./subcharts/datahub-ingestion-cron
     condition: datahub-ingestion-cron.enabled
   - name: acryl-datahub-actions
-    version: 0.2.153
+    version: 0.2.154
     repository: file://./subcharts/acryl-datahub-actions
     condition: acryl-datahub-actions.enabled
 maintainers:

--- a/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.153
+version: 0.2.154
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.1.1

--- a/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
@@ -82,6 +82,12 @@ spec:
           args: {{ .Values.image.args | toRawJson }}
           {{- end }}
           env:
+            {{- if .Values.global.basePath.enabled }}
+            - name: DATAHUB_BASE_PATH
+              value: {{ .Values.global.basePath.frontend | quote }}
+            - name: DATAHUB_GMS_BASE_PATH
+              value: {{ .Values.global.basePath.gms | quote }}
+            {{- end }}
             - name: DATAHUB_GMS_PROTOCOL
               value: {{ include "acryl-datahub-actions.datahubGmsProtocol" . }}
             - name: DATAHUB_GMS_HOST
@@ -105,7 +111,7 @@ spec:
               value: "{{ .Values.global.kafka.bootstrap.server }}"
             {{- if eq .Values.global.kafka.schemaregistry.type "INTERNAL" }}
             - name: SCHEMA_REGISTRY_URL
-              value: {{ printf "%s://%s:%s/schema-registry/api/" (include "acryl-datahub-actions.datahubGmsProtocol" .) (include "acryl-datahub-actions.datahubGmsHost" .) (include "acryl-datahub-actions.datahubGmsPort" .) | quote }}
+              value: {{ printf "%s://%s:%s%s/schema-registry/api/" (include "acryl-datahub-actions.datahubGmsProtocol" .) (include "acryl-datahub-actions.datahubGmsHost" .) (include "acryl-datahub-actions.datahubGmsPort" .) (ternary .Values.global.basePath.gms "" .Values.global.basePath.enabled) | quote }}
             {{- else if eq .Values.global.kafka.schemaregistry.type "KAFKA" }}
             - name: SCHEMA_REGISTRY_URL
               value: "{{ .Values.global.kafka.schemaregistry.url }}"

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.164
+version: 0.2.165
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.0.0

--- a/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
@@ -87,19 +87,25 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
-              path: /admin
+              path: {{ if .Values.global.basePath.enabled }}{{ .Values.global.basePath.frontend }}{{ end }}/admin
               port: http
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: /admin
+              path: {{ if .Values.global.basePath.enabled }}{{ .Values.global.basePath.frontend }}{{ end }}/admin
               port: http
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           env:
+            {{- if .Values.global.basePath.enabled }}
+            - name: DATAHUB_BASE_PATH
+              value: {{ .Values.global.basePath.frontend | quote }}
+            - name: DATAHUB_GMS_BASE_PATH
+              value: {{ .Values.global.basePath.gms | quote }}
+            {{- end }}
             - name: ENTITY_VERSIONING_ENABLED
               value: {{ .Values.global.datahub.entityVersioning.enabled | quote }}
             {{- if .Values.global.datahub.monitoring.enablePrometheus }}

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.187
+version: 0.2.188
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.0.0

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -94,14 +94,14 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
-              path: /health
+              path: {{ if .Values.global.basePath.enabled }}{{ .Values.global.basePath.gms }}{{ end }}/health
               port: http
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: /health
+              path: {{ if .Values.global.basePath.enabled }}{{ .Values.global.basePath.gms }}{{ end }}/health
               port: http
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
@@ -115,6 +115,14 @@ spec:
               value: {{ .Values.theme_v2.default | quote }}
             - name: THEME_V2_TOGGLEABLE
               value: {{ .Values.theme_v2.toggeable | quote }}
+            {{- if .Values.global.basePath.enabled }}
+            - name: DATAHUB_BASE_PATH
+              value: {{ .Values.global.basePath.frontend | quote }}
+            {{- end }}
+            {{- if .Values.global.basePath.enabled }}
+            - name: DATAHUB_GMS_BASE_PATH
+              value: {{ .Values.global.basePath.gms | quote }}
+            {{- end }}
             - name: ENTITY_VERSIONING_ENABLED
               value: {{ .Values.global.datahub.entityVersioning.enabled | quote }}
             - name: SHOW_SEARCH_FILTERS_V2
@@ -204,7 +212,7 @@ spec:
             {{- end }}
             {{- if eq .Values.global.kafka.schemaregistry.type "INTERNAL" }}
             - name: KAFKA_SCHEMAREGISTRY_URL
-              value: {{ printf "http://localhost:%s/schema-registry/api/" .Values.global.datahub.gms.port }}
+              value: {{ printf "http://localhost:%s%s/schema-registry/api/" .Values.global.datahub.gms.port (ternary .Values.global.basePath.gms "" .Values.global.basePath.enabled) }}
             {{- else if eq .Values.global.kafka.schemaregistry.type "KAFKA" }}
             - name: KAFKA_SCHEMAREGISTRY_URL
               value: "{{ .Values.global.kafka.schemaregistry.url }}"

--- a/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.166
+version: 0.2.167
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.0.0

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -93,6 +93,12 @@ spec:
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           env:
+            {{- if .Values.global.basePath.enabled }}
+            - name: DATAHUB_BASE_PATH
+              value: {{ .Values.global.basePath.frontend | quote }}
+            - name: DATAHUB_GMS_BASE_PATH
+              value: {{ .Values.global.basePath.gms | quote }}
+            {{- end }}
             - name: PRE_PROCESS_HOOKS_UI_ENABLED
               value: {{ or .Values.global.datahub.reProcessUIEventHooks (not .Values.global.datahub.preProcessHooksUIEnabled) | quote }}
             - name: ENTITY_VERSIONING_ENABLED
@@ -141,7 +147,7 @@ spec:
             {{- end }}
             {{- if eq .Values.global.kafka.schemaregistry.type "INTERNAL" }}
             - name: KAFKA_SCHEMAREGISTRY_URL
-              value: {{ printf "http://%s-%s:%s/schema-registry/api/" .Release.Name "datahub-gms" .Values.global.datahub.gms.port }}
+              value: {{ printf "http://%s-%s:%s%s/schema-registry/api/" .Release.Name "datahub-gms" .Values.global.datahub.gms.port (ternary .Values.global.basePath.gms "" .Values.global.basePath.enabled) }}
             {{- else if eq .Values.global.kafka.schemaregistry.type "KAFKA" }}
             - name: KAFKA_SCHEMAREGISTRY_URL
               value: "{{ .Values.global.kafka.schemaregistry.url }}"

--- a/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.170
+version: 0.2.171
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.0.0

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
@@ -97,6 +97,12 @@ spec:
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           env:
+            {{- if .Values.global.basePath.enabled }}
+            - name: DATAHUB_BASE_PATH
+              value: {{ .Values.global.basePath.frontend | quote }}
+            - name: DATAHUB_GMS_BASE_PATH
+              value: {{ .Values.global.basePath.gms | quote }}
+            {{- end }}
             - name: ENTITY_VERSIONING_ENABLED
               value: {{ .Values.global.datahub.entityVersioning.enabled | quote }}
             - name: SHOW_SEARCH_FILTERS_V2
@@ -135,7 +141,7 @@ spec:
             {{- end }}
             {{- if eq .Values.global.kafka.schemaregistry.type "INTERNAL" }}
             - name: KAFKA_SCHEMAREGISTRY_URL
-              value: {{ printf "http://%s-%s:%s/schema-registry/api/" .Release.Name "datahub-gms" .Values.global.datahub.gms.port }}
+              value: {{ printf "http://%s-%s:%s%s/schema-registry/api/" .Release.Name "datahub-gms" .Values.global.datahub.gms.port (ternary .Values.global.basePath.gms "" .Values.global.basePath.enabled) }}
             {{- else if eq .Values.global.kafka.schemaregistry.type "KAFKA" }}
             - name: KAFKA_SCHEMAREGISTRY_URL
               value: "{{ .Values.global.kafka.schemaregistry.url }}"

--- a/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
+++ b/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
@@ -3,6 +3,12 @@
 Return the env variables for upgrade jobs
 */}}
 {{- define "datahub.upgrade.env" -}}
+{{- if .Values.global.basePath.enabled }}
+- name: DATAHUB_BASE_PATH
+  value: {{ .Values.global.basePath.frontend | quote }}
+- name: DATAHUB_GMS_BASE_PATH
+  value: {{ .Values.global.basePath.gms | quote }}
+{{- end }}
 - name: ENTITY_REGISTRY_CONFIG_PATH
   value: /datahub/datahub-gms/resources/entity-registry.yml
 - name: DATAHUB_GMS_HOST
@@ -74,7 +80,7 @@ Return the env variables for upgrade jobs
 {{- end }}
 {{- if eq .Values.global.kafka.schemaregistry.type "INTERNAL" }}
 - name: KAFKA_SCHEMAREGISTRY_URL
-  value: {{ printf "http://%s-%s:%s/schema-registry/api/" .Release.Name "datahub-gms" .Values.global.datahub.gms.port }}
+  value: {{ printf "http://%s-%s:%s%s/schema-registry/api/" .Release.Name "datahub-gms" .Values.global.datahub.gms.port (ternary .Values.global.basePath.gms "" .Values.global.basePath.enabled) }}
 {{- else if eq .Values.global.kafka.schemaregistry.type "KAFKA" }}
 - name: KAFKA_SCHEMAREGISTRY_URL
   value: "{{ .Values.global.kafka.schemaregistry.url }}"

--- a/charts/datahub/values.schema.json
+++ b/charts/datahub/values.schema.json
@@ -1402,6 +1402,25 @@
         "imageRegistry": {
           "type": "string"
         },
+        "basePath": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "frontend": {
+              "type": "string"
+            },
+            "gms": {
+              "type": "string"
+            }
+	  },
+	  "required": [
+	    "enabled",
+	    "frontend",
+	    "gms"
+	  ]
+        },
         "elasticsearch": {
           "type": "object",
           "properties": {
@@ -2417,6 +2436,7 @@
         "datahub_analytics_enabled",
         "datahub_standalone_consumers_enabled",
         "imageRegistry",
+        "basePath",
         "elasticsearch",
         "kafka",
         "neo4j",

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -513,6 +513,21 @@ global:
   datahub_standalone_consumers_enabled: false
   imageRegistry: "docker.io"
 
+  # Base path configuration for serving DataHub behind a proxy
+  # When enabled, DataHub services will be accessible under the specified base paths
+  # This allows hosting DataHub under a subpath like /datahub instead of root /
+  # When using the INTERNAL schema registry this will also set the basePath path for clients.
+  basePath:
+    # Enable basepath support
+    enabled: false
+    # Base path for DataHub frontend (e.g., /datahub)
+    # When set, the frontend will be accessible at this path
+    frontend: ""
+    # Base path for DataHub GMS API (e.g., /datahub)
+    # When set, the GMS will be accessible at this path
+    # For deployments where GMS won't be exposed via an ingress that can be left empty.
+    gms: ""
+
   elasticsearch:
     host: "elasticsearch-master"
     # If you want to use OpenSearch instead of ElasticSearch use different hostname below


### PR DESCRIPTION
Add support via global.basePath property to enable DATAHUB_BASE_PATH and DATAHUB_GMS_BASE_PATH.
```
basePath:
  # Enable basepath support
  enabled: false
  # Base path for DataHub frontend (e.g., /datahub)
  # When set, the frontend will be accessible at this path
  frontend: ""
  # Base path for DataHub GMS API (e.g., /datahub)
  # When set, the GMS will be accessible at this path
  # For deployments where GMS won't be exposed via an ingress that can be left empty.
  gms: ""
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `global.basePath` to set `DATAHUB_BASE_PATH`/`DATAHUB_GMS_BASE_PATH`, update probes and INTERNAL Schema Registry URLs to honor base paths, and bump chart versions.
> 
> - **Base path support**
>   - Add `global.basePath` (with `enabled`, `frontend`, `gms`) to `values.yaml` and `values.schema.json` (now required).
>   - Inject `DATAHUB_BASE_PATH` and `DATAHUB_GMS_BASE_PATH` env vars when enabled in:
>     - `datahub-frontend`, `datahub-gms`, `datahub-mae-consumer`, `datahub-mce-consumer`, `acryl-datahub-actions`, and upgrade jobs (`templates/datahub-upgrade/_upgrade.tpl`).
>   - Update health probes to respect base paths:
>     - Frontend liveness/readiness `path` -> `{{ basePath.frontend }}/admin`.
>     - GMS liveness/readiness `path` -> `{{ basePath.gms }}/health`.
>   - Adjust INTERNAL Schema Registry URLs to include base path where applicable.
> - **Version bumps**
>   - Root chart `datahub` `0.6.22`.
>   - Subcharts: `datahub-gms 0.2.188`, `datahub-frontend 0.2.165`, `datahub-mae-consumer 0.2.167`, `datahub-mce-consumer 0.2.171`, `acryl-datahub-actions 0.2.154`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8de2b231d979f7eb2ebb543f23e349509284208. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->