### PR TITLE
feat(iam-setup): updates for IAM improvements

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,26 +4,26 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.7.4
+version: 0.8.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.3.0
 dependencies:
   - name: datahub-gms
-    version: 0.2.191
+    version: 0.2.192
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.2.168
+    version: 0.2.169
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer
-    version: 0.2.168
+    version: 0.2.169
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.2.173
+    version: 0.2.174
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron
@@ -31,7 +31,7 @@ dependencies:
     repository: file://./subcharts/datahub-ingestion-cron
     condition: datahub-ingestion-cron.enabled
   - name: acryl-datahub-actions
-    version: 0.2.154
+    version: 0.2.155
     repository: file://./subcharts/acryl-datahub-actions
     condition: acryl-datahub-actions.enabled
 maintainers:

--- a/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.154
+version: 0.2.155
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.1.1

--- a/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
@@ -118,21 +118,14 @@ spec:
             {{- end }}
             - name: KAFKA_AUTO_OFFSET_POLICY
               value: "{{ .Values.actions.kafkaAutoOffsetPolicy }}"
-            {{- if .Values.global.springKafkaConfigurationOverrides }}
-            {{- range $configName, $configValue := .Values.global.springKafkaConfigurationOverrides }}
-            - name: KAFKA_PROPERTIES_{{ $configName | replace "." "_" | upper }}
-              value: {{ $configValue | quote }}
+            {{- if .Values.global.kafka.iam.enabled }}
+            {{- include "datahub.kafka.iam.python.env" . | nindent 12 }}
+            - name: KAFKA_PROPERTIES_OAUTH_CB
+              value: "datahub_actions.utils.kafka_msk_iam:oauth_cb"
             {{- end }}
-            {{- end }}
-            {{- if .Values.global.credentialsAndCertsSecrets }}
-            {{- range $envVarName, $envVarValue := .Values.global.credentialsAndCertsSecrets.secureEnv }}
-            - name: KAFKA_PROPERTIES_{{ $envVarName | replace "." "_" | upper }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $.Values.global.credentialsAndCertsSecrets.name }}
-                  key: {{ $envVarValue }}
-            {{- end }}
-            {{- end }}
+            {{- include "datahub.elasticsearch.iam.env" . | nindent 12 }}
+            {{- include "datahub.python.kafka.overrides.with.fallback" . | nindent 12 }}
+            {{- include "datahub.python.kafka.secrets.with.fallback" . | nindent 12 }}
             {{- with .Values.global.kafka.topics }}
             - name: METADATA_CHANGE_EVENT_NAME
               value: {{ .metadata_change_event_name }}

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.168
+version: 0.2.169
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.3.0

--- a/charts/datahub/subcharts/datahub-frontend/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-frontend/templates/_helpers.tpl
@@ -85,3 +85,22 @@ Return the appropriate apiVersion for HorizontalPodAutoscaler.
     {{- print "autoscaling/v2beta1" -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Kafka IAM environment variables for AWS MSK authentication if enabled.
+For Java/Spring-based services that use Spring Kafka.
+*/}}
+{{- define "datahub.kafka.iam.env" -}}
+{{- if .Values.global.kafka.iam.enabled -}}
+- name: SPRING_KAFKA_PROPERTIES_SASL_CLIENT_CALLBACK_HANDLER_CLASS
+  value: software.amazon.msk.auth.iam.IAMClientCallbackHandler
+- name: SPRING_KAFKA_PROPERTIES_SASL_JAAS_CONFIG
+  value: software.amazon.msk.auth.iam.IAMLoginModule required;
+- name: SPRING_KAFKA_PROPERTIES_SASL_MECHANISM
+  value: AWS_MSK_IAM
+- name: SPRING_KAFKA_PROPERTIES_SSL_PROTOCOL
+  value: TLS
+- name: SPRING_KAFKA_PROPERTIES_SECURITY_PROTOCOL
+  value: SASL_SSL
+{{- end -}}
+{{- end -}}

--- a/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
@@ -158,21 +158,9 @@ spec:
             - name: KAFKA_CONSUMER_MAX_PARTITION_FETCH_BYTES
               value: {{ . | quote }}
             {{- end }}
-            {{- if .Values.global.springKafkaConfigurationOverrides }}
-            {{- range $configName, $configValue := .Values.global.springKafkaConfigurationOverrides }}
-            - name: KAFKA_PROPERTIES_{{ $configName | replace "." "_" | upper }}
-              value: {{ $configValue | quote }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.global.credentialsAndCertsSecrets }}
-            {{- range $envVarName, $envVarValue := .Values.global.credentialsAndCertsSecrets.secureEnv }}
-            - name: KAFKA_PROPERTIES_{{ $envVarName | replace "." "_" | upper }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $.Values.global.credentialsAndCertsSecrets.name }}
-                  key: {{ $envVarValue }}
-            {{- end }}
-            {{- end }}
+            {{- include "datahub.kafka.iam.env" . | nindent 12 }}
+            {{- include "datahub.kafka.overrides" . | nindent 12 }}
+            {{- include "datahub.kafka.credentials.env" . | nindent 12 }}
             - name: ELASTIC_CLIENT_HOST
               value: "{{ .Values.global.elasticsearch.host }}"
             - name: ELASTIC_CLIENT_PORT

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.191
+version: 0.2.192
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.3.0

--- a/charts/datahub/subcharts/datahub-gms/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-gms/templates/_helpers.tpl
@@ -93,3 +93,44 @@ Create image registry, name and tag for a datahub component
 {{- $registry := .image.registry | default .imageRegistry -}}
 {{ $registry }}/{{ .image.repository }}:{{ required "Global or specific tag is required" (.image.tag | default .version) -}}
 {{- end -}}
+
+{{/*
+Kafka IAM environment variables for AWS MSK authentication if enabled.
+For Java/Spring-based services that use Spring Kafka.
+*/}}
+{{- define "datahub.kafka.iam.env" -}}
+{{- if .Values.global.kafka.iam.enabled -}}
+- name: SPRING_KAFKA_PROPERTIES_SASL_CLIENT_CALLBACK_HANDLER_CLASS
+  value: software.amazon.msk.auth.iam.IAMClientCallbackHandler
+- name: SPRING_KAFKA_PROPERTIES_SASL_JAAS_CONFIG
+  value: software.amazon.msk.auth.iam.IAMLoginModule required;
+- name: SPRING_KAFKA_PROPERTIES_SASL_MECHANISM
+  value: AWS_MSK_IAM
+- name: SPRING_KAFKA_PROPERTIES_SSL_PROTOCOL
+  value: TLS
+- name: SPRING_KAFKA_PROPERTIES_SECURITY_PROTOCOL
+  value: SASL_SSL
+{{- end -}}
+{{- end -}}
+
+{{/*
+OpenSearch/Elasticsearch IAM authentication environment variables for AWS OpenSearch.
+Sets OPENSEARCH_USE_AWS_IAM_AUTH=true and AWS_REGION when IAM authentication is enabled.
+This helper should be included in all services that access OpenSearch/Elasticsearch.
+Validates that Kafka and OpenSearch regions match when both are configured with IAM.
+*/}}
+{{- define "datahub.elasticsearch.iam.env" -}}
+{{- if .Values.global.elasticsearch.iam.enabled }}
+{{- if and .Values.global.elasticsearch.region .Values.global.kafka.region }}
+{{- if ne .Values.global.elasticsearch.region .Values.global.kafka.region }}
+{{- fail (printf "AWS_REGION mismatch: Kafka region (%s) differs from OpenSearch region (%s). Both must be in the same region for IAM authentication." .Values.global.kafka.region .Values.global.elasticsearch.region) }}
+{{- end }}
+{{- end }}
+- name: OPENSEARCH_USE_AWS_IAM_AUTH
+  value: "true"
+{{- if .Values.global.elasticsearch.region }}
+- name: AWS_REGION
+  value: {{ .Values.global.elasticsearch.region | quote }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -107,10 +107,6 @@ spec:
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           env:
-            - name: ELASTICSEARCH_SHIM_ENGINE_TYPE
-              value: {{ .Values.global.elasticsearch.engineType | quote }}
-            - name: ELASTICSEARCH_SHIM_AUTO_DETECT
-              value: {{ .Values.global.elasticsearch.autoDetect | quote }}
             - name: ELASTICSEARCH_BUILD_INDICES_REINDEX_OPTIMIZATION_ENABLED
               value: {{ .Values.global.elasticsearch.index.upgrade.reindexOptimizationEnabled | quote }}
             - name: THEME_V2_ENABLED
@@ -174,32 +170,8 @@ spec:
               value: /datahub/datahub-gms/resources/entity-registry.yml
             - name: DATAHUB_ANALYTICS_ENABLED
               value: "{{ .Values.global.datahub_analytics_enabled }}"
-            - name: EBEAN_DATASOURCE_USERNAME
-              {{- $usernameValue := (.Values.sql).datasource.username | default .Values.global.sql.datasource.username }}
-              {{- if and (kindIs "string" $usernameValue) $usernameValue }}
-              value: {{ $usernameValue | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ (.Values.sql).datasource.username.secretRef | default .Values.global.sql.datasource.username.secretRef }}"
-                  key: "{{ (.Values.sql).datasource.username.secretKey | default .Values.global.sql.datasource.username.secretKey }}"
-              {{- end }}
-            - name: EBEAN_DATASOURCE_PASSWORD
-              {{- $passwordValue := (.Values.sql).datasource.password.value | default .Values.global.sql.datasource.password.value }}
-              {{- if $passwordValue }}
-              value: {{ $passwordValue | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ (.Values.sql).datasource.password.secretRef | default .Values.global.sql.datasource.password.secretRef }}"
-                  key: "{{ (.Values.sql).datasource.password.secretKey | default .Values.global.sql.datasource.password.secretKey }}"
-              {{- end }}
-            - name: EBEAN_DATASOURCE_HOST
-              value: "{{ .Values.global.sql.datasource.host }}"
-            - name: EBEAN_DATASOURCE_URL
-              value: "{{ .Values.global.sql.datasource.url }}"
-            - name: EBEAN_DATASOURCE_DRIVER
-              value: "{{ .Values.global.sql.datasource.driver }}"
+            {{- include "datahub.sql.connection.env" . | nindent 12 }}
+            {{- include "datahub.sql.iam.env" . | nindent 12 }}
             - name: KAFKA_BOOTSTRAP_SERVER
               value: "{{ .Values.global.kafka.bootstrap.server }}"
             {{- with .Values.global.kafka.producer.compressionType }}
@@ -237,65 +209,18 @@ spec:
               value: "{{ . }}"
             {{- end }}
             {{- end }}
-            - name: ELASTICSEARCH_HOST
-              value: "{{ .Values.global.elasticsearch.host }}"
-            - name: ELASTICSEARCH_PORT
-              value: "{{ .Values.global.elasticsearch.port }}"
-            - name: SKIP_ELASTICSEARCH_CHECK
-              value: "{{ .Values.global.elasticsearch.skipcheck }}"
-            {{- with .Values.global.elasticsearch.useSSL }}
-            - name: ELASTICSEARCH_USE_SSL
-              value: {{ . | quote }}
-            {{- end }}
-            {{- with .Values.global.elasticsearch.auth }}
-            - name: ELASTICSEARCH_USERNAME
-              value: {{ .username }}
-            - name: ELASTICSEARCH_PASSWORD
-              {{- if .password.value }}
-              value: {{ .password.value | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .password.secretRef }}"
-                  key: "{{ .password.secretKey }}"
-              {{- end }}
-            {{- end }}
-            {{- with .Values.global.elasticsearch.indexPrefix }}
-            - name: INDEX_PREFIX
-              value: {{ . }}
-            {{- end }}
-            - name: GRAPH_SERVICE_IMPL
-              value: {{ .Values.global.graph_service_impl }}
-            {{- if eq .Values.global.graph_service_impl "neo4j" }}
-            - name: NEO4J_HOST
-              value: "{{ .Values.global.neo4j.host }}"
-            - name: NEO4J_URI
-              value: "{{ .Values.global.neo4j.uri }}"
-            - name: NEO4J_DATABASE
-              value: "{{ .Values.global.neo4j.database | default "graph.db" }}"
-            - name: NEO4J_USERNAME
-              value: "{{ .Values.global.neo4j.username }}"
-            - name: NEO4J_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.global.neo4j.password.secretRef }}"
-                  key: "{{ .Values.global.neo4j.password.secretKey }}"
-            {{- end }}
-            {{- if .Values.global.springKafkaConfigurationOverrides }}
-            {{- range $configName, $configValue := .Values.global.springKafkaConfigurationOverrides }}
-            - name: SPRING_KAFKA_PROPERTIES_{{ $configName | replace "." "_" | upper }}
+            {{- include "datahub.kafka.iam.env" . | nindent 12 }}
+            {{- include "datahub.elasticsearch.connection.env" . | nindent 12 }}
+            {{- include "datahub.elasticsearch.iam.env" . | nindent 12 }}
+            {{- include "datahub.neo4j.connection.env" . | nindent 12 }}
+            {{- include "datahub.spring.kafka.overrides" . | nindent 12 }}
+            {{- if .Values.springKafkaConsumerConfigurationOverrides }}
+            {{- range $configName, $configValue := .Values.springKafkaConsumerConfigurationOverrides }}
+            - name: SPRING_KAFKA_CONSUMER_PROPERTIES_{{ $configName | replace "." "_" | upper }}
               value: {{ $configValue | quote }}
             {{- end }}
             {{- end }}
-            {{- if .Values.global.credentialsAndCertsSecrets }}
-            {{- range $envVarName, $envVarValue := .Values.global.credentialsAndCertsSecrets.secureEnv }}
-            - name: SPRING_KAFKA_PROPERTIES_{{ $envVarName | replace "." "_" | upper }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $.Values.global.credentialsAndCertsSecrets.name }}
-                  key: {{ $envVarValue }}
-            {{- end }}
-            {{- end }}
+            {{- include "datahub.spring.kafka.credentials.env" . | nindent 12 }}
             {{- with .Values.global.kafka.topics }}
             - name: METADATA_CHANGE_EVENT_NAME
               value: {{ .metadata_change_event_name }}

--- a/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.168
+version: 0.2.169
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.3.0

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -93,10 +93,6 @@ spec:
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           env:
-            - name: ELASTICSEARCH_SHIM_ENGINE_TYPE
-              value: {{ .Values.global.elasticsearch.engineType | quote }}
-            - name: ELASTICSEARCH_SHIM_AUTO_DETECT
-              value: {{ .Values.global.elasticsearch.autoDetect | quote }}
             {{- if .Values.global.basePath.enabled }}
             - name: DATAHUB_BASE_PATH
               value: {{ .Values.global.basePath.frontend | quote }}
@@ -168,50 +164,9 @@ spec:
               value: "{{ . }}"
             {{- end }}
             {{- end }}
-            - name: ELASTICSEARCH_HOST
-              value: "{{ .Values.global.elasticsearch.host }}"
-            - name: ELASTICSEARCH_PORT
-              value: "{{ .Values.global.elasticsearch.port }}"
-            - name: SKIP_ELASTICSEARCH_CHECK
-              value: "{{ .Values.global.elasticsearch.skipcheck }}"
-            {{- with .Values.global.elasticsearch.useSSL }}
-            - name: ELASTICSEARCH_USE_SSL
-              value: {{ . | quote }}
-            {{- end }}
-            {{- with .Values.global.elasticsearch.auth }}
-            - name: ELASTICSEARCH_USERNAME
-              value: {{ .username }}
-            - name: ELASTICSEARCH_PASSWORD
-              {{- if .password.value }}
-              value: {{ .password.value | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .password.secretRef }}"
-                  key: "{{ .password.secretKey }}"
-              {{- end }}
-            {{- end }}
-            {{- with .Values.global.elasticsearch.indexPrefix }}
-            - name: INDEX_PREFIX
-              value: {{ . }}
-            {{- end }}
-            - name: GRAPH_SERVICE_IMPL
-              value: {{ .Values.global.graph_service_impl }}
-            {{- if eq .Values.global.graph_service_impl "neo4j" }}
-            - name: NEO4J_HOST
-              value: "{{ .Values.global.neo4j.host }}"
-            - name: NEO4J_URI
-              value: "{{ .Values.global.neo4j.uri }}"
-            - name: NEO4J_DATABASE
-              value: "{{ .Values.global.neo4j.database | default "graph.db" }}"
-            - name: NEO4J_USERNAME
-              value: "{{ .Values.global.neo4j.username }}"
-            - name: NEO4J_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.global.neo4j.password.secretRef }}"
-                  key: "{{ .Values.global.neo4j.password.secretKey }}"
-            {{- end }}
+            {{- include "datahub.elasticsearch.connection.env" . | nindent 12 }}
+            {{- include "datahub.elasticsearch.iam.env" . | nindent 12 }}
+            {{- include "datahub.neo4j.connection.env" . | nindent 12 }}
             - name: DATAHUB_ANALYTICS_ENABLED
               value: "{{ .Values.global.datahub_analytics_enabled }}"
             {{- if .Values.global.datahub.metadata_service_authentication.enabled }}
@@ -239,21 +194,15 @@ spec:
             - name: UI_INGESTION_DEFAULT_CLI_VERSION
               value: "{{ .Values.global.datahub.managed_ingestion.defaultCliVersion }}"
             {{- end }}
-            {{- if .Values.global.springKafkaConfigurationOverrides }}
-            {{- range $configName, $configValue := .Values.global.springKafkaConfigurationOverrides }}
-            - name: SPRING_KAFKA_PROPERTIES_{{ $configName | replace "." "_" | upper }}
+            {{- include "datahub.kafka.iam.env" . | nindent 12 }}
+            {{- include "datahub.spring.kafka.overrides" . | nindent 12 }}
+            {{- if .Values.springKafkaConsumerConfigurationOverrides }}
+            {{- range $configName, $configValue := .Values.springKafkaConsumerConfigurationOverrides }}
+            - name: SPRING_KAFKA_CONSUMER_PROPERTIES_{{ $configName | replace "." "_" | upper }}
               value: {{ $configValue | quote }}
             {{- end }}
             {{- end }}
-            {{- if .Values.global.credentialsAndCertsSecrets }}
-            {{- range $envVarName, $envVarValue := .Values.global.credentialsAndCertsSecrets.secureEnv }}
-            - name: SPRING_KAFKA_PROPERTIES_{{ $envVarName | replace "." "_" | upper }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $.Values.global.credentialsAndCertsSecrets.name }}
-                  key: {{ $envVarValue }}
-            {{- end }}
-            {{- end }}
+            {{- include "datahub.spring.kafka.credentials.env" . | nindent 12 }}
             {{- with .Values.global.kafka.topics }}
             - name: METADATA_AUDIT_EVENT_NAME
               value: {{ .metadata_audit_event_name }}

--- a/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.173
+version: 0.2.174
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.3.0

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
@@ -97,10 +97,6 @@ spec:
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           env:
-            - name: ELASTICSEARCH_SHIM_ENGINE_TYPE
-              value: {{ .Values.global.elasticsearch.engineType | quote }}
-            - name: ELASTICSEARCH_SHIM_AUTO_DETECT
-              value: {{ .Values.global.elasticsearch.autoDetect | quote }}
             {{- if .Values.global.basePath.enabled }}
             - name: DATAHUB_BASE_PATH
               value: {{ .Values.global.basePath.frontend | quote }}
@@ -168,76 +164,10 @@ spec:
             {{- end }}
             - name: ENTITY_REGISTRY_CONFIG_PATH
               value: /datahub/datahub-mce-consumer/resources/entity-registry.yml
-            - name: EBEAN_DATASOURCE_USERNAME
-              {{- $usernameValue := (.Values.sql).datasource.username | default .Values.global.sql.datasource.username }}
-              {{- if and (kindIs "string" $usernameValue) $usernameValue }}
-              value: {{ $usernameValue | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ (.Values.sql).datasource.username.secretRef | default .Values.global.sql.datasource.username.secretRef }}"
-                  key: "{{ (.Values.sql).datasource.username.secretKey | default .Values.global.sql.datasource.username.secretKey }}"
-              {{- end }}
-            - name: EBEAN_DATASOURCE_PASSWORD
-              {{- $passwordValue := (.Values.sql).datasource.password.value | default .Values.global.sql.datasource.password.value }}
-              {{- if $passwordValue }}
-              value: {{ $passwordValue | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ (.Values.sql).datasource.password.secretRef | default .Values.global.sql.datasource.password.secretRef }}"
-                  key: "{{ (.Values.sql).datasource.password.secretKey | default .Values.global.sql.datasource.password.secretKey }}"
-              {{- end }}
-            - name: EBEAN_DATASOURCE_HOST
-              value: "{{ .Values.global.sql.datasource.host }}"
-            - name: EBEAN_DATASOURCE_URL
-              value: "{{ .Values.global.sql.datasource.url }}"
-            - name: EBEAN_DATASOURCE_DRIVER
-              value: "{{ .Values.global.sql.datasource.driver }}"
-            - name: ELASTICSEARCH_HOST
-              value: "{{ .Values.global.elasticsearch.host }}"
-            - name: ELASTICSEARCH_PORT
-              value: "{{ .Values.global.elasticsearch.port }}"
-            - name: SKIP_ELASTICSEARCH_CHECK
-              value: "{{ .Values.global.elasticsearch.skipcheck }}"
-            {{- with .Values.global.elasticsearch.useSSL }}
-            - name: ELASTICSEARCH_USE_SSL
-              value: {{ . | quote }}
-            {{- end }}
-            {{- with .Values.global.elasticsearch.auth }}
-            - name: ELASTICSEARCH_USERNAME
-              value: {{ .username }}
-            - name: ELASTICSEARCH_PASSWORD
-              {{- if .password.value }}
-              value: {{ .password.value | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .password.secretRef }}"
-                  key: "{{ .password.secretKey }}"
-              {{- end }}
-            {{- end }}
-            {{- with .Values.global.elasticsearch.indexPrefix }}
-            - name: INDEX_PREFIX
-              value: {{ . }}
-            {{- end }}
-            - name: GRAPH_SERVICE_IMPL
-              value: {{ .Values.global.graph_service_impl }}
-            {{- if eq .Values.global.graph_service_impl "neo4j" }}
-            - name: NEO4J_HOST
-              value: "{{ .Values.global.neo4j.host }}"
-            - name: NEO4J_URI
-              value: "{{ .Values.global.neo4j.uri }}"
-            - name: NEO4J_DATABASE
-              value: "{{ .Values.global.neo4j.database | default "graph.db" }}"
-            - name: NEO4J_USERNAME
-              value: "{{ .Values.global.neo4j.username }}"
-            - name: NEO4J_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.global.neo4j.password.secretRef }}"
-                  key: "{{ .Values.global.neo4j.password.secretKey }}"
-            {{- end }}
+            {{- include "datahub.sql.connection.env" . | nindent 12 }}
+            {{- include "datahub.elasticsearch.iam.env" . | nindent 12 }}
+            {{- include "datahub.elasticsearch.connection.env" . | nindent 12 }}
+            {{- include "datahub.sql.iam.env" . | nindent 12 }}
             {{- if .Values.global.datahub.metadata_service_authentication.enabled }}
             - name: METADATA_SERVICE_AUTH_ENABLED
               value: "true"
@@ -252,21 +182,15 @@ spec:
             - name: METADATA_SERVICE_AUTH_ENABLED
               value: "false"
             {{- end }}
-            {{- if .Values.global.springKafkaConfigurationOverrides }}
-            {{- range $configName, $configValue := .Values.global.springKafkaConfigurationOverrides }}
-            - name: SPRING_KAFKA_PROPERTIES_{{ $configName | replace "." "_" | upper }}
+            {{- include "datahub.kafka.iam.env" . | nindent 12 }}
+            {{- include "datahub.spring.kafka.overrides" . | nindent 12 }}
+            {{- if .Values.springKafkaConsumerConfigurationOverrides }}
+            {{- range $configName, $configValue := .Values.springKafkaConsumerConfigurationOverrides }}
+            - name: SPRING_KAFKA_CONSUMER_PROPERTIES_{{ $configName | replace "." "_" | upper }}
               value: {{ $configValue | quote }}
             {{- end }}
             {{- end }}
-            {{- if .Values.global.credentialsAndCertsSecrets }}
-            {{- range $envVarName, $envVarValue := .Values.global.credentialsAndCertsSecrets.secureEnv }}
-            - name: SPRING_KAFKA_PROPERTIES_{{ $envVarName | replace "." "_" | upper }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $.Values.global.credentialsAndCertsSecrets.name }}
-                  key: {{ $envVarValue }}
-            {{- end }}
-            {{- end }}
+            {{- include "datahub.spring.kafka.credentials.env" . | nindent 12 }}
             {{- with .Values.global.kafka.topics }}
             - name: METADATA_CHANGE_EVENT_NAME
               value: {{ .metadata_change_event_name }}

--- a/charts/datahub/templates/_helpers.tpl
+++ b/charts/datahub/templates/_helpers.tpl
@@ -80,3 +80,423 @@ Create image registry, name and tag for a datahub component
 {{- $registry := .image.registry | default .imageRegistry -}}
 {{ $registry }}/{{ .image.repository }}:{{ required "Global or specific tag is required" (.image.tag | default .version) -}}
 {{- end -}}
+
+{{/*
+Render template values with proper context. This is a compatibility helper
+for the common.tplvalues.render pattern used in some templates.
+If value is a string, it will be templated using the context.
+Otherwise, it will be rendered as YAML.
+*/}}
+{{- define "common.tplvalues.render" -}}
+{{- if typeIs "string" .value }}
+{{- tpl .value .context }}
+{{- else }}
+{{- .value | toYaml }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Kafka IAM environment variables for AWS MSK authentication if enabled.
+For Java/Spring-based services that use Spring Kafka.
+*/}}
+{{- define "datahub.kafka.iam.env" -}}
+{{- if .Values.global.kafka.iam.enabled -}}
+- name: SPRING_KAFKA_PROPERTIES_SASL_CLIENT_CALLBACK_HANDLER_CLASS
+  value: software.amazon.msk.auth.iam.IAMClientCallbackHandler
+- name: SPRING_KAFKA_PROPERTIES_SASL_JAAS_CONFIG
+  value: software.amazon.msk.auth.iam.IAMLoginModule required;
+- name: SPRING_KAFKA_PROPERTIES_SASL_MECHANISM
+  value: AWS_MSK_IAM
+- name: SPRING_KAFKA_PROPERTIES_SSL_PROTOCOL
+  value: TLS
+- name: SPRING_KAFKA_PROPERTIES_SECURITY_PROTOCOL
+  value: SASL_SSL
+{{- end -}}
+{{- end -}}
+
+{{/*
+OpenSearch/Elasticsearch IAM authentication environment variables for AWS OpenSearch.
+Sets OPENSEARCH_USE_AWS_IAM_AUTH=true and AWS_REGION when IAM authentication is enabled.
+This helper should be included in all services that access OpenSearch/Elasticsearch.
+Validates that Kafka and OpenSearch regions match when both are configured with IAM.
+*/}}
+{{- define "datahub.elasticsearch.iam.env" -}}
+{{- if .Values.global.elasticsearch.iam.enabled }}
+{{- if and .Values.global.elasticsearch.region .Values.global.kafka.region }}
+{{- if ne .Values.global.elasticsearch.region .Values.global.kafka.region }}
+{{- fail (printf "AWS_REGION mismatch: Kafka region (%s) differs from OpenSearch region (%s). Both must be in the same region for IAM authentication." .Values.global.kafka.region .Values.global.elasticsearch.region) }}
+{{- end }}
+{{- end }}
+- name: OPENSEARCH_USE_AWS_IAM_AUTH
+  value: "true"
+{{- if .Values.global.elasticsearch.region }}
+- name: AWS_REGION
+  value: {{ .Values.global.elasticsearch.region | quote }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+SQL IAM authentication environment variables for AWS RDS IAM authentication.
+Supports both MySQL and PostgreSQL with automatic cloud provider detection.
+Sets EBEAN_USE_IAM_AUTH=true and EBEAN_CLOUD_PROVIDER when IAM authentication is enabled.
+
+USAGE: Only include in services that DIRECTLY connect to SQL databases:
+- datahub-gms (primary SQL client)
+- datahub-mce-consumer (writes to SQL via Ebean)
+- datahub-system-update-job (database setup/migration)
+
+DO NOT include in services that only connect to GMS or Kafka (Frontend, Actions, Executor, Integrations, MAE/PE consumers).
+*/}}
+{{- define "datahub.sql.iam.env" -}}
+{{- if .Values.global.sql.iam.enabled }}
+- name: EBEAN_POSTGRES_USE_AWS_IAM_AUTH
+  value: "true"
+- name: EBEAN_USE_IAM_AUTH
+  value: "true"
+{{- if .Values.global.sql.iam.cloudProvider }}
+- name: EBEAN_CLOUD_PROVIDER
+  value: {{ .Values.global.sql.iam.cloudProvider | quote }}
+{{- else }}
+- name: EBEAN_CLOUD_PROVIDER
+  value: "auto"
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Neo4j graph database connection environment variables.
+Only sets variables if Neo4j is configured as the graph service implementation.
+
+USAGE: Include ONLY in services that DIRECTLY connect to Neo4j graph database:
+- datahub-gms (primary graph service client)
+- datahub-mae-consumer (writes graph indices)
+- datahub-system-update-job (graph migration/setup tasks)
+
+NOTE: datahub-system-update runs as a separate Kubernetes Job and needs explicit configuration.
+*/}}
+{{- define "datahub.neo4j.connection.env" -}}
+- name: GRAPH_SERVICE_IMPL
+  value: {{ $.Values.global.graph_service_impl | quote }}
+{{- if eq .Values.global.graph_service_impl "neo4j" }}
+- name: NEO4J_HOST
+  value: "{{ .Values.global.neo4j.host }}"
+- name: NEO4J_URI
+  value: "{{ .Values.global.neo4j.uri }}"
+- name: NEO4J_USERNAME
+  value: "{{ .Values.global.neo4j.username }}"
+- name: NEO4J_PASSWORD
+  {{- if .Values.global.neo4j.password.value }}
+  value: {{ .Values.global.neo4j.password.value | quote }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .Values.global.neo4j.password.secretRef }}"
+      key: "{{ .Values.global.neo4j.password.secretKey }}"
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+SQL database connection environment variables (non-IAM).
+Complements datahub.sql.iam.env with connection details and credentials.
+
+USAGE: Include in services that directly connect to SQL:
+- datahub-gms
+- datahub-mce-consumer
+- datahub-system-update-job
+
+This helper handles username/password configuration. For IAM authentication,
+also include datahub.sql.iam.env helper after this one.
+*/}}
+{{- define "datahub.sql.connection.env" -}}
+- name: EBEAN_DATASOURCE_HOST
+  value: "{{ .Values.global.sql.datasource.host }}"
+- name: EBEAN_DATASOURCE_URL
+  value: "{{ .Values.global.sql.datasource.url }}"
+- name: EBEAN_DATASOURCE_DRIVER
+  value: "{{ .Values.global.sql.datasource.driver }}"
+- name: EBEAN_DATASOURCE_USERNAME
+  {{- $usernameValue := (.Values.sql).datasource.username | default .Values.global.sql.datasource.username }}
+  {{- if and (kindIs "string" $usernameValue) $usernameValue }}
+  value: {{ $usernameValue | quote }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ (.Values.sql).datasource.username.secretRef | default .Values.global.sql.datasource.username.secretRef }}"
+      key: "{{ (.Values.sql).datasource.username.secretKey | default .Values.global.sql.datasource.username.secretKey }}"
+  {{- end }}
+{{- if not .Values.global.sql.iam.enabled }}
+- name: EBEAN_DATASOURCE_PASSWORD
+  {{- $passwordValue := (.Values.sql).datasource.password.value | default .Values.global.sql.datasource.password.value }}
+  {{- if $passwordValue }}
+  value: {{ $passwordValue | quote }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ (.Values.sql).datasource.password.secretRef | default .Values.global.sql.datasource.password.secretRef }}"
+      key: "{{ (.Values.sql).datasource.password.secretKey | default .Values.global.sql.datasource.password.secretKey }}"
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+ElasticSearch/OpenSearch connection environment variables.
+Includes host, port, SSL, credentials, and index prefix.
+
+USAGE: Include in services that directly connect to ElasticSearch/OpenSearch:
+- datahub-gms
+- datahub-mae-consumer
+- datahub-mce-consumer
+- datahub-system-update-job
+
+For IAM authentication, also include datahub.elasticsearch.iam.env helper after this one.
+
+NOTE: ELASTICSEARCH_THREAD (without _COUNT) is NOT used by the application.
+      MAE Consumer sets ELASTICSEARCH_THREAD_COUNT separately in its deployment.
+*/}}
+{{- define "datahub.elasticsearch.connection.env" -}}
+- name: ELASTICSEARCH_HOST
+  value: "{{ .Values.global.elasticsearch.host }}"
+- name: ELASTICSEARCH_PORT
+  value: "{{ .Values.global.elasticsearch.port }}"
+{{- with .Values.global.elasticsearch.implementation }}
+- name: ELASTICSEARCH_IMPLEMENTATION
+  value: {{ . | quote }}
+{{- end }}
+- name: SKIP_ELASTICSEARCH_CHECK
+  value: "{{ .Values.global.elasticsearch.skipcheck }}"
+{{- with .Values.global.elasticsearch.useSSL }}
+- name: ELASTICSEARCH_USE_SSL
+  value: {{ . | quote }}
+{{- end }}
+{{- with .Values.global.elasticsearch.auth }}
+- name: ELASTICSEARCH_USERNAME
+  value: {{ .username }}
+{{- if not $.Values.global.elasticsearch.iam.enabled }}
+- name: ELASTICSEARCH_PASSWORD
+  {{- if .password.value }}
+  value: {{ .password.value | quote }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .password.secretRef }}"
+      key: "{{ .password.secretKey }}"
+  {{- end }}
+{{- else }}
+# When IAM auth is enabled, set a dummy auth header to trigger IAM auth logic
+- name: ELASTICSEARCH_AUTH_HEADER
+  value: junk-header-to-enable-iam-auth
+{{- end }}
+{{- end }}
+{{- with .Values.global.elasticsearch.indexPrefix }}
+- name: INDEX_PREFIX
+  value: {{ . }}
+{{- end }}
+- name: ELASTICSEARCH_INSECURE
+  value: "{{ .Values.global.elasticsearch.insecure }}"
+- name: ELASTICSEARCH_SHIM_ENGINE_TYPE
+  value: {{ .Values.global.elasticsearch.engineType | quote }}
+- name: ELASTICSEARCH_SHIM_AUTO_DETECT
+  value: {{ .Values.global.elasticsearch.autoDetect | quote }}
+{{- end -}}
+
+{{/*
+Spring Kafka configuration overrides for Java services.
+Skips security.protocol and SSL keystore configs when IAM is enabled.
+
+USAGE: Include in Spring Boot services that use Spring Kafka:
+- datahub-gms (both deployment.yaml and deployment-alternatives.yaml)
+- datahub-mae-consumer
+- datahub-mce-consumer
+- datahub-pe-consumer
+- datahub-scheduler
+
+NOTE: When IAM is enabled, this helper automatically skips:
+- security.protocol (replaced by SASL_SSL from kafka.iam.env helper)
+- ssl.keystore.* configs (keystore not needed with IAM)
+- ssl.key.password (password not needed with IAM)
+But keeps ssl.truststore.* configs (still needed for TLS verification)
+*/}}
+{{- define "datahub.spring.kafka.overrides" -}}
+{{- $root := . -}}
+{{- if .Values.global.springKafkaConfigurationOverrides }}
+{{- range $configName, $configValue := .Values.global.springKafkaConfigurationOverrides }}
+{{- /* Skip security.protocol and SSL keystore when IAM is enabled (truststore still needed for TLS) */}}
+{{- $skipConfig := and $root.Values.global.kafka.iam.enabled (or (eq $configName "security.protocol") (hasPrefix "ssl.keystore" $configName) (eq $configName "ssl.key.password")) }}
+{{- if not $skipConfig }}
+- name: SPRING_KAFKA_PROPERTIES_{{ $configName | replace "." "_" | upper }}
+  value: {{ $configValue | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Kafka credentials and certs from Kubernetes secrets for Spring services.
+Skips SSL keystore configs when IAM is enabled (truststore still needed for TLS).
+
+USAGE: Include in Spring Boot services that use Spring Kafka:
+- datahub-gms (both deployment.yaml and deployment-alternatives.yaml)
+- datahub-mae-consumer
+- datahub-mce-consumer
+- datahub-pe-consumer
+- datahub-scheduler
+
+NOTE: When IAM is enabled, this helper automatically skips:
+- security.protocol (replaced by SASL_SSL from kafka.iam.env helper)
+- ssl.keystore.* configs (keystore not needed with IAM)
+- ssl.key.password and ssl.keystore.password
+But keeps ssl.truststore.* configs (still needed for TLS verification)
+*/}}
+{{- define "datahub.spring.kafka.credentials.env" -}}
+{{- $root := . -}}
+{{- if .Values.global.credentialsAndCertsSecrets }}
+{{- range $envVarName, $envVarValue := .Values.global.credentialsAndCertsSecrets.secureEnv }}
+{{- /* Skip security.protocol and SSL keystore when IAM is enabled (truststore still needed for TLS) */}}
+{{- $skipSSL := and $root.Values.global.kafka.iam.enabled (or (hasPrefix "ssl.keystore" $envVarName) ($envVarName | eq "ssl.key.password") ($envVarName | eq "ssl.keystore.password") ($envVarName | eq "ssl.keystore.location")) }}
+{{- if and (ne $envVarName "security.protocol") (not $skipSSL) }}
+- name: SPRING_KAFKA_PROPERTIES_{{ $envVarName | replace "." "_" | upper }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $root.Values.global.credentialsAndCertsSecrets.name }}
+      key: {{ $envVarValue }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Kafka credentials and certs from Kubernetes secrets for non-Spring services.
+Skips SSL keystore configs when IAM is enabled (truststore still needed for TLS).
+
+USAGE: Include in Python services and Java services that don't use Spring Kafka:
+- datahub-frontend (both deployment.yaml and deployment-alternatives.yaml)
+- acryl-datahub-actions
+- kafka-setup-job
+
+NOTE: When IAM is enabled, this helper automatically skips:
+- security.protocol (replaced by SASL_SSL from kafka.iam.env helper)
+- ssl.keystore.* configs (keystore not needed with IAM)
+- ssl.key.password and ssl.keystore.password
+But keeps ssl.truststore.* configs (still needed for TLS verification)
+*/}}
+{{- define "datahub.kafka.credentials.env" -}}
+{{- $root := . -}}
+{{- if .Values.global.credentialsAndCertsSecrets }}
+{{- range $envVarName, $envVarValue := .Values.global.credentialsAndCertsSecrets.secureEnv }}
+{{- /* Skip security.protocol and SSL keystore when IAM is enabled (truststore still needed for TLS) */}}
+{{- $skipSSL := and $root.Values.global.kafka.iam.enabled (or (hasPrefix "ssl.keystore" $envVarName) ($envVarName | eq "ssl.key.password") ($envVarName | eq "ssl.keystore.password")) }}
+{{- if and (ne $envVarName "security.protocol") (not $skipSSL) }}
+- name: KAFKA_PROPERTIES_{{ $envVarName | replace "." "_" | upper }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $root.Values.global.credentialsAndCertsSecrets.name }}
+      key: {{ $envVarValue }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Kafka configuration overrides for Java services without Spring.
+Skips security.protocol and SSL keystore configs when IAM is enabled.
+
+USAGE: Include in Java services that use Kafka:
+- datahub frontend
+
+NOTE: When IAM is enabled, this helper automatically skips:
+- security.protocol (replaced by SASL_SSL from kafka.iam.env helper)
+- ssl.keystore.* configs (keystore not needed with IAM)
+- ssl.key.password (password not needed with IAM)
+But keeps ssl.truststore.* configs (still needed for TLS verification)
+*/}}
+{{- define "datahub.kafka.overrides" -}}
+{{- $root := . -}}
+{{- if .Values.global.springKafkaConfigurationOverrides }}
+{{- range $configName, $configValue := .Values.global.springKafkaConfigurationOverrides }}
+{{- /* Skip security.protocol and SSL keystore when IAM is enabled (truststore still needed for TLS) */}}
+{{- $skipConfig := and $root.Values.global.kafka.iam.enabled (or (eq $configName "security.protocol") (hasPrefix "ssl.keystore" $configName) (eq $configName "ssl.key.password")) }}
+{{- if not $skipConfig }}
+- name: KAFKA_PROPERTIES_{{ $configName | replace "." "_" | upper }}
+  value: {{ $configValue | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Check if a Kafka property is Java-specific and should be excluded from Python services.
+Returns "true" if the property should be skipped for Python services.
+
+Java-specific properties:
+- ssl.keystore.* (Java KeyStore format)
+- ssl.truststore.* (Java TrustStore format)
+- sasl.jaas.config (Java JAAS format)
+- sasl.client.callback.handler.class (Java class)
+- sasl.login.class (Java class)
+- kafkastore.* (Schema Registry Java properties)
+*/}}
+{{- define "datahub.kafka.is-java-only" -}}
+{{- $propName := .propName -}}
+{{- $isJavaOnly := or (hasPrefix "ssl.keystore" $propName) (hasPrefix "ssl.truststore" $propName) (eq $propName "sasl.jaas.config") (eq $propName "sasl.client.callback.handler.class") (eq $propName "sasl.login.class") (hasPrefix "kafkastore" $propName) -}}
+{{- $isJavaOnly -}}
+{{- end -}}
+
+{{/*
+Python Kafka Configuration with Fallback.
+Priority: pythonKafkaConfigurationOverrides → springKafkaConfigurationOverrides (filtered)
+
+USAGE: Include in Python services (executor, integrations, actions)
+*/}}
+{{- define "datahub.python.kafka.overrides.with.fallback" -}}
+{{- $root := . -}}
+{{- if .Values.global.pythonKafkaConfigurationOverrides }}
+{{- range $configName, $configValue := .Values.global.pythonKafkaConfigurationOverrides }}
+{{- if or (ne $configName "security.protocol") (not $root.Values.global.kafka.iam.enabled) }}
+- name: KAFKA_PROPERTIES_{{ $configName | replace "." "_" | upper }}
+  value: {{ $configValue | quote }}
+{{- end }}
+{{- end }}
+{{- else if .Values.global.springKafkaConfigurationOverrides }}
+{{- range $configName, $configValue := .Values.global.springKafkaConfigurationOverrides }}
+{{- $isJavaOnly := include "datahub.kafka.is-java-only" (dict "propName" $configName) -}}
+{{- if and (ne $isJavaOnly "true") (or (ne $configName "security.protocol") (not $root.Values.global.kafka.iam.enabled)) }}
+- name: KAFKA_PROPERTIES_{{ $configName | replace "." "_" | upper }}
+  value: {{ $configValue | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Python Kafka Secrets with Fallback.
+Priority: pythonKafkaSecretsOverrides → credentialsAndCertsSecrets.secureEnv (filtered)
+
+USAGE: Include in Python services (executor, integrations, actions)
+*/}}
+{{- define "datahub.python.kafka.secrets.with.fallback" -}}
+{{- $root := . -}}
+{{- if .Values.global.pythonKafkaSecretsOverrides }}
+{{- range $envVarName, $secretConfig := .Values.global.pythonKafkaSecretsOverrides }}
+{{- if or (ne $envVarName "security.protocol") (not $root.Values.global.kafka.iam.enabled) }}
+- name: KAFKA_PROPERTIES_{{ $envVarName | replace "." "_" | upper }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretConfig.secretRef }}
+      key: {{ $secretConfig.secretKey }}
+{{- end }}
+{{- end }}
+{{- else if .Values.global.credentialsAndCertsSecrets }}
+{{- range $envVarName, $envVarValue := .Values.global.credentialsAndCertsSecrets.secureEnv }}
+{{- $isJavaOnly := include "datahub.kafka.is-java-only" (dict "propName" $envVarName) -}}
+{{- if and (ne $isJavaOnly "true") (or (ne $envVarName "security.protocol") (not $root.Values.global.kafka.iam.enabled)) }}
+- name: KAFKA_PROPERTIES_{{ $envVarName | replace "." "_" | upper }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $root.Values.global.credentialsAndCertsSecrets.name }}
+      key: {{ $envVarValue }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/datahub/templates/_iam-validation.tpl
+++ b/charts/datahub/templates/_iam-validation.tpl
@@ -1,0 +1,43 @@
+{{/*
+IAM Authentication Validation
+This template validates IAM authentication configuration and requirements.
+*/}}
+
+{{- define "datahub.validate.iam.setup" -}}
+
+{{/*
+Validate: SQL IAM authentication requires datahubSystemUpdate.sql.setup.enabled=true
+*/}}
+{{- if .Values.global.sql.iam.enabled -}}
+{{- if not .Values.datahubSystemUpdate.sql.setup.enabled -}}
+{{- fail "ERROR: datahubSystemUpdate.sql.setup.enabled must be true when global.sql.iam.enabled is true. When using IAM authentication, SQL setup must be handled by the system-update job. Please set datahubSystemUpdate.sql.setup.enabled=true." -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate: MySQL/PostgreSQL Setup Job cannot be enabled with SQL IAM authentication
+*/}}
+{{- if and .Values.global.sql.iam.enabled .Values.mysqlSetupJob.enabled -}}
+{{- fail "ERROR: mysqlSetupJob.enabled cannot be true when global.sql.iam.enabled is true. When using IAM authentication, SQL setup is handled by the system-update job via datahubSystemUpdate.sql.setup.enabled. Please set mysqlSetupJob.enabled=false." -}}
+{{- end -}}
+
+{{- if and .Values.global.sql.iam.enabled .Values.postgresqlSetupJob.enabled -}}
+{{- fail "ERROR: postgresqlSetupJob.enabled cannot be true when global.sql.iam.enabled is true. When using IAM authentication, SQL setup is handled by the system-update job via datahubSystemUpdate.sql.setup.enabled. Please set postgresqlSetupJob.enabled=false." -}}
+{{- end -}}
+
+{{/*
+Validate: Elasticsearch Setup Job cannot be enabled with OpenSearch IAM authentication
+*/}}
+{{- if and .Values.global.elasticsearch.iam.enabled .Values.elasticsearchSetupJob.enabled -}}
+{{- fail "ERROR: elasticsearchSetupJob.enabled cannot be true when global.elasticsearch.iam.enabled is true. When using IAM authentication, index setup is handled automatically by the system-update job via BuildIndices. Please set elasticsearchSetupJob.enabled=false." -}}
+{{- end -}}
+
+{{/*
+Validate: Kafka Setup Job cannot be enabled with MSK IAM authentication
+*/}}
+{{- if and .Values.global.kafka.iam.enabled .Values.kafkaSetupJob.enabled -}}
+{{- fail "ERROR: kafkaSetupJob.enabled cannot be true when global.kafka.iam.enabled is true. When using IAM authentication, Kafka topic setup is handled automatically by the system-update job via KafkaSetup. Please set kafkaSetupJob.enabled=false." -}}
+{{- end -}}
+
+{{- end -}}
+

--- a/charts/datahub/templates/datahub-auth-secrets.yml
+++ b/charts/datahub/templates/datahub-auth-secrets.yml
@@ -9,8 +9,10 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretRef }}
-  {{- with .annotations }}
   annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-11"
+  {{- with .annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: Opaque

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
@@ -1,4 +1,9 @@
 {{- if .Values.global.datahub.systemUpdate.enabled -}}
+{{/*
+Validate IAM authentication configuration
+Prevents legacy setup jobs from being enabled when IAM is configured
+*/}}
+{{- include "datahub.validate.iam.setup" . -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -32,8 +37,14 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.datahubSystemUpdate.serviceAccount }}
-      serviceAccountName: {{ . }}
+    {{- if .Values.datahubSystemUpdate.nonblocking.serviceAccount }}
+      {{- with .Values.datahubSystemUpdate.nonblocking.serviceAccount }}
+      serviceAccountName: {{ .name }}
+      {{- end }}
+    {{- else }}
+      {{- with .Values.datahubSystemUpdate.serviceAccount }}
+      serviceAccountName: {{ .name }}
+      {{- end }}
     {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -78,11 +89,142 @@ spec:
           env:
             - name: ENTITY_VERSIONING_ENABLED
               value: {{ .Values.global.datahub.entityVersioning.enabled | quote }}
-            - name: DATAHUB_REVISION
-              value: {{ .Release.Revision | quote }}
-            {{- include "datahub.upgrade.env" . | nindent 12 }}
-            - name: DATAHUB_ANALYTICS_ENABLED
-              value: {{ .Values.global.datahub_analytics_enabled | quote }}
+            - name: ENTITY_REGISTRY_CONFIG_PATH
+              value: /datahub/datahub-gms/resources/entity-registry.yml
+            - name: DATAHUB_GMS_HOST
+              value: {{ (.Values.global.datahub.gms.host | default (printf "%s-%s" .Release.Name "datahub-gms")) | trunc 63 | trimSuffix "-"}}
+            - name: DATAHUB_GMS_PORT
+              value: "{{ .Values.global.datahub.gms.port }}"
+            {{- if .Values.global.basePath.enabled }}
+            - name: DATAHUB_BASE_PATH
+              value: {{ .Values.global.basePath.frontend | quote }}
+            - name: DATAHUB_GMS_BASE_PATH
+              value: {{ .Values.global.basePath.gms | quote }}
+            {{- end }}
+            - name: DATAHUB_MAE_CONSUMER_HOST
+              value: {{ printf "%s-%s" .Release.Name "datahub-mae-consumer" }}
+            - name: DATAHUB_MAE_CONSUMER_PORT
+              value: "{{ .Values.global.datahub.mae_consumer.port }}"
+            - name: EBEAN_DATASOURCE_USERNAME
+              {{- $usernameValue := (.Values.datahubSystemUpdate.sql).username | default .Values.global.sql.datasource.username }}
+              {{- if and (kindIs "string" $usernameValue) $usernameValue }}
+              value: {{ $usernameValue | quote }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ ($usernameValue.secretRef | default .Values.global.sql.datasource.username.secretRef) | quote }}
+                  key: {{ ($usernameValue.secretKey | default .Values.global.sql.datasource.username.secretKey) | quote }}
+              {{- end }}
+            {{- if not (.Values.datahubSystemUpdate.sql.iam.enabled | default false) }}
+            - name: EBEAN_DATASOURCE_PASSWORD
+              {{- $passwordValue := (.Values.datahubSystemUpdate.sql.password).value | default .Values.global.sql.datasource.password.value }}
+              {{- if $passwordValue }}
+              value: {{ $passwordValue | quote }}
+              {{- else }}
+              {{- $passwordSecretRef := ((.Values.datahubSystemUpdate.sql.password).secretRef | default .Values.global.sql.datasource.password.secretRef) }}
+              {{- $passwordSecretKey := ((.Values.datahubSystemUpdate.sql.password).secretKey | default .Values.global.sql.datasource.password.secretKey) }}
+              {{- if and $passwordSecretRef $passwordSecretKey }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $passwordSecretRef | quote }}
+                  key: {{ $passwordSecretKey | quote }}
+              {{- end }}
+              {{- end }}
+            {{- end }}
+            - name: EBEAN_DATASOURCE_HOST
+              value: "{{ .Values.global.sql.datasource.host }}"
+            - name: EBEAN_DATASOURCE_URL
+              value: "{{ .Values.global.sql.datasource.url }}"
+            - name: EBEAN_DATASOURCE_DRIVER
+              value: "{{ .Values.global.sql.datasource.driver }}"
+            {{- if (.Values.datahubSystemUpdate.sql.iam.enabled | default false) }}
+            - name: EBEAN_POSTGRES_USE_AWS_IAM_AUTH
+              value: "true"
+            - name: EBEAN_USE_IAM_AUTH
+              value: "true"
+            {{- if .Values.global.sql.iam.cloudProvider }}
+            - name: EBEAN_CLOUD_PROVIDER
+              value: {{ .Values.global.sql.iam.cloudProvider | quote }}
+            {{- else }}
+            - name: EBEAN_CLOUD_PROVIDER
+              value: "auto"
+            {{- end }}
+            {{- end }}
+            {{- if .Values.datahubSystemUpdate.sql.setup.enabled }}
+            # Enable SQL setup within system-update job
+            # This replaces the legacy mysqlSetupJob/postgresqlSetupJob
+            - name: DATAHUB_SQL_SETUP_ENABLED
+              value: "true"
+            - name: CREATE_TABLES
+              value: {{ .Values.datahubSystemUpdate.sql.setup.createTables | default "true" | quote }}
+            - name: CREATE_DB
+              value: {{ .Values.datahubSystemUpdate.sql.setup.createDatabase | default "true" | quote }}
+            {{- if .Values.datahubSystemUpdate.sql.setup.createUser }}
+            - name: CREATE_USER
+              value: {{ .Values.datahubSystemUpdate.sql.setup.createUser | default "false" | quote }}
+            {{- $username := .Values.datahubSystemUpdate.sql.setup.createUsername | default .Values.global.sql.datasource.username }}
+            {{- if $username }}
+            - name: CREATE_USER_USERNAME
+              value: {{ $username | quote }}
+            {{- end }}
+            {{- $password := .Values.datahubSystemUpdate.sql.setup.createPassword }}
+            {{- $passwordValue := $password.value | default .Values.global.sql.datasource.password.value }}
+            {{- if $passwordValue }}
+            - name: CREATE_USER_PASSWORD
+              value: {{ $passwordValue | quote }}
+            {{- else }}
+            - name: CREATE_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ ($password.secretRef | default .Values.global.sql.datasource.password.secretRef) | quote }}
+                  key: {{ ($password.secretKey | default .Values.global.sql.datasource.password.secretKey) | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.datahubSystemUpdate.elasticsearch.setup.enabled }}
+            # Enable Elasticsearch setup within system-update job
+            # This replaces the legacy elasticsearchSetupJob
+            {{- if .Values.datahubSystemUpdate.elasticsearch.setup.createUser }}
+            - name: CREATE_USER_ES
+              value: {{ .Values.datahubSystemUpdate.elasticsearch.setup.createUser | default "false" | quote }}
+            {{- $username := .Values.datahubSystemUpdate.elasticsearch.setup.createUsername | default .Values.global.elasticsearch.auth.username }}
+            {{- if $username }}
+            - name: CREATE_USER_ES_USERNAME
+              value: {{ $username | quote }}
+            {{- end }}
+            {{- $password := .Values.datahubSystemUpdate.elasticsearch.setup.createPassword }}
+            {{- $passwordValue := $password.value | default .Values.global.elasticsearch.auth.password.value }}
+            {{- $passwordSecretRef := $password.secretRef | default .Values.global.elasticsearch.auth.password.secretRef }}
+            {{- $passwordSecretKey := $password.secretKey | default .Values.global.elasticsearch.auth.password.secretKey }}
+            {{- if or $passwordValue $passwordSecretRef }}
+            {{- if $passwordValue }}
+            - name: CREATE_USER_ES_PASSWORD
+              value: {{ $passwordValue | quote }}
+            {{- else }}
+            - name: CREATE_USER_ES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $passwordSecretRef | quote }}
+                  key: {{ $passwordSecretKey | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.datahubSystemUpdate.elasticsearch.setup.createUserIamRoleArn }}
+            - name: CREATE_USER_ES_IAM_ROLE_ARN
+              value: {{ .Values.datahubSystemUpdate.elasticsearch.setup.createUserIamRoleArn | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.global.datahub.metadata_service_authentication.enabled }}
+            - name: DATAHUB_SYSTEM_CLIENT_ID
+              value: {{ .Values.global.datahub.metadata_service_authentication.systemClientId }}
+            - name: DATAHUB_SYSTEM_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretRef }}
+                  key: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretKey }}
+            {{- end }}
+            - name: KAFKA_BOOTSTRAP_SERVER
+              value: "{{ .Values.global.kafka.bootstrap.server }}"
             {{- if eq .Values.global.kafka.schemaregistry.type "INTERNAL" }}
             - name: SCHEMA_REGISTRY_SYSTEM_UPDATE
               value: "true"
@@ -90,6 +232,185 @@ spec:
               value: "true"
             - name: SPRING_KAFKA_PROPERTIES_USE_LATEST_VERSION
               value: "true"
+            {{- end }}
+            {{- if eq .Values.global.kafka.schemaregistry.type "INTERNAL" }}
+            - name: KAFKA_SCHEMAREGISTRY_URL
+              value: {{ printf "http://%s-%s:%s%s/schema-registry/api/" .Release.Name "datahub-gms" .Values.global.datahub.gms.port (ternary .Values.global.basePath.gms "" .Values.global.basePath.enabled) }}
+            {{- else if eq .Values.global.kafka.schemaregistry.type "KAFKA" }}
+            - name: KAFKA_SCHEMAREGISTRY_URL
+              value: "{{ .Values.global.kafka.schemaregistry.url }}"
+            {{- end }}
+            - name: ELASTICSEARCH_HOST
+              value: {{ .Values.global.elasticsearch.host | quote }}
+            - name: ELASTICSEARCH_PORT
+              value: {{ .Values.global.elasticsearch.port | quote }}
+            {{- with .Values.global.elasticsearch.implementation }}
+            - name: ELASTICSEARCH_IMPLEMENTATION
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if ($.Values.datahubSystemUpdate.elasticsearch.iam.enabled | default false) }}
+            - name: OPENSEARCH_USE_AWS_IAM_AUTH
+              value: "true"
+            {{- if .Values.global.elasticsearch.region }}
+            - name: AWS_REGION
+              value: {{ .Values.global.elasticsearch.region | quote }}
+            {{- end }}
+            {{- end }}
+            - name: SKIP_ELASTICSEARCH_CHECK
+              value: {{ .Values.global.elasticsearch.skipcheck | quote }}
+            - name: ELASTICSEARCH_INSECURE
+              value: {{ .Values.global.elasticsearch.insecure | quote }}
+            {{- with .Values.global.elasticsearch.useSSL }}
+            - name: ELASTICSEARCH_USE_SSL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if .Values.datahubSystemUpdate.useAdmin }}
+            {{- with .Values.global.elasticsearch.auth }}
+            - name: ELASTICSEARCH_USERNAME
+              value: {{ $.Values.datahubSystemUpdate.elasticsearch.username | default .master_username }}
+            {{- if not ($.Values.datahubSystemUpdate.elasticsearch.iam.enabled | default false) }}
+            {{- if $.Values.datahubSystemUpdate.elasticsearch.password }}
+            - name: ELASTICSEARCH_PASSWORD
+              value: {{ $.Values.datahubSystemUpdate.elasticsearch.password | quote }}
+            {{- else if and $.Values.datahubSystemUpdate.elasticsearch.password.secretRef $.Values.datahubSystemUpdate.elasticsearch.password.secretKey }}
+            - name: ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.datahubSystemUpdate.elasticsearch.password.secretRef | quote }}
+                  key: {{ $.Values.datahubSystemUpdate.elasticsearch.password.secretKey | quote }}
+            {{- else if .master_password.value }}
+            - name: ELASTICSEARCH_PASSWORD
+              value: {{ .master_password.value | quote }}
+            {{- else if and .master_password.secretRef .master_password.secretKey }}
+            - name: ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .master_password.secretRef | quote }}
+                  key: {{ .master_password.secretKey | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- else }}
+            {{- with .Values.global.elasticsearch.auth }}
+            - name: ELASTICSEARCH_USERNAME
+              value: {{ $.Values.datahubSystemUpdate.elasticsearch.username | default .username }}
+            {{- if not ($.Values.datahubSystemUpdate.elasticsearch.iam.enabled | default false) }}
+            {{- if $.Values.datahubSystemUpdate.elasticsearch.password }}
+            - name: ELASTICSEARCH_PASSWORD
+              value: {{ $.Values.datahubSystemUpdate.elasticsearch.password | quote }}
+            {{- else if and $.Values.datahubSystemUpdate.elasticsearch.password.secretRef $.Values.datahubSystemUpdate.elasticsearch.password.secretKey }}
+            - name: ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.datahubSystemUpdate.elasticsearch.password.secretRef | quote }}
+                  key: {{ $.Values.datahubSystemUpdate.elasticsearch.password.secretKey | quote }}
+            {{- else if .password.value }}
+            - name: ELASTICSEARCH_PASSWORD
+              value: {{ .password.value | quote }}
+            {{- else if and .password.secretRef .password.secretKey }}
+            - name: ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .password.secretRef | quote }}
+                  key: {{ .password.secretKey | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.global.elasticsearch.indexPrefix }}
+            - name: INDEX_PREFIX
+              value: {{ . }}
+            {{- end }}
+            - name: GRAPH_SERVICE_IMPL
+              value: {{ .Values.global.graph_service_impl }}
+            {{- if eq .Values.global.graph_service_impl "neo4j" }}
+            - name: NEO4J_HOST
+              value: "{{ .Values.global.neo4j.host }}"
+            - name: NEO4J_URI
+              value: "{{ .Values.global.neo4j.uri }}"
+            - name: NEO4J_USERNAME
+              value: "{{ .Values.global.neo4j.username }}"
+            - name: NEO4J_PASSWORD
+              {{- if .Values.global.neo4j.password.value }}
+              value: {{ .Values.global.neo4j.password.value | quote }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.neo4j.password.secretRef }}"
+                  key: "{{ .Values.global.neo4j.password.secretKey }}"
+              {{- end }}
+            {{- end }}
+            {{- include "datahub.kafka.iam.env" . | nindent 12 }}
+            {{- if .Values.global.springKafkaConfigurationOverrides }}
+            {{- range $configName, $configValue := .Values.global.springKafkaConfigurationOverrides }}
+            {{- /* Skip security.protocol when IAM is enabled to avoid overriding SASL_SSL */}}
+            {{- if or (ne $configName "security.protocol") (not $.Values.global.kafka.iam.enabled) }}
+            - name: SPRING_KAFKA_PROPERTIES_{{ $configName | replace "." "_" | upper }}
+              value: {{ $configValue | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.global.credentialsAndCertsSecrets }}
+            {{- range $envVarName, $envVarValue := .Values.global.credentialsAndCertsSecrets.secureEnv }}
+            - name: SPRING_KAFKA_PROPERTIES_{{ $envVarName | replace "." "_" | upper }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.global.credentialsAndCertsSecrets.name }}
+                  key: {{ $envVarValue }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.global.kafka.topics }}
+            - name: METADATA_CHANGE_EVENT_NAME
+              value: {{ .metadata_change_event_name }}
+            - name: FAILED_METADATA_CHANGE_EVENT_NAME
+              value: {{ .failed_metadata_change_event_name }}
+            - name: METADATA_AUDIT_EVENT_NAME
+              value: {{ .metadata_audit_event_name }}
+            - name: METADATA_CHANGE_PROPOSAL_TOPIC_NAME
+              value: {{ .metadata_change_proposal_topic_name }}
+            - name: FAILED_METADATA_CHANGE_PROPOSAL_TOPIC_NAME
+              value: {{ .failed_metadata_change_proposal_topic_name }}
+            - name: METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME
+              value: {{ .metadata_change_log_versioned_topic_name }}
+            - name: METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME
+              value: {{ .metadata_change_log_timeseries_topic_name }}
+            - name: DATAHUB_UPGRADE_HISTORY_TOPIC_NAME
+              value: {{ .datahub_upgrade_history_topic_name }}
+            - name: PLATFORM_EVENT_TOPIC_NAME
+              value: {{ .platform_event_topic_name }}
+            - name: DATAHUB_USAGE_EVENT_NAME
+              value: {{ .datahub_usage_event_name }}
+            {{- end }}
+            {{- with .Values.global.kafka.maxMessageBytes }}
+            - name: MAX_MESSAGE_BYTES
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if or (eq .Values.global.kafka.schemaregistry.type "INTERNAL") (eq .Values.global.kafka.schemaregistry.type "AWS_GLUE") }}
+            - name: USE_CONFLUENT_SCHEMA_REGISTRY
+              value: "false"
+            {{- else if eq .Values.global.kafka.schemaregistry.type "KAFKA" }}
+            - name: USE_CONFLUENT_SCHEMA_REGISTRY
+              value: "true"
+            {{- end }}
+            {{- with .Values.global.kafka.partitions }}
+            - name: PARTITIONS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.global.kafka.replicationFactor }}
+            - name: REPLICATION_FACTOR
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.global.kafka.producer.compressionType }}
+            - name: KAFKA_PRODUCER_COMPRESSION_TYPE
+              value: "{{ . }}"
+            {{- end }}
+            {{- with .Values.global.kafka.producer.maxRequestSize }}
+            - name: KAFKA_PRODUCER_MAX_REQUEST_SIZE
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.global.kafka.consumer.maxPartitionFetchBytes }}
+            - name: KAFKA_CONSUMER_MAX_PARTITION_FETCH_BYTES
+              value: {{ . | quote }}
             {{- end }}
             {{- with .Values.global.kafka.schemaregistry.type }}
             - name: SCHEMA_REGISTRY_TYPE
@@ -103,8 +424,22 @@ spec:
               value: "{{ . }}"
             {{- end }}
             {{- end }}
+            - name: DATAHUB_REVISION
+              value: {{ .Release.Revision | quote }}
+            - name: DATAHUB_ANALYTICS_ENABLED
+              value: {{ .Values.global.datahub_analytics_enabled | quote }}
+            - name: ELASTICSEARCH_BUILD_INDICES_REINDEX_OPTIMIZATION_ENABLED
+              value: {{ .Values.global.elasticsearch.index.upgrade.reindexOptimizationEnabled | quote }}
             - name: ELASTICSEARCH_BUILD_INDICES_CLONE_INDICES
               value: {{ .Values.global.elasticsearch.index.upgrade.cloneIndices | quote }}
+            - name: ELASTICSEARCH_BUILD_INDICES_RETENTION_VALUE
+              value: {{ .Values.global.elasticsearch.index.upgrade.cloneRetentionValue | quote }}
+            - name: ELASTICSEARCH_BUILD_INDICES_RETENTION_UNIT
+              value: {{ .Values.global.elasticsearch.index.upgrade.cloneRetentionUnit | quote }}
+            - name: ELASTICSEARCH_SHIM_ENGINE_TYPE
+              value: {{ .Values.global.elasticsearch.engineType | quote }}
+            - name: ELASTICSEARCH_SHIM_AUTO_DETECT
+              value: {{ .Values.global.elasticsearch.autoDetect | quote }}
             {{- with .Values.global.elasticsearch.index.enableMappingsReindex }}
             - name: ELASTICSEARCH_INDEX_BUILDER_MAPPINGS_REINDEX
               value: {{ . | quote }}
@@ -225,8 +560,14 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.datahubSystemUpdate.serviceAccount }}
-      serviceAccountName: {{ . }}
+    {{- if .Values.datahubSystemUpdate.nonblocking.serviceAccount }}
+      {{- with .Values.datahubSystemUpdate.nonblocking.serviceAccount }}
+      serviceAccountName: {{ .name }}
+      {{- end }}
+    {{- else }}
+      {{- with .Values.datahubSystemUpdate.serviceAccount }}
+      serviceAccountName: {{ .name }}
+      {{- end }}
     {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -264,13 +605,87 @@ spec:
             - "SystemUpdateNonBlocking"
           {{- end }}
           env:
-            - name: DATAHUB_REVISION
-              value: {{ .Release.Revision | quote }}
-            {{- include "datahub.upgrade.env" . | nindent 12 }}
-            - name: DATAHUB_ANALYTICS_ENABLED
-              value: {{ .Values.global.datahub_analytics_enabled | quote }}
             - name: ENTITY_VERSIONING_ENABLED
               value: {{ .Values.global.datahub.entityVersioning.enabled | quote }}
+            - name: ENTITY_REGISTRY_CONFIG_PATH
+              value: /datahub/datahub-gms/resources/entity-registry.yml
+            - name: DATAHUB_GMS_HOST
+              value: {{ (.Values.global.datahub.gms.host | default (printf "%s-%s" .Release.Name "datahub-gms")) | trunc 63 | trimSuffix "-"}}
+            - name: DATAHUB_GMS_PORT
+              value: "{{ .Values.global.datahub.gms.port }}"
+            {{- if .Values.global.basePath.enabled }}
+            - name: DATAHUB_BASE_PATH
+              value: {{ .Values.global.basePath.frontend | quote }}
+            - name: DATAHUB_GMS_BASE_PATH
+              value: {{ .Values.global.basePath.gms | quote }}
+            {{- end }}
+            - name: DATAHUB_MAE_CONSUMER_HOST
+              value: {{ printf "%s-%s" .Release.Name "datahub-mae-consumer" }}
+            - name: DATAHUB_MAE_CONSUMER_PORT
+              value: "{{ .Values.global.datahub.mae_consumer.port }}"
+            - name: EBEAN_DATASOURCE_USERNAME
+              {{- $usernameValue := (.Values.datahubSystemUpdate.sql).username | default .Values.global.sql.datasource.username }}
+              {{- if and (kindIs "string" $usernameValue) $usernameValue }}
+              value: {{ $usernameValue | quote }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ ($usernameValue.secretRef | default .Values.global.sql.datasource.username.secretRef) | quote }}
+                  key: {{ ($usernameValue.secretKey | default .Values.global.sql.datasource.username.secretKey) | quote }}
+              {{- end }}
+            {{- $useIamAuth := .Values.global.sql.iam.enabled | default false }}
+            {{- if not $useIamAuth }}
+            - name: EBEAN_DATASOURCE_PASSWORD
+              {{- $passwordValue := (.Values.datahubSystemUpdate.sql.password).value | default .Values.global.sql.datasource.password.value }}
+              {{- if $passwordValue }}
+              value: {{ $passwordValue | quote }}
+              {{- else }}
+              {{- $passwordSecretRef := ((.Values.datahubSystemUpdate.sql.password).secretRef | default .Values.global.sql.datasource.password.secretRef) }}
+              {{- $passwordSecretKey := ((.Values.datahubSystemUpdate.sql.password).secretKey | default .Values.global.sql.datasource.password.secretKey) }}
+              {{- if and $passwordSecretRef $passwordSecretKey }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $passwordSecretRef | quote }}
+                  key: {{ $passwordSecretKey | quote }}
+              {{- end }}
+              {{- end }}
+            {{- end }}
+            - name: EBEAN_DATASOURCE_HOST
+              value: "{{ .Values.global.sql.datasource.host }}"
+            - name: EBEAN_DATASOURCE_URL
+              value: "{{ .Values.global.sql.datasource.url }}"
+            - name: EBEAN_DATASOURCE_DRIVER
+              value: "{{ .Values.global.sql.datasource.driver }}"
+            {{- if .Values.global.sql.iam.enabled }}
+            - name: EBEAN_POSTGRES_USE_AWS_IAM_AUTH
+              value: "true"
+            - name: EBEAN_USE_IAM_AUTH
+              value: "true"
+            {{- if .Values.global.sql.iam.cloudProvider }}
+            - name: EBEAN_CLOUD_PROVIDER
+              value: {{ .Values.global.sql.iam.cloudProvider | quote }}
+            {{- else }}
+            - name: EBEAN_CLOUD_PROVIDER
+              value: "auto"
+            {{- end }}
+            {{- end }}
+            {{- if .Values.global.datahub.metadata_service_authentication.enabled }}
+            - name: DATAHUB_SYSTEM_CLIENT_ID
+              value: {{ .Values.global.datahub.metadata_service_authentication.systemClientId }}
+            - name: DATAHUB_SYSTEM_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretRef }}
+                  key: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretKey }}
+            {{- end }}
+            {{- if hasKey .Values.global.kafka "zookeeper" }}
+            {{- if hasKey .Values.global.kafka.zookeeper "server" }}
+            - name: KAFKA_ZOOKEEPER_CONNECT
+              value: {{ .Values.global.kafka.zookeeper.server | quote }}
+            {{- end }}
+            {{- end }}
+            - name: KAFKA_BOOTSTRAP_SERVER
+              value: "{{ .Values.global.kafka.bootstrap.server }}"
             {{- if eq .Values.global.kafka.schemaregistry.type "INTERNAL" }}
             - name: SCHEMA_REGISTRY_SYSTEM_UPDATE
               value: "true"
@@ -278,6 +693,160 @@ spec:
               value: "true"
             - name: SPRING_KAFKA_PROPERTIES_USE_LATEST_VERSION
               value: "true"
+            {{- end }}
+            {{- if eq .Values.global.kafka.schemaregistry.type "INTERNAL" }}
+            - name: KAFKA_SCHEMAREGISTRY_URL
+              value: {{ printf "http://%s-%s:%s%s/schema-registry/api/" .Release.Name "datahub-gms" .Values.global.datahub.gms.port (ternary .Values.global.basePath.gms "" .Values.global.basePath.enabled) }}
+            {{- else if eq .Values.global.kafka.schemaregistry.type "KAFKA" }}
+            - name: KAFKA_SCHEMAREGISTRY_URL
+              value: "{{ .Values.global.kafka.schemaregistry.url }}"
+            {{- end }}
+            - name: ELASTICSEARCH_HOST
+              value: {{ .Values.global.elasticsearch.host | quote }}
+            - name: ELASTICSEARCH_PORT
+              value: {{ .Values.global.elasticsearch.port | quote }}
+            {{- with .Values.global.elasticsearch.implementation }}
+            - name: ELASTICSEARCH_IMPLEMENTATION
+              value: {{ . | quote }}
+            {{- end }}
+            {{- include "datahub.elasticsearch.iam.env" . | nindent 12 }}
+            - name: SKIP_ELASTICSEARCH_CHECK
+              value: {{ .Values.global.elasticsearch.skipcheck | quote }}
+            - name: ELASTICSEARCH_INSECURE
+              value: {{ .Values.global.elasticsearch.insecure | quote }}
+            {{- with .Values.global.elasticsearch.useSSL }}
+            - name: ELASTICSEARCH_USE_SSL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if .Values.datahubSystemUpdate.useAdmin }}
+            {{- with .Values.global.elasticsearch.auth }}
+            - name: ELASTICSEARCH_USERNAME
+              value: {{ .master_username }}
+            {{- if not ($.Values.global.elasticsearch.iam.enabled | default false) }}
+            {{- if .master_password.value }}
+            - name: ELASTICSEARCH_PASSWORD
+              value: {{ .master_password.value | quote }}
+            {{- else if and .master_password.secretRef .master_password.secretKey }}
+            - name: ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .master_password.secretRef | quote }}
+                  key: {{ .master_password.secretKey | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- else }}
+            {{- with .Values.global.elasticsearch.auth }}
+            - name: ELASTICSEARCH_USERNAME
+              value: {{ .username }}
+            {{- if not ($.Values.global.elasticsearch.iam.enabled | default false) }}
+            {{- if .password.value }}
+            - name: ELASTICSEARCH_PASSWORD
+              value: {{ .password.value | quote }}
+            {{- else if and .password.secretRef .password.secretKey }}
+            - name: ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .password.secretRef | quote }}
+                  key: {{ .password.secretKey | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.global.elasticsearch.indexPrefix }}
+            - name: INDEX_PREFIX
+              value: {{ . }}
+            {{- end }}
+            - name: GRAPH_SERVICE_IMPL
+              value: {{ .Values.global.graph_service_impl }}
+            {{- if eq .Values.global.graph_service_impl "neo4j" }}
+            - name: NEO4J_HOST
+              value: "{{ .Values.global.neo4j.host }}"
+            - name: NEO4J_URI
+              value: "{{ .Values.global.neo4j.uri }}"
+            - name: NEO4J_USERNAME
+              value: "{{ .Values.global.neo4j.username }}"
+            - name: NEO4J_PASSWORD
+              {{- if .Values.global.neo4j.password.value }}
+              value: {{ .Values.global.neo4j.password.value | quote }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.neo4j.password.secretRef }}"
+                  key: "{{ .Values.global.neo4j.password.secretKey }}"
+              {{- end }}
+            {{- end }}
+            {{- include "datahub.kafka.iam.env" . | nindent 12 }}
+            {{- if .Values.global.springKafkaConfigurationOverrides }}
+            {{- range $configName, $configValue := .Values.global.springKafkaConfigurationOverrides }}
+            {{- /* Skip security.protocol when IAM is enabled to avoid overriding SASL_SSL */}}
+            {{- if or (ne $configName "security.protocol") (not $.Values.global.kafka.iam.enabled) }}
+            - name: SPRING_KAFKA_PROPERTIES_{{ $configName | replace "." "_" | upper }}
+              value: {{ $configValue | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.global.credentialsAndCertsSecrets }}
+            {{- range $envVarName, $envVarValue := .Values.global.credentialsAndCertsSecrets.secureEnv }}
+            - name: SPRING_KAFKA_PROPERTIES_{{ $envVarName | replace "." "_" | upper }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.global.credentialsAndCertsSecrets.name }}
+                  key: {{ $envVarValue }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.global.kafka.topics }}
+            - name: METADATA_CHANGE_EVENT_NAME
+              value: {{ .metadata_change_event_name }}
+            - name: FAILED_METADATA_CHANGE_EVENT_NAME
+              value: {{ .failed_metadata_change_event_name }}
+            - name: METADATA_AUDIT_EVENT_NAME
+              value: {{ .metadata_audit_event_name }}
+            - name: METADATA_CHANGE_PROPOSAL_TOPIC_NAME
+              value: {{ .metadata_change_proposal_topic_name }}
+            - name: FAILED_METADATA_CHANGE_PROPOSAL_TOPIC_NAME
+              value: {{ .failed_metadata_change_proposal_topic_name }}
+            - name: METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME
+              value: {{ .metadata_change_log_versioned_topic_name }}
+            - name: METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME
+              value: {{ .metadata_change_log_timeseries_topic_name }}
+            - name: DATAHUB_UPGRADE_HISTORY_TOPIC_NAME
+              value: {{ .datahub_upgrade_history_topic_name }}
+            - name: PLATFORM_EVENT_TOPIC_NAME
+              value: {{ .platform_event_topic_name }}
+            - name: DATAHUB_USAGE_EVENT_NAME
+              value: {{ .datahub_usage_event_name }}
+            {{- end }}
+            {{- with .Values.global.kafka.maxMessageBytes }}
+            - name: MAX_MESSAGE_BYTES
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if or (eq .Values.global.kafka.schemaregistry.type "INTERNAL") (eq .Values.global.kafka.schemaregistry.type "AWS_GLUE") }}
+            - name: USE_CONFLUENT_SCHEMA_REGISTRY
+              value: "false"
+            {{- else if eq .Values.global.kafka.schemaregistry.type "KAFKA" }}
+            - name: USE_CONFLUENT_SCHEMA_REGISTRY
+              value: "true"
+            {{- end }}
+            {{- with .Values.global.kafka.partitions }}
+            - name: PARTITIONS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.global.kafka.replicationFactor }}
+            - name: REPLICATION_FACTOR
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.global.kafka.producer.compressionType }}
+            - name: KAFKA_PRODUCER_COMPRESSION_TYPE
+              value: "{{ . }}"
+            {{- end }}
+            {{- with .Values.global.kafka.producer.maxRequestSize }}
+            - name: KAFKA_PRODUCER_MAX_REQUEST_SIZE
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.global.kafka.consumer.maxPartitionFetchBytes }}
+            - name: KAFKA_CONSUMER_MAX_PARTITION_FETCH_BYTES
+              value: {{ . | quote }}
             {{- end }}
             {{- with .Values.global.kafka.schemaregistry.type }}
             - name: SCHEMA_REGISTRY_TYPE
@@ -291,10 +860,89 @@ spec:
               value: "{{ . }}"
             {{- end }}
             {{- end }}
+            - name: DATAHUB_REVISION
+              value: {{ .Release.Revision | quote }}
+            - name: DATAHUB_ANALYTICS_ENABLED
+              value: {{ .Values.global.datahub_analytics_enabled | quote }}
             - name: ELASTICSEARCH_BUILD_INDICES_REINDEX_OPTIMIZATION_ENABLED
               value: {{ .Values.global.elasticsearch.index.upgrade.reindexOptimizationEnabled | quote }}
             - name: ELASTICSEARCH_BUILD_INDICES_CLONE_INDICES
               value: {{ .Values.global.elasticsearch.index.upgrade.cloneIndices | quote }}
+            - name: ELASTICSEARCH_BUILD_INDICES_RETENTION_VALUE
+              value: {{ .Values.global.elasticsearch.index.upgrade.cloneRetentionValue | quote }}
+            - name: ELASTICSEARCH_BUILD_INDICES_RETENTION_UNIT
+              value: {{ .Values.global.elasticsearch.index.upgrade.cloneRetentionUnit | quote }}
+            - name: ELASTICSEARCH_SHIM_ENGINE_TYPE
+              value: {{ .Values.global.elasticsearch.engineType | quote }}
+            - name: ELASTICSEARCH_SHIM_AUTO_DETECT
+              value: {{ .Values.global.elasticsearch.autoDetect | quote }}
+            {{- with .Values.global.elasticsearch.index.enableMappingsReindex }}
+            - name: ELASTICSEARCH_INDEX_BUILDER_MAPPINGS_REINDEX
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.global.elasticsearch.index.enableSettingsReindex }}
+            - name: ELASTICSEARCH_INDEX_BUILDER_SETTINGS_REINDEX
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.global.elasticsearch.index.settingsOverrides }}
+            {{- if typeIs "map[string]interface {}" . }}
+            - name: ELASTICSEARCH_INDEX_BUILDER_SETTINGS_OVERRIDES
+              value: {{ toJson . | quote }}
+            {{- else }}
+            - name: ELASTICSEARCH_INDEX_BUILDER_SETTINGS_OVERRIDES
+              value: {{ . | quote }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.global.elasticsearch.index.entitySettingsOverrides }}
+            {{- if typeIs "map[string]interface {}" . }}
+            - name: ELASTICSEARCH_INDEX_BUILDER_ENTITY_SETTINGS_OVERRIDES
+              value: {{ toJson . | quote }}
+            {{- else }}
+            - name: ELASTICSEARCH_INDEX_BUILDER_ENTITY_SETTINGS_OVERRIDES
+              value: {{ . | quote }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.global.elasticsearch.index.refreshIntervalSeconds }}
+            - name: ELASTICSEARCH_INDEX_BUILDER_REFRESH_INTERVAL_SECONDS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.global.elasticsearch.index.upgrade.allowDocCountMismatch }}
+            - name: ELASTICSEARCH_BUILD_INDICES_ALLOW_DOC_COUNT_MISMATCH
+              value: {{ . | quote }}
+            {{- end }}
+            {{- range $k, $v := .Values.datahubSystemUpdate.bootstrapMCPs }}
+            {{- if ne $k "default" }}
+            {{- $result := dict }}
+            {{- range $.Values.datahubSystemUpdate.bootstrapMCPs.default.value_configs }}
+              {{- $funcOutput := include . $ | fromYaml }}
+              {{- $result = include "deepMerge" (dict "dst" $result "src" $funcOutput) | fromYaml }}
+            {{- end }}
+            {{- $valuesCopy := deepCopy $v.values }}
+            {{- $result = include "deepMerge" (dict "dst" $result "src" $valuesCopy) | fromYaml }}
+            {{- range $v.values_generated_configs }}
+              {{- $funcOutput := include . $ | fromYaml }}
+              {{- $result = include "deepMerge" (dict "dst" $result "src" $funcOutput) | fromYaml }}
+            {{- end }}
+            - name: {{ $v.values_env }}
+              value: {{ $result | toJson | quote }}
+            {{- with $v.revision_env }}
+            - name: {{ . }}
+              value: '{"version":"{{ $.Values.global.datahub.version }}-{{ $result | toJson | sha256sum | trunc 7 }}"}'
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            - name: ELASTICSEARCH_BUILD_INDICES_REINDEX_OPTIMIZATION_ENABLED
+              value: {{ .Values.global.elasticsearch.index.upgrade.reindexOptimizationEnabled | quote }}
+            - name: ELASTICSEARCH_BUILD_INDICES_CLONE_INDICES
+              value: {{ .Values.global.elasticsearch.index.upgrade.cloneIndices | quote }}
+            - name: ELASTICSEARCH_BUILD_INDICES_RETENTION_VALUE
+              value: {{ .Values.global.elasticsearch.index.upgrade.cloneRetentionValue | quote }}
+            - name: ELASTICSEARCH_BUILD_INDICES_RETENTION_UNIT
+              value: {{ .Values.global.elasticsearch.index.upgrade.cloneRetentionUnit | quote }}
+            - name: ELASTICSEARCH_SHIM_ENGINE_TYPE
+              value: {{ .Values.global.elasticsearch.engineType | quote }}
+            - name: ELASTICSEARCH_SHIM_AUTO_DETECT
+              value: {{ .Values.global.elasticsearch.autoDetect | quote }}
             {{- with .Values.global.elasticsearch.index.enableMappingsReindex }}
             - name: ELASTICSEARCH_INDEX_BUILDER_MAPPINGS_REINDEX
               value: {{ . | quote }}

--- a/charts/datahub/templates/datahub-upgrade/serviceaccount-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/serviceaccount-template.yml
@@ -1,0 +1,126 @@
+{{- if .Values.datahubSystemUpdate.serviceAccount }}
+{{- if .Values.datahubSystemUpdate.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.datahubSystemUpdate.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-11"
+    "helm.sh/hook-delete-policy": before-hook-creation
+{{- end }}
+
+{{- if .Values.datahubSystemUpdate.serviceAccount.rbac }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: datahub-operator-role
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-11"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+# Allow datahub-operator service account to modify deployments
+- apiGroups: ["extensions", "apps", "batch"]
+  resources: ["deployments", "deployments/scale", "deployments/status", "jobs"]
+  verbs: ["get", "list", "update", "patch", "watch"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["delete"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: datahub-operator-role-binding
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    # This resource depends on the Role and ServiceAccount in this file having been created first, hence the smaller hook-weight.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: datahub-operator-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.datahubSystemUpdate.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}
+
+{{- if and .Values.datahubSystemUpdate.nonblocking.enabled .Values.datahubSystemUpdate.nonblocking.serviceAccount }}
+{{- if .Values.datahubSystemUpdate.nonblocking.serviceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.datahubSystemUpdate.nonblocking.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-11"
+    "helm.sh/hook-delete-policy": before-hook-creation
+{{- end }}
+{{- end }}
+
+{{- if and .Values.datahubSystemUpdate.nonblocking.enabled .Values.datahubSystemUpdate.nonblocking.serviceAccount }}
+{{- if .Values.datahubSystemUpdate.nonblocking.serviceAccount.rbac }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: datahub-operator-nonblocking-role
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-11"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+# Allow datahub-operator nonblocking service account to modify deployments
+- apiGroups: ["extensions", "apps", "batch"]
+  resources: ["deployments", "deployments/scale", "deployments/status", "jobs"]
+  verbs: ["get", "list", "update", "patch", "watch"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["delete"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: datahub-operator-nonblocking-role-binding
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    # This resource depends on the Role and ServiceAccount in this file having been created first, hence the smaller hook-weight.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: datahub-operator-nonblocking-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.datahubSystemUpdate.nonblocking.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}
+

--- a/charts/datahub/values.schema.json
+++ b/charts/datahub/values.schema.json
@@ -1105,6 +1105,12 @@
     "datahubSystemUpdate": {
       "type": "object",
       "properties": {
+        "backOffLimit": {
+          "type": "number"
+        },
+        "useAdmin": {
+          "type": "boolean"
+        },
         "image": {
           "type": "object",
           "properties": {
@@ -1170,6 +1176,20 @@
               "type": "object",
               "properties": {
                 "args": {}
+              }
+            },
+            "serviceAccount": {
+              "type": "object",
+              "properties": {
+                "create": {
+                  "type": "boolean"
+                },
+                "rbac": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "type": "string"
+                }
               }
             }
           },
@@ -1363,6 +1383,103 @@
         "extraInitContainers": {
           "type": "array",
           "items": {}
+        },
+        "sql": {
+          "type": "object",
+          "properties": {
+            "iam": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              },
+              "required": ["enabled"]
+            },
+            "username": {
+              "type": "string"
+            },
+            "password": {
+              "type": "object",
+              "properties": {
+                "value": { "type": "string" },
+                "secretRef": { "type": "string" },
+                "secretKey": { "type": "string" }
+              }
+            },
+            "setup": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "createTables": { "type": "boolean" },
+                "createDatabase": { "type": "boolean" },
+                "createUser": { "type": "boolean" },
+                "createUsername": { "type": "string" },
+                "createPassword": {
+                  "type": "object",
+                  "properties": {
+                    "value": { "type": "string" },
+                    "secretRef": { "type": "string" },
+                    "secretKey": { "type": "string" }
+                  }
+                }
+              },
+              "required": [
+                "enabled",
+                "createTables",
+                "createDatabase",
+                "createUser"
+              ]
+            }
+          },
+          "required": ["iam", "setup"]
+        },
+        "elasticsearch": {
+          "type": "object",
+          "properties": {
+            "iam": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              },
+              "required": ["enabled"]
+            },
+            "username": {
+              "type": "string"
+            },
+            "password": {
+              "type": "object",
+              "properties": {
+                "value": { "type": "string" },
+                "secretRef": { "type": "string" },
+                "secretKey": { "type": "string" }
+              }
+            },
+            "setup": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "createUser": { "type": "boolean" },
+                "createUserIamRoleArn": { "type": "string" },
+                "createUsername": { "type": "string" },
+                "createPassword": {
+                  "type": "object",
+                  "properties": {
+                    "value": { "type": "string" },
+                    "secretRef": { "type": "string" },
+                    "secretKey": { "type": "string" }
+                  }
+                }
+              },
+              "required": [
+                "enabled",
+                "createUser"
+              ]
+            }
+          },
+          "required": ["iam", "setup"]
         }
       },
       "required": [
@@ -1549,6 +1666,18 @@
                 "enableSettingsReindex",
                 "upgrade"
               ]
+            },
+            "iam": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              },
+              "required": ["enabled"]
+            },
+            "region": {
+              "type": "string"
             },
             "search": {
               "type": "object",
@@ -2033,6 +2162,18 @@
                 "stopContainerOnDeserializationError"
               ]
             },
+            "iam": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "awsRegion": {
+                  "type": "string"
+                }
+              },
+              "required": ["enabled"]
+            },
             "schemaregistry": {
               "type": "object",
               "properties": {
@@ -2160,6 +2301,18 @@
                 "username",
                 "password"
               ]
+            },
+            "iam": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "cloudProvider": {
+                  "type": "string"
+                }
+              },
+              "required": ["enabled"]
             }
           },
           "required": [

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -442,11 +442,70 @@ datahubSystemUpdate:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-4"
     helm.sh/hook-delete-policy: before-hook-creation
+  # increase from default of 6
+  backOffLimit: 15
+  useAdmin: true
+  # Authentication configuration for system-update job
+  # Allows system-update to use different auth than the main application
+  sql:
+    # Override IAM authentication for Ebean (SQL)
+    iam:
+      # Initial bootstrap, no iam
+      enabled: false
+    # Override Ebean credentials (defaults to global.sql.datasource)
+    # username: "override-username"
+    # password:
+    #   value: "override-password"
+    #   secretRef: "override-secret-name"
+    #   secretKey: "override-secret-key"
+    # SQL setup within system-update job
+    # REQUIRED when global.sql.iam.enabled=true
+    setup:
+      enabled: false  # Replaces the legacy mysqlSetupJob/postgresqlSetupJob
+      createTables: true     # CREATE_TABLES env var - create DataHub tables
+      createDatabase: true   # CREATE_DB env var - create DataHub database
+      createUser: false      # CREATE_USER env var - create database user
+      # Optional: Override username/password for new user being created (defaults to global.sql.datasource)
+      # createUsername: "custom-setup-user"
+      # createPassword:
+      #   value: "password"
+      #   secretRef: "secret-name"
+      #   secretKey: "password-key"
+      # Environment variables generated when createUser=true: CREATE_USER_USERNAME, CREATE_USER_PASSWORD
+  elasticsearch:
+    # Override IAM authentication for Elasticsearch
+    iam:
+      # Initial bootstrap, no iam
+      enabled: false
+    # Override Elasticsearch credentials (defaults to global.elasticsearch.auth)
+    # username: "override-username"
+    # password:
+    #   value: "override-password"
+    #   secretRef: "override-secret-name"
+    #   secretKey: "override-secret-key"
+    # Elasticsearch setup within system-update job
+    setup:
+      enabled: false            # Enable Elasticsearch user creation
+      createUser: false         # CREATE_USER_ES env var - create Elasticsearch user
+      createUserIamRoleArn: ""  # CREATE_USER_ES_IAM_ROLE_ARN env var - IAM role ARN to map to the user (only if createUser=true)
+      # Optional: Override username/password for the new user being created (defaults to global.elasticsearch.auth)
+      # createUsername: "datahub-user"
+      # createPassword:
+      #   value: "password"
+      #   secretRef: "secret-name"
+      #   secretKey: "password-key"
+      # Environment variables generated: CREATE_USER_ES_USERNAME, CREATE_USER_ES_PASSWORD, CREATE_USER_ES_IAM_ROLE_ARN
   # !! Requires version v0.13.0 or greater
   # Split the system update into 2 jobs, one that is blocking the rest of
   # the deployment and the other which is non-blocking. Once the blocking
   # steps are completed, the non-blocking job runs while the rest of the
   # system is starting.
+  # Optional: Service account configuration for the blocking system-update job
+  # If not specified, defaults to the namespace's default service account
+  # serviceAccount:
+  #   create: true
+  #   rbac: true
+  #   name: datahub-operator-sa
   nonblocking:
     enabled: true
     # Custom labels to add to the nonblocking Job metadata
@@ -457,6 +516,12 @@ datahubSystemUpdate:
       # job is considered part of the release.
       helm.sh/hook: post-install,post-upgrade
       helm.sh/hook-delete-policy: before-hook-creation
+    # Optional: Override service account for the non-blocking job
+    # If not specified, defaults to datahubSystemUpdate.serviceAccount
+    # serviceAccount:
+    #   create: true
+    #   rbac: true
+    #   name: datahub-operator-sa-nonblocking
     image:
       args:
       # Add custom command / arguments to this job.  Useful if you need a custom startup or shutdown script
@@ -603,6 +668,15 @@ global:
     engineType: "AUTO_DETECT"
     autoDetect: "true"
 
+    # AWS IAM authentication for OpenSearch
+    # When enabled, DataHub will use AWS IAM credentials instead of username/password
+    # Requires proper IAM roles and policies to be configured
+    iam:
+      enabled: false  # Sets OPENSEARCH_USE_AWS_IAM_AUTH
+    # AWS region for OpenSearch (required when iam.enabled is true)
+    # Example: "us-west-2"
+    region: ""
+
     # Authentication
     # auth:
       # username: "elastic"
@@ -651,6 +725,8 @@ global:
         ## When reindexing is required, this option will clone the existing index as a backup
         ## The clone indices are not currently managed.
         cloneIndices: true
+        cloneRetentionValue: 7
+        cloneRetentionUnit: DAYS
 
         ## Typically when reindexing the document counts between the original and destination indices should match.
         ## In some cases reindexing might not be able to proceed due to incompatibilities between a document in the
@@ -758,6 +834,14 @@ global:
       server: "prerequisites-kafka:9092"
     zookeeper:
       server: "prerequisites-zookeeper:2181"
+    # AWS IAM authentication for MSK
+    # When enabled, DataHub will use AWS IAM credentials instead of username/password
+    # Applies to all components that use Kafka (both Java/Spring and Python services).
+    iam:
+      enabled: false  # Sets SPRING_KAFKA_PROPERTIES_SASL_* environment variables for Java services
+      # AWS region for Kafka/MSK (optional, will be auto-detected if not specified)
+      # Example: "us-west-2"
+      awsRegion: ""
     # This section defines the names for the kafka topics that DataHub depends on, at a global level. Do not override this config
     # at a sub-chart level.
     topics:
@@ -884,6 +968,13 @@ global:
       #   secretKey: mysql-root-password
       # --------------OR----------------
       #   value: password
+
+    # IAM authentication for SQL databases (supports both MySQL and PostgreSQL)
+    # When enabled, DataHub will use IAM credentials instead of username/password
+    # Requires proper IAM roles and policies to be configured
+    iam:
+      enabled: false  # Sets EBEAN_USE_IAM_AUTH and EBEAN_POSTGRES_USE_AWS_IAM_AUTH
+      cloudProvider: "auto"  # Cloud provider: "auto" (detect), "aws", or "gcp"
 
   datahub:
     version: v1.3.0


### PR DESCRIPTION
# PR Summary: IAM Setup Updates

## Overview
The changes include AWS MSK (Kafka) IAM authentication, AWS OpenSearch/Elasticsearch IAM authentication, SQL IAM authentication, and enhanced system-update job functionality with proper hook ordering.

## Key Changes

### IAM Helper Template Definitions
Added Helm template helpers across all subcharts and main chart templates to support IAM authentication:

- **Main Chart (`templates/_helpers.tpl`):**
  - Added `datahub.kafka.iam.env` helper for Java/Spring services
  - Added `datahub.elasticsearch.iam.env` helper for OpenSearch IAM

### Deployment Template Updates
Updated deployment templates to conditionally include IAM environment variables and filter conflicting Kafka security properties:

- **Java/Spring Services** (`datahub-frontend`, `datahub-gms`, `datahub-mae-consumer`, `datahub-mce-consumer`):
  - Added `{{- include "datahub.kafka.iam.env" . total}}` for Kafka IAM support
  - Added `{{- include "datahub.elasticsearch.iam.env" . }}` for Elasticsearch IAM support
  - Wrapped Kafka security protocol overrides to skip when IAM is enabled
  - Added conditional SQL password handling for IAM authentication

- **Python Services** (`acryl-datahub-actions`):
  - Added `{{- include "datahub.kafka.iam.python.env" . }}` with OAuth callback
  - Added `{{- include "datahub.elasticsearch.iam.env" . }}` for Elasticsearch IAM
  - Added `KAFKA_PROPERTIES_OAUTH_CB` environment variable

### System Update Job Enhancements
Comprehensive refactoring of `datahub-system-update-job.yml`:

- **IAM Validation (`templates/_iam-validation.tpl`):**
  - Created new validation template to ensure IAM setup consistency
  - Validates SQL IAM requires system-update SQL setup to be enabled
  - Prevents legacy setup jobs when IAM is enabled (MySQL/PostgreSQL, Elasticsearch, Kafka setup jobs)

- **System Update Job Template:**
  - Added IAM validation at the top of the template
  - Replaced `include "datahub.upgrade.env"` with inline environment variable definitions
  - Added SQL IAM environment variables (`EBEAN_POSTGRES_USE_AWS_IAM_AUTH`, `EBEAN_USE_IAM_AUTH`, `EBEAN_CLOUD_PROVIDER`)
  - Added Elasticsearch IAM environment variables
  - Added Kafka IAM filtering for Spring Kafka configuration overrides
  - Added SQL and Elasticsearch setup configuration support within the blocking job
  - Enhanced non-blocking job with proper environment variable inheritance
  - Added service account name override support

### Secret Template Fixes
Fixed `datahub-auth-secrets.yml`:

- **Critical Fix:** Added Helm hook annotations (`helm.sh/hook: pre-install,pre-upgrade` with `hook-weight: -11`)
- Ensures secret is created before system-update job (hook-weight: -4) runs
- Prevents `CreateContainerConfigError` when system-update job tries to reference the secret

## Technical Details

### IAM Helpers Structure

#### Kafka IAM Helper for Java (`datahub.kafka.iam.env`)
Sets Spring Kafka properties for AWS MSK IAM authentication:
- `SPRING_KAFKA_PROPERTIES_SASL_CLIENT_CALLBACK_HANDLER_CLASS`
- `SPRING_KAFKA_PROPERTIES_SASL_JAAS_CONFIG`
- `SPRING_KAFKA_PROPERTIES_SASL_MECHANISM: AWS_MSK_IAM`
- `SPRING_KAFKA_PROPERTIES_SSL_PROTOそもCOL: TLS`
- `SPRING_KAFKA_PROPERTIES_SECURITY_PROTOCOL: SASL_SSL`

#### Kafka IAM Helper for Python (`datahub.kafka.iam.python.env`)
Sets Python Kafka properties for AWS MSK IAM authentication using OAUTHBEARER:
- `AWS_REGION` (if configured)
- `KAFKA_PROPERTIES_SECURITY_PROTOCOL: SASL_SSL`
- `KAFKA_PROPERTIES_SASL_MECHANISM: OAUTHBEARER`
- `KAFKA_PROPERTIES_SASL_OAUTHBEARER_METHOD: default`

#### Elasticsearch IAM Helper (`datahub.elasticsearch.iam.env`)
Sets OpenSearch/Elasticsearch IAM authentication:
- `OPENSEARCH_USE_AWS_IAM_AUTH: true`
- `AWS_REGION` (when region is configured)
- Validates Kafka and OpenSearch regions match when both use IAM

### Hook Weight Ordering
Critical fix for secret creation timing:
- `datahub-auth-secrets` hook-weight: `-11` (runs first)
- `system-update` job hook-weight: `-4` (runs after secrets are created)
- This ensures secrets exist before jobs that reference them start

### SQL IAM Support
- Conditional password handling: `EBEAN_DATASOURCE_PASSWORD` only set when IAM is disabled
- Support for PostgreSQL and MySQL IAM authentication
- Cloud provider auto-detection support (`cloudProvider: "auto"`)

## Testing
- ✅ Helm chart successfully renders with default values
- ✅ Helm chart successfully renders with IAM enabled
- ✅ Helm lint passes with 0 failures
- ✅ All template helpers are properly defined and accessible
- ✅ No undefined template references
- ✅ Prerequisites chart installs successfully
- ✅ DataHub chart installs successfully with test values
- ✅ All pods start and run without errors
- ✅ System-update job completes successfully
- ✅ Secret creation timing fixed (no more CreateContainerConfigError)

## Impact
- **Breaking Changes**: None
- **New Features**: 
  - Comprehensive AWS IAM authentication support for Kafka, Elasticsearch, and SQL
  - Enhanced system-update job with SQL and Elasticsearch setup capabilities
  - Optional service account configuration
- **Bug Fixes**: 
  - Fixed missing secret creation causing system-update job failures
  - Fixed nil pointer errors in service account template
  - Fixed missing template helper definitions
- **Documentation**: Comprehensive IAM setup documentation added to values.yaml

