### PR TITLE
feat(cdc): support cdc config

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,14 +4,14 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.6.24
+version: 0.6.25
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.2.0
 dependencies:
   - name: datahub-gms
-    version: 0.2.188
+    version: 0.2.189
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
@@ -23,7 +23,7 @@ dependencies:
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.2.171
+    version: 0.2.172
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.188
+version: 0.2.189
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.0.0

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -123,6 +123,10 @@ spec:
             - name: DATAHUB_GMS_BASE_PATH
               value: {{ .Values.global.basePath.gms | quote }}
             {{- end }}
+            {{- if .Values.global.cdc.enabled }}
+            - name: CDC_MCL_PROCESSING_ENABLED
+              value: {{ .Values.global.cdc.enabled | quote }}
+            {{- end }}
             - name: ENTITY_VERSIONING_ENABLED
               value: {{ .Values.global.datahub.entityVersioning.enabled | quote }}
             - name: SHOW_SEARCH_FILTERS_V2

--- a/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.171
+version: 0.2.172
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.0.0

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
@@ -103,6 +103,10 @@ spec:
             - name: DATAHUB_GMS_BASE_PATH
               value: {{ .Values.global.basePath.gms | quote }}
             {{- end }}
+            {{- if .Values.global.cdc.enabled }}
+            - name: CDC_MCL_PROCESSING_ENABLED
+              value: {{ .Values.global.cdc.enabled | quote }}
+            {{- end }}
             - name: ENTITY_VERSIONING_ENABLED
               value: {{ .Values.global.datahub.entityVersioning.enabled | quote }}
             - name: SHOW_SEARCH_FILTERS_V2

--- a/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
+++ b/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
@@ -171,6 +171,62 @@ Return the env variables for upgrade jobs
   value: {{ .platform_event_topic_name }}
 - name: DATAHUB_USAGE_EVENT_NAME
   value: {{ .datahub_usage_event_name }}
+- name: CDC_TOPIC_NAME
+  value: {{ .cdc_topic_name }}
+{{- end }}
+
+{{- if .Values.global.cdc.enabled }}
+- name: CDC_MCL_PROCESSING_ENABLED
+  value: {{ .Values.global.cdc.enabled | quote }}
+- name: CDC_CONFIGURE_SOURCE
+  value: {{ .Values.global.cdc.configureSource | quote }}
+- name: CDC_URN_KEY_SPEC
+  value: {{ .Values.global.cdc.urnKeySpec | quote }}
+- name: CDC_DB_TYPE
+  value: {{ .Values.global.cdc.database.type | quote }}
+- name: CDC_USER
+  {{- $cdcUsernameValue := .Values.global.cdc.database.username }}
+  {{- if and (kindIs "string" $cdcUsernameValue) $cdcUsernameValue }}
+  value: {{ $cdcUsernameValue | quote }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .Values.global.cdc.database.username.secretRef }}"
+      key: "{{ .Values.global.cdc.database.username.secretKey }}"
+  {{- end }}
+- name: CDC_PASSWORD
+  {{- $cdcPasswordValue := .Values.global.cdc.database.password.value }}
+  {{- if $cdcPasswordValue }}
+  value: {{ $cdcPasswordValue | quote }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .Values.global.cdc.database.password.secretRef }}"
+      key: "{{ .Values.global.cdc.database.password.secretKey }}"
+  {{- end }}
+- name: DATAHUB_CDC_CONNECTOR_NAME
+  value: {{ .Values.global.cdc.debezium.connectorName | quote }}
+- name: CDC_KAFKA_CONNECT_URL
+  value: {{ .Values.global.cdc.debezium.kafkaConnectUrl | quote }}
+- name: CDC_KAFKA_CONNECT_REQUEST_TIMEOUT
+  value: {{ .Values.global.cdc.debezium.requestTimeout | quote }}
+{{- if eq .Values.global.cdc.database.type "mysql" }}
+- name: CDC_SERVER_ID
+  value: {{ .Values.global.cdc.database.serverId | quote }}
+{{- else if eq .Values.global.cdc.database.type "postgres" }}
+- name: CDC_INCLUDE_TABLE
+  value: {{ .Values.global.cdc.database.includeTable | quote }}
+- name: CDC_INCLUDE_SCHEMA
+  value: {{ .Values.global.cdc.database.includeSchema | quote }}
+{{- end }}
+{{- with .Values.global.cdc.debezium.connectorClass }}
+- name: DEBEZIUM_CONNECTOR_CLASS
+  value: {{ . | quote }}
+{{- end }}
+{{- with .Values.global.cdc.debezium.pluginName }}
+- name: DEBEZIUM_PLUGIN_NAME
+  value: {{ . | quote }}
+{{- end }}
 {{- end }}
 {{- end -}}
 

--- a/charts/datahub/templates/mysql-setup-job.yml
+++ b/charts/datahub/templates/mysql-setup-job.yml
@@ -82,6 +82,42 @@ spec:
               value: {{ .Values.global.sql.datasource.hostForMysqlClient | quote }}
             - name: MYSQL_PORT
               value: {{ .Values.global.sql.datasource.port | quote }}
+            - name: DATAHUB_DB_NAME
+              value: "datahub"
+            - name: MYSQL_ROOT_PASSWORD
+              {{- $rootPasswordValue := .Values.global.sql.datasource.password.value }}
+              {{- if $rootPasswordValue }}
+              value: {{ $rootPasswordValue | quote }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.sql.datasource.password.secretRef }}"
+                  key: "{{ .Values.global.sql.datasource.password.secretKey }}"
+              {{- end }}
+          {{- if .Values.global.cdc.enabled }}
+            - name: CDC_MCL_PROCESSING_ENABLED
+              value: {{ .Values.global.cdc.enabled | quote }}
+            - name: CDC_USER
+              {{- $cdcUsernameValue := .Values.global.cdc.database.username }}
+              {{- if and (kindIs "string" $cdcUsernameValue) $cdcUsernameValue }}
+              value: {{ $cdcUsernameValue | quote }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.cdc.database.username.secretRef }}"
+                  key: "{{ .Values.global.cdc.database.username.secretKey }}"
+              {{- end }}
+            - name: CDC_PASSWORD
+              {{- $cdcPasswordValue := .Values.global.cdc.database.password.value }}
+              {{- if $cdcPasswordValue }}
+              value: {{ $cdcPasswordValue | quote }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.cdc.database.password.secretRef }}"
+                  key: "{{ .Values.global.cdc.database.password.secretKey }}"
+              {{- end }}
+          {{- end }}
           {{- with .Values.mysqlSetupJob.extraEnvs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/datahub/templates/postgresql-setup-job.yml
+++ b/charts/datahub/templates/postgresql-setup-job.yml
@@ -82,6 +82,32 @@ spec:
               value: {{ .Values.global.sql.datasource.hostForpostgresqlClient | quote }}
             - name: POSTGRES_PORT
               value: {{ .Values.global.sql.datasource.port | quote }}
+            - name: DATAHUB_DB_NAME
+              value: "datahub"
+          {{- if .Values.global.cdc.enabled }}
+            - name: CDC_MCL_PROCESSING_ENABLED
+              value: {{ .Values.global.cdc.enabled | quote }}
+            - name: CDC_USER
+              {{- $cdcUsernameValue := .Values.global.cdc.database.username }}
+              {{- if and (kindIs "string" $cdcUsernameValue) $cdcUsernameValue }}
+              value: {{ $cdcUsernameValue | quote }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.cdc.database.username.secretRef }}"
+                  key: "{{ .Values.global.cdc.database.username.secretKey }}"
+              {{- end }}
+            - name: CDC_PASSWORD
+              {{- $cdcPasswordValue := .Values.global.cdc.database.password.value }}
+              {{- if $cdcPasswordValue }}
+              value: {{ $cdcPasswordValue | quote }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.cdc.database.password.secretRef }}"
+                  key: "{{ .Values.global.cdc.database.password.secretKey }}"
+              {{- end }}
+          {{- end }}
           {{- with .Values.postgresqlSetupJob.extraEnvs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/datahub/values.schema.json
+++ b/charts/datahub/values.schema.json
@@ -1421,6 +1421,82 @@
 	    "gms"
 	  ]
         },
+        "cdc": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "urnKeySpec": {
+              "type": "string"
+            },
+            "configureSource": {
+              "type": "boolean"
+            },
+            "database": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["mysql", "postgres"]
+                },
+                "username": {
+                  "oneOf": [
+                    {"type": "string"},
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secretRef": {"type": "string"},
+                        "secretKey": {"type": "string"}
+                      },
+                      "required": ["secretRef", "secretKey"]
+                    }
+                  ]
+                },
+                "password": {
+                  "type": "object",
+                  "properties": {
+                    "value": {"type": "string"},
+                    "secretRef": {"type": "string"},
+                    "secretKey": {"type": "string"}
+                  }
+                },
+                "serverId": {
+                  "type": "string"
+                },
+                "includeTable": {
+                  "type": "string"
+                },
+                "includeSchema": {
+                  "type": "string"
+                }
+              },
+              "required": ["type", "username", "password"]
+            },
+            "debezium": {
+              "type": "object",
+              "properties": {
+                "connectorName": {
+                  "type": "string"
+                },
+                "kafkaConnectUrl": {
+                  "type": "string"
+                },
+                "requestTimeout": {
+                  "type": "string"
+                },
+                "connectorClass": {
+                  "type": "string"
+                },
+                "pluginName": {
+                  "type": "string"
+                }
+              },
+              "required": ["connectorName", "kafkaConnectUrl", "requestTimeout"]
+            }
+          },
+          "required": ["enabled", "urnKeySpec", "configureSource", "database", "debezium"]
+        },
         "elasticsearch": {
           "type": "object",
           "properties": {

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -528,6 +528,52 @@ global:
     # For deployments where GMS won't be exposed via an ingress that can be left empty.
     gms: ""
 
+  # Change Data Capture (CDC) configuration
+  # CDC mode provides strict ordering guarantees for metadata changes by generating
+  # MCLs from database change events via Debezium instead of directly from GMS.
+  # For more information, see: https://datahubproject.io/docs/deploy/configure-cdc
+  # NOTE: CDC topic name is configured in kafka.topics.cdc_topic_name
+  cdc:
+    # Enable CDC mode (disabled by default)
+    enabled: false
+    # Partitioning key specification (table:column format)
+    urnKeySpec: "datahub.metadata_aspect_v2:urn"
+    # Auto-configure Debezium connector (recommended false for production)
+    configureSource: false
+    # Database configuration for CDC
+    database:
+      # Database type: mysql or postgres
+      type: "mysql"
+      # CDC database username - can be a direct string value or reference a secret
+      username: "datahub_cdc"
+      # OR use secret reference:
+      # username:
+      #   secretRef: mysql-secrets
+      #   secretKey: mysql-cdc-username
+      # CDC database password - supports both direct value and secret reference
+      password:
+        secretRef: mysql-secrets
+        secretKey: mysql-cdc-password
+        # --------------OR----------------
+        # value: datahub_cdc
+      # MySQL-specific configuration
+      serverId: "184001"
+      # PostgreSQL-specific configuration
+      includeTable: "public.metadata_aspect_v2"
+      includeSchema: "public"
+    # Debezium/Kafka Connect configuration
+    debezium:
+      # Debezium connector name
+      connectorName: "datahub-cdc-connector"
+      # Kafka Connect REST API URL
+      kafkaConnectUrl: "http://kafka-connect:8083"
+      # Request timeout in milliseconds
+      requestTimeout: "10000"
+      # Optional: Override connector class for specific database
+      # connectorClass: "io.debezium.connector.mysql.MySqlConnector"
+      # Optional: Override logical decoding plugin
+      # pluginName: "decoderbufs"
+
   elasticsearch:
     host: "elasticsearch-master"
     # If you want to use OpenSearch instead of ElasticSearch use different hostname below
@@ -705,6 +751,7 @@ global:
       metadata_change_log_timeseries_topic_name: "MetadataChangeLog_Timeseries_v1"
       platform_event_topic_name: "PlatformEvent_v1"
       datahub_upgrade_history_topic_name: "DataHubUpgradeHistory_v1"
+      cdc_topic_name: "datahub.metadata_aspect_v2"
     consumer_groups:
       datahub_upgrade_history_kafka_consumer_group_id: {}
       #   gms: "<<release-name>>-duhe-consumer-job-client-gms"


### PR DESCRIPTION
Adds support for CDC mode generation of MCLs (defaults to false) 
This chart does not support setting up kafka-connect - It is recommended that it be setup in a manner suitable/compatible with  your kafka environment
This chart will enable use of kafka-connect source when configured. See values under `global.cdc` for related options. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
