### PR TITLE
fix(datahub-frontend): Fix render failure when HPA is enabled

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.8.3
+version: 0.8.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
@@ -15,7 +15,7 @@ dependencies:
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.3.0
+    version: 0.3.1
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.0
+version: 0.3.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.3.0

--- a/charts/datahub/subcharts/datahub-frontend/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-frontend/templates/_helpers.tpl
@@ -75,6 +75,17 @@ Return the appropriate apiVersion for ingress.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Return the appropriate apiVersion for HorizontalPodAutoscaler.
+*/}}
+{{- define "datahub-frontend.hpa.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "autoscaling/v2") (semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version) -}}
+    {{- print "autoscaling/v2" -}}
+  {{- else -}}
+    {{- print "autoscaling/v2beta1" -}}
+  {{- end -}}
+{{- end -}}
+
 {{- define "acryl.debug" -}}
 {{- if .Values.debug.enabled -}}
   {{- if .Values.debug.suspend -}}


### PR DESCRIPTION
Running `helm template datahub ./charts/datahub` with `datahub-frontend.hpa.enabled` gives error because helper function `datahub-frontend.hpa.apiVersion` was removed in the #643


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)  #644 
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Helm-template-only change plus version bumps; main risk is HPA apiVersion selection across Kubernetes versions.
> 
> **Overview**
> Fixes a Helm rendering failure when `datahub-frontend.hpa.enabled` is set by reintroducing the `datahub-frontend.hpa.apiVersion` helper used by `templates/hpa.yaml`, selecting `autoscaling/v2` on k8s >=1.23 when available and falling back to `autoscaling/v2beta1`.
> 
> Bumps chart versions: root `datahub` chart to `0.8.4`, `datahub-frontend` subchart to `0.3.1`, and updates the root chart dependency to reference `datahub-frontend` `0.3.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3acd9db48a3da38969b5d2173db66543cbb79f07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->