### PR TITLE
fix: declare image tags explicitly

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.7.3
+version: 0.7.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/quickstart-values-with-neo4j.yaml
+++ b/charts/datahub/quickstart-values-with-neo4j.yaml
@@ -4,14 +4,14 @@ datahub-gms:
   enabled: true
   image:
     repository: acryldata/datahub-gms
-    # tag: "v0.11.0 # defaults to .global.datahub.version
+    tag: ~
 
 
 datahub-frontend:
   enabled: true
   image:
     repository: acryldata/datahub-frontend-react
-    # tag: "v0.11.0 # defaults to .global.datahub.version
+    tag: ~
 
   # Set up ingress to expose react front-end
   ingress:
@@ -40,35 +40,35 @@ elasticsearchSetupJob:
   enabled: true
   image:
     repository: acryldata/datahub-elasticsearch-setup
-    # tag: "v0.11.0 # defaults to .global.datahub.version
+    tag: ~
 
 
 kafkaSetupJob:
   enabled: true
   image:
     repository: acryldata/datahub-kafka-setup
-    # tag: "v0.11.0 # defaults to .global.datahub.version
+    tag: ~
 
 
 mysqlSetupJob:
   enabled: true
   image:
     repository: acryldata/datahub-mysql-setup
-    # tag: "v0.11.0 # defaults to .global.datahub.version
+    tag: ~
 
 
 datahubUpgrade:
   enabled: true
   image:
     repository: acryldata/datahub-upgrade
-    # tag: "v0.11.0 # defaults to .global.datahub.version
+    tag: ~
 
 
 datahub-ingestion-cron:
   enabled: false
   image:
     repository: acryldata/datahub-ingestion
-    # tag: "v0.11.0 # defaults to .global.datahub.version
+    tag: ~
 
 
 global:

--- a/charts/datahub/subcharts/acryl-datahub-actions/values.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/values.yaml
@@ -6,6 +6,7 @@ replicaCount: 1
 image:
   repository: acryldata/datahub-actions
   pullPolicy: IfNotPresent
+  tag: ~
   # Override the image's command & args with a new one.
   # This may be necessary for custom startup or shutdown behaviors
   command:

--- a/charts/datahub/subcharts/datahub-frontend/values.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/values.yaml
@@ -29,7 +29,7 @@ revisionHistoryLimit: 10
 
 image:
   repository: acryldata/datahub-frontend-react
-  tag:
+  tag: ~
   pullPolicy: IfNotPresent
   # Override the image's command & args with a new one.
   # This may be necessary for custom startup or shutdown behaviors

--- a/charts/datahub/subcharts/datahub-gms/values.yaml
+++ b/charts/datahub/subcharts/datahub-gms/values.yaml
@@ -18,7 +18,7 @@ revisionHistoryLimit: 10
 image:
   repository: acryldata/datahub-gms
   pullPolicy: IfNotPresent
-  tag:
+  tag: ~
   # Override the image's command & args with a new one.
   # This may be necessary for custom startup or shutdown behaviors
   command:

--- a/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: acryldata/datahub-ingestion
-  tag:
+  tag: ~
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/datahub/subcharts/datahub-mae-consumer/values.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/values.yaml
@@ -9,7 +9,7 @@ revisionHistoryLimit: 10
 image:
   repository: acryldata/datahub-mae-consumer
   pullPolicy: IfNotPresent
-  tag:
+  tag: ~
   # Override the image's command & args with a new one.
   # This may be necessary for custom startup or shutdown behaviors
   command:

--- a/charts/datahub/subcharts/datahub-mce-consumer/values.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/values.yaml
@@ -9,7 +9,7 @@ revisionHistoryLimit: 10
 image:
   repository: acryldata/datahub-mce-consumer
   pullPolicy: IfNotPresent
-  tag:
+  tag: ~
   # Override the image's command & args with a new one.
   # This may be necessary for custom startup or shutdown behaviors
   command:

--- a/charts/datahub/values.schema.json
+++ b/charts/datahub/values.schema.json
@@ -14,6 +14,12 @@
           "properties": {
             "repository": {
               "type": "string"
+            },
+            "tag": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -71,6 +77,12 @@
           "properties": {
             "repository": {
               "type": "string"
+            },
+            "tag": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -181,6 +193,12 @@
           "properties": {
             "repository": {
               "type": "string"
+            },
+            "tag": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -274,7 +292,10 @@
               "type": "string"
             },
             "tag": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -331,6 +352,12 @@
           "properties": {
             "repository": {
               "type": "string"
+            },
+            "tag": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -386,6 +413,12 @@
           "properties": {
             "repository": {
               "type": "string"
+            },
+            "tag": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -444,6 +477,12 @@
           "properties": {
             "repository": {
               "type": "string"
+            },
+            "tag": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -467,6 +506,12 @@
           "properties": {
             "repository": {
               "type": "string"
+            },
+            "tag": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -590,6 +635,12 @@
           "properties": {
             "repository": {
               "type": "string"
+            },
+            "tag": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -713,6 +764,12 @@
           "properties": {
             "repository": {
               "type": "string"
+            },
+            "tag": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -836,6 +893,12 @@
           "properties": {
             "repository": {
               "type": "string"
+            },
+            "tag": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -959,6 +1022,12 @@
           "properties": {
             "repository": {
               "type": "string"
+            },
+            "tag": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -1110,6 +1179,12 @@
           "properties": {
             "repository": {
               "type": "string"
+            },
+            "tag": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -4,7 +4,7 @@ datahub-gms:
   enabled: true
   image:
     repository: acryldata/datahub-gms
-    # tag: "v0.11.0 # defaults to .global.datahub.version
+    tag: ~ # defaults to .global.datahub.version
     # Add custom command / arguments to this job.  Useful if you need a custom startup or shutdown script
     # to run
     # command: customCommand
@@ -65,7 +65,7 @@ datahub-frontend:
     targetMemoryUtilizationPercentage: 70
   image:
     repository: acryldata/datahub-frontend-react
-    # tag: "v0.11.0" # # defaults to .global.datahub.version
+    tag: ~ # defaults to .global.datahub.version
     # Add custom command / arguments to this job.  Useful if you need a custom startup or shutdown script
     # to run
     # command: customCommand
@@ -106,7 +106,7 @@ acryl-datahub-actions:
   enabled: true
   image:
     repository: acryldata/datahub-actions
-    # tag: "v1.2.0" # # defaults to .global.datahub.version
+    tag: ~ # defaults to .global.datahub.version
     # Add custom command / arguments to this job.  Useful if you need a custom startup or shutdown script
     # to run
     # command: customCommand
@@ -125,7 +125,7 @@ acryl-datahub-actions:
 datahub-mae-consumer:
   image:
     repository: acryldata/datahub-mae-consumer
-    # tag: "v0.11.0" # defaults to .global.datahub.version
+    tag: ~ # defaults to .global.datahub.version
     # Add custom command / arguments to this job.  Useful if you need a custom startup or shutdown script
     # to run
     # command: customCommand
@@ -140,7 +140,7 @@ datahub-mae-consumer:
 datahub-mce-consumer:
   image:
     repository: acryldata/datahub-mce-consumer
-    # tag: "v0.11.0" # defaults to .global.datahub.version
+    tag: ~ # defaults to .global.datahub.version
     # Add custom command / arguments to this job.  Useful if you need a custom startup or shutdown script
     # to run
     # command: customCommand
@@ -156,13 +156,13 @@ datahub-ingestion-cron:
   enabled: false
   image:
     repository: acryldata/datahub-ingestion
-    # tag: "v0.11.0" # defaults to .global.datahub.version
+    tag: ~ # defaults to .global.datahub.version
 
 elasticsearchSetupJob:
   enabled: true
   image:
     repository: acryldata/datahub-elasticsearch-setup
-    # tag: "v0.11.0" # defaults to .global.datahub.version
+    tag: ~ # defaults to .global.datahub.version
     # Add custom command / arguments to this job.  Useful if you need a custom startup or shutdown script
     # to run
     # command: customCommand
@@ -202,8 +202,7 @@ kafkaSetupJob:
   enabled: false
   image:
     repository: acryldata/datahub-kafka-setup
-    tag: v1.2.0.1
-    # tag: "v0.11.0" # defaults to .global.datahub.version
+    tag: v1.2.0.1 # defaults to .global.datahub.version
     # Add custom command / arguments to this job.  Useful if you need a custom startup or shutdown script
     # to run
     # command: customCommand
@@ -239,7 +238,7 @@ mysqlSetupJob:
   enabled: true
   image:
     repository: acryldata/datahub-mysql-setup
-    # tag: "v0.11.0" # defaults to .global.datahub.version
+    tag: ~ # defaults to .global.datahub.version
     # Add custom command / arguments to this job.  Useful if you need a custom startup or shutdown script
     # to run
     # command: customCommand
@@ -280,7 +279,7 @@ postgresqlSetupJob:
   enabled: false
   image:
     repository: acryldata/datahub-postgres-setup
-    # tag: "v0.11.0" # defaults to .global.datahub.version
+    tag: ~ # defaults to .global.datahub.version
     # Add custom command / arguments to this job.  Useful if you need a custom startup or shutdown script
     # to run
     # command: customCommand
@@ -326,7 +325,7 @@ datahubUpgrade:
   enabled: true
   image:
     repository: acryldata/datahub-upgrade
-    # tag: "v0.11.0"  # defaults to .global.datahub.version
+    tag: ~ # defaults to .global.datahub.version
   batchSize: 1000
   batchDelayMs: 100
   podSecurityContext: {}
@@ -405,7 +404,7 @@ datahubSystemCronHourly:
   labels: {}
   image:
     repository: 795586375822.dkr.ecr.us-west-2.amazonaws.com/datahub-upgrade
-    # tag: "v0.2.0"  # defaults to .global.datahub.version
+    tag: ~ # defaults to .global.datahub.version
   podSecurityContext: {}
     # fsGroup: 1000
   securityContext: {}
@@ -427,7 +426,7 @@ datahubSystemUpdate:
   labels: {}
   image:
     repository: acryldata/datahub-upgrade
-    # tag:
+    tag: ~ # defaults to .global.datahub.version
     # Add custom command / arguments to this job.  Useful if you need a custom startup or shutdown script
     # to run
     # command: customCommand


### PR DESCRIPTION
The PR fixes `datahub/values.schema.json` by adding the missing `tag` properties and correcting the type to reflect that the `image.tag` property exists and can be either specified or omitted.
The PR also adds the `image.tag` property declaration to the `values.yaml` files.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
