### PR TITLE
Add support for custom annotations in missing Deployment templates

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,18 +4,18 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.8.10
+version: 0.8.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.4.0.3
 dependencies:
   - name: datahub-gms
-    version: 0.3.3
+    version: 0.3.4
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.3.1
+    version: 0.3.2
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer
@@ -31,7 +31,7 @@ dependencies:
     repository: file://./subcharts/datahub-ingestion-cron
     condition: datahub-ingestion-cron.enabled
   - name: acryl-datahub-actions
-    version: 0.3.1
+    version: 0.3.2
     repository: file://./subcharts/acryl-datahub-actions
     condition: acryl-datahub-actions.enabled
 maintainers:

--- a/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.1
+version: 0.3.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.1.1

--- a/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
     {{- range $key, $val := .Values.extraLabels }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/datahub/subcharts/acryl-datahub-actions/values.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/values.yaml
@@ -30,6 +30,8 @@ serviceMonitor:
   create: false
   extraLabels: {}
 
+annotations: {}
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.1
+version: 0.3.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.3.0

--- a/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
     {{- range $key, $val := .Values.extraLabels }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}

--- a/charts/datahub/subcharts/datahub-frontend/values.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/values.yaml
@@ -51,6 +51,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+annotations: {}
+
 podAnnotations: {}
   # co.elastic.logs/enabled: "true"
 

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.3
+version: 0.3.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.3.0

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
     {{- range $key, $val := .Values.extraLabels }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if and (.Values.global.strict_mode) (gt (.Values.replicaCount | int) 1) (.Values.global.datahub.managed_ingestion.enabled) (not .Values.global.datahub_standalone_consumers_enabled)}}
   {{- fail "\nManaged ingestion can not be used with multiple GMS instances in non standalone mode. Please enable standalone mode with only 1 MCE replica if you wish to run multiple GMS instances and managed ingestion." }}

--- a/charts/datahub/subcharts/datahub-gms/values.yaml
+++ b/charts/datahub/subcharts/datahub-gms/values.yaml
@@ -48,6 +48,8 @@ serviceMonitor:
   create: false
   extraLabels: {}
 
+annotations: {}
+
 podAnnotations: {}
   # co.elastic.logs/enabled: "true"
 


### PR DESCRIPTION

## Description

This PR adds support for custom `annotations` in specific Deployment templates where this capability was previously missing.

When using this Helm chart as a dependency within a custom Helm chart, there is a need to orchestrate the deployment order of certain components. This can be achieved either through:

* Helm hooks (e.g., `helm.sh/hook`)
* Argo CD sync waves (e.g., `argocd.argoproj.io/sync-wave`)

While most components in the chart already support custom annotations, this functionality was not available in the following Deployment templates:

* `charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml`
* `charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml`
* `charts/datahub/subcharts/datahub-gms/templates/deployment.yaml`

This PR introduces annotation support in these three Deployments to ensure consistency across all components and enable advanced orchestration use cases.

---

## Changes

* Added support for configurable custom annotations in:

  * `acryl-datahub-actions` Deployment
  * `datahub-frontend` Deployment
  * `datahub-gms` Deployment
* Aligned behavior with other components that already expose annotation configuration.

---

## Motivation

Including this chart as a dependency in higher-level Helm charts may require fine-grained orchestration of resource creation. Enabling custom annotations allows users to:

* Control resource lifecycle using Helm hooks
* Define deployment ordering using Argo CD sync waves
* Maintain consistency across all DataHub components

---

## Testing

* Verified that annotations are correctly rendered when specified in `values.yaml`.
* Confirmed no changes in behavior when annotations are not provided.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm templating change that only adds optional metadata annotations and bumps chart versions; main risk is unintended annotation rendering/indentation affecting manifests when values are provided.
> 
> **Overview**
> Adds support for user-specified `annotations` on the `Deployment` resources for `datahub-gms`, `datahub-frontend`, and `acryl-datahub-actions`, enabling orchestration via hooks/sync-waves without relying on pod annotations.
> 
> Bumps the parent `datahub` chart version and increments the three affected subchart versions, and exposes a new top-level `annotations: {}` value in each subchart `values.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf11715b1216b1d5757f5f80372369350cbb3489. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->