### PR TITLE
feat(datahub-gms): Add support for additional ports and disabling loadbalancer node ports

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,14 +4,14 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.8.8
+version: 0.8.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.4.0.3
 dependencies:
   - name: datahub-gms
-    version: 0.3.2
+    version: 0.3.3
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.2
+version: 0.3.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.3.0

--- a/charts/datahub/subcharts/datahub-gms/templates/service.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/service.yaml
@@ -10,6 +10,11 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+{{- if eq .Values.service.type "LoadBalancer" }}
+  {{- if hasKey .Values.service "allocateLoadBalancerNodePorts" }}
+  allocateLoadBalancerNodePorts: {{ .Values.service.allocateLoadBalancerNodePorts }}
+  {{- end }}
+{{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}
@@ -26,6 +31,9 @@ spec:
       targetPort: {{ .Values.global.datahub.monitoring.portName }}
       protocol: TCP
     {{- end }}
+    {{- if .Values.service.additionalPorts }}
+    {{- toYaml .Values.service.additionalPorts | nindent 4 }}
+    {{- end}}
   {{- if and (eq .Values.service.type "LoadBalancer") (.Values.service.loadBalancerClass) }}
   loadBalancerClass: {{ .Values.service.loadBalancerClass }}
   {{- end }}

--- a/charts/datahub/subcharts/datahub-gms/values.yaml
+++ b/charts/datahub/subcharts/datahub-gms/values.yaml
@@ -66,6 +66,10 @@ priorityClassName:
 
 service:
   type: LoadBalancer # ClusterIP or NodePort
+  # Defines if NodePorts will be automatically allocated for services 
+  # with type LoadBalancer. It may be set to "false" if the cluster load-balancer 
+  # does not rely on NodePorts.
+  # allocateLoadBalancerNodePorts: true
   port: "8080"
   targetPort: http
   protocol: TCP
@@ -74,6 +78,12 @@ service:
   # Internal load balancer or various other annotation support in AWS
   annotations: {}
     # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+  # Additional ports to be added to the datahub-gms service
+  additionalPorts: []
+    # - name: https
+    #   port: 443
+    #   targetPort: 8080
+    #   protocol: TCP
 
 ingress:
   # className: ""


### PR DESCRIPTION
This issue came about when we attempted to expose the datahub-gms service over AWS PrivateLink and we realized we couldn't add an additional listener to the LB

- adds support for specifying additional ports on the `datahub-gms` service
- allows enabling/disabling the `allocateLoadBalancerNodePorts` property on a LoadBalancer service

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Helm templating-only changes that affect the rendered Kubernetes `Service` spec; risk is limited to misconfiguration leading to unexpected ports/LoadBalancer behavior during deployment.
> 
> **Overview**
> Adds new `datahub-gms.service` Helm values to (1) append arbitrary `additionalPorts` entries onto the generated Kubernetes `Service` and (2) optionally set `allocateLoadBalancerNodePorts` when `service.type=LoadBalancer`.
> 
> Bumps chart versions (`datahub` `0.8.9`, `datahub-gms` `0.3.3`) and updates the parent chart dependency to pull the new `datahub-gms` subchart version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc1a6cc66937d003f4ef3d39ebdae224b04e0a54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->