### PR TITLE
fix(datahub-gms): Fix render failure when HPA is enabled

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,14 +4,14 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.8.4
+version: 0.8.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.4.0
 dependencies:
   - name: datahub-gms
-    version: 0.3.1
+    version: 0.3.2
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.1
+version: 0.3.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.3.0

--- a/charts/datahub/subcharts/datahub-gms/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-gms/templates/_helpers.tpl
@@ -76,6 +76,17 @@ Return the appropriate apiVersion for ingress.
 {{- end -}}
 
 {{/*
+Return the appropriate apiVersion for HorizontalPodAutoscaler.
+*/}}
+{{- define "datahub-gms.hpa.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "autoscaling/v2") (semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version) -}}
+    {{- print "autoscaling/v2" -}}
+  {{- else -}}
+    {{- print "autoscaling/v2beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Create the jvm debug flag
 */}}
 {{- define "acryl.debug" -}}


### PR DESCRIPTION
Running helm template datahub ./charts/datahub with datahub-gms.hpa.enabled gives error because helper function datahub-gms.hpa.apiVersion was removed in the https://github.com/acryldata/datahub-helm/pull/643

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Helm-template change plus version bumps; behavior is limited to which HPA API version is rendered based on cluster capabilities.
> 
> **Overview**
> Fixes a Helm rendering failure when `datahub-gms.hpa.enabled` by reintroducing the `datahub-gms.hpa.apiVersion` helper used by the HPA template, selecting `autoscaling/v2` on newer clusters and falling back to `autoscaling/v2beta1` otherwise.
> 
> Bumps the root `datahub` chart version to `0.8.5` and the `datahub-gms` subchart (and dependency pin) to `0.3.2` to publish the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07ef90f99ee5a9c733670b177af93e9d2c3f3c51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->