### PR TITLE
fix(validation): Make content in securityContext and podSecurityConte…

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.8.3
+version: 0.8.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/values.schema.json
+++ b/charts/datahub/values.schema.json
@@ -59,7 +59,7 @@
         "extraInitContainers",
         "jvmOpts"
       ]
-    },       
+    },
     "datahub-gms": {
       "type": "object",
       "properties": {
@@ -518,25 +518,13 @@
         },
         "podSecurityContext": {
           "type": "object",
-          "properties": {
-            "fsGroup": {
-              "type": "number"
-            }
-          },
-          "required": [
-            "fsGroup"
-          ]
+          "properties": {},
+          "required": []
         },
         "securityContext": {
           "type": "object",
-          "properties": {
-            "runAsUser": {
-              "type": "number"
-            }
-          },
-          "required": [
-            "runAsUser"
-          ]
+          "properties": {},
+          "required": []
         },
         "annotations": {
           "type": "object",
@@ -641,25 +629,13 @@
         },
         "podSecurityContext": {
           "type": "object",
-          "properties": {
-            "fsGroup": {
-              "type": "number"
-            }
-          },
-          "required": [
-            "fsGroup"
-          ]
+          "properties": {},
+          "required": []
         },
         "securityContext": {
           "type": "object",
-          "properties": {
-            "runAsUser": {
-              "type": "number"
-            }
-          },
-          "required": [
-            "runAsUser"
-          ]
+          "properties": {},
+          "required": []
         },
         "annotations": {
           "type": "object",
@@ -764,25 +740,13 @@
         },
         "podSecurityContext": {
           "type": "object",
-          "properties": {
-            "fsGroup": {
-              "type": "number"
-            }
-          },
-          "required": [
-            "fsGroup"
-          ]
+          "properties": {},
+          "required": []
         },
         "securityContext": {
           "type": "object",
-          "properties": {
-            "runAsUser": {
-              "type": "number"
-            }
-          },
-          "required": [
-            "runAsUser"
-          ]
+          "properties": {},
+          "required": []
         },
         "annotations": {
           "type": "object",
@@ -887,25 +851,13 @@
         },
         "podSecurityContext": {
           "type": "object",
-          "properties": {
-            "fsGroup": {
-              "type": "number"
-            }
-          },
-          "required": [
-            "fsGroup"
-          ]
+          "properties": {},
+          "required": []
         },
         "securityContext": {
           "type": "object",
-          "properties": {
-            "runAsUser": {
-              "type": "number"
-            }
-          },
-          "required": [
-            "runAsUser"
-          ]
+          "properties": {},
+          "required": []
         },
         "annotations": {
           "type": "object",


### PR DESCRIPTION
…xt optional

In some Kubernetes clusters, like Openshift, it is better to not specify anything in securityContext
as the defaults are a lot more strict, than what you get by setting runAsUser and fsGroup.


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema-only change; main impact is Helm values validation becomes less strict and could allow misconfigured contexts to pass without early errors.
> 
> **Overview**
> Relaxes Helm values validation for multiple jobs/components by making `podSecurityContext` and `securityContext` accept empty objects (removing required `fsGroup` / `runAsUser` fields), improving compatibility with platforms like OpenShift.
> 
> Bumps the `datahub` chart version from `0.8.9` to `0.8.10`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0394d7b27940fd1592488ae7e996a817652c3f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->