### PR TITLE
feat(system-update): add missing configuration for setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.tgz
 .vscode
 .idea
+.DS_Store

--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.8.11
+version: 0.8.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/VALUES_REFERENCE.md
+++ b/charts/datahub/VALUES_REFERENCE.md
@@ -2065,6 +2065,96 @@ This document provides a comprehensive reference for every single configurable v
 <td><code>2Gi</code></td>
 <td>Memory request for system update job.</td>
 </tr>
+<tr>
+<td><code>datahubSystemUpdate.sql.setup.enabled</code></td>
+<td>boolean</td>
+<td><code>false</code></td>
+<td>Enable SQL setup within system-update job. Replaces the legacy <code>mysqlSetupJob</code> and <code>postgresqlSetupJob</code>. REQUIRED when <code>global.sql.iam.enabled=true</code>.</td>
+</tr>
+<tr>
+<td><code>datahubSystemUpdate.sql.setup.createTables</code></td>
+<td>boolean</td>
+<td><code>true</code></td>
+<td>Create DataHub tables (CREATE_TABLES env var).</td>
+</tr>
+<tr>
+<td><code>datahubSystemUpdate.sql.setup.createDatabase</code></td>
+<td>boolean</td>
+<td><code>true</code></td>
+<td>Create DataHub database (CREATE_DB env var).</td>
+</tr>
+<tr>
+<td><code>datahubSystemUpdate.sql.setup.createUser</code></td>
+<td>boolean</td>
+<td><code>false</code></td>
+<td>Create database user (CREATE_USER env var).</td>
+</tr>
+<tr>
+<td><code>datahubSystemUpdate.sql.setup.createUsername</code></td>
+<td>string</td>
+<td>-</td>
+<td>Username for the new user being created (CREATE_USER_USERNAME env var). Defaults to <code>global.sql.datasource.username</code>.</td>
+</tr>
+<tr>
+<td><code>datahubSystemUpdate.sql.setup.createPassword.value</code></td>
+<td>string</td>
+<td>-</td>
+<td>Password value for the new user. Defaults to <code>global.sql.datasource.password.value</code>.</td>
+</tr>
+<tr>
+<td><code>datahubSystemUpdate.sql.setup.createPassword.secretRef</code></td>
+<td>string</td>
+<td>-</td>
+<td>Secret reference for the new user password. Defaults to <code>global.sql.datasource.password.secretRef</code>.</td>
+</tr>
+<tr>
+<td><code>datahubSystemUpdate.sql.setup.createPassword.secretKey</code></td>
+<td>string</td>
+<td>-</td>
+<td>Secret key for the new user password. Defaults to <code>global.sql.datasource.password.secretKey</code>.</td>
+</tr>
+<tr>
+<td><code>datahubSystemUpdate.elasticsearch.setup.enabled</code></td>
+<td>boolean</td>
+<td><code>false</code></td>
+<td>Enable Elasticsearch setup within system-update job. Replaces the legacy <code>elasticsearchSetupJob</code>.</td>
+</tr>
+<tr>
+<td><code>datahubSystemUpdate.elasticsearch.setup.createUser</code></td>
+<td>boolean</td>
+<td><code>false</code></td>
+<td>Create Elasticsearch user (CREATE_USER_ES env var).</td>
+</tr>
+<tr>
+<td><code>datahubSystemUpdate.elasticsearch.setup.createUserIamRoleArn</code></td>
+<td>string</td>
+<td><code>""</code></td>
+<td>IAM role ARN to map to the created user (CREATE_USER_ES_IAM_ROLE_ARN env var). Only used when <code>createUser=true</code>.</td>
+</tr>
+<tr>
+<td><code>datahubSystemUpdate.elasticsearch.setup.createUsername</code></td>
+<td>string</td>
+<td>-</td>
+<td>Username for the new Elasticsearch user (CREATE_USER_ES_USERNAME env var). Defaults to <code>global.elasticsearch.auth.username</code>.</td>
+</tr>
+<tr>
+<td><code>datahubSystemUpdate.elasticsearch.setup.createPassword.value</code></td>
+<td>string</td>
+<td>-</td>
+<td>Password value for the new Elasticsearch user. Defaults to <code>global.elasticsearch.auth.password.value</code>.</td>
+</tr>
+<tr>
+<td><code>datahubSystemUpdate.elasticsearch.setup.createPassword.secretRef</code></td>
+<td>string</td>
+<td>-</td>
+<td>Secret reference for the new Elasticsearch user password. Defaults to <code>global.elasticsearch.auth.password.secretRef</code>.</td>
+</tr>
+<tr>
+<td><code>datahubSystemUpdate.elasticsearch.setup.createPassword.secretKey</code></td>
+<td>string</td>
+<td>-</td>
+<td>Secret key for the new Elasticsearch user password. Defaults to <code>global.elasticsearch.auth.password.secretKey</code>.</td>
+</tr>
 </tbody>
 </table>
 

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
@@ -82,6 +82,66 @@ spec:
             - name: DATAHUB_REVISION
               value: {{ .Release.Revision | quote }}
             {{- include "datahub.upgrade.env" . | nindent 12 }}
+            {{- if .Values.datahubSystemUpdate.sql.setup.enabled }}
+            # Enable SQL setup within system-update job
+            # This replaces the legacy mysqlSetupJob/postgresqlSetupJob
+            - name: DATAHUB_SQL_SETUP_ENABLED
+              value: "true"
+            - name: CREATE_TABLES
+              value: {{ .Values.datahubSystemUpdate.sql.setup.createTables | default "true" | quote }}
+            - name: CREATE_DB
+              value: {{ .Values.datahubSystemUpdate.sql.setup.createDatabase | default "true" | quote }}
+            {{- if .Values.datahubSystemUpdate.sql.setup.createUser }}
+            - name: CREATE_USER
+              value: {{ .Values.datahubSystemUpdate.sql.setup.createUser | default "false" | quote }}
+            {{- $username := .Values.datahubSystemUpdate.sql.setup.createUsername | default .Values.global.sql.datasource.username }}
+            {{- if $username }}
+            - name: CREATE_USER_USERNAME
+              value: {{ $username | quote }}
+            {{- end }}
+            {{- if not .Values.datahubSystemUpdate.sql.iam.enabled }}
+            {{- $password := .Values.datahubSystemUpdate.sql.setup.createPassword | default .Values.global.sql.datasource.password }}
+            {{- if $password.value }}
+            - name: CREATE_USER_PASSWORD
+              value: {{ $password.value | quote }}
+            {{- else if $password.secretRef }}
+            - name: CREATE_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $password.secretRef | quote }}
+                  key: {{ $password.secretKey | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.datahubSystemUpdate.elasticsearch.setup.enabled }}
+            # Enable Elasticsearch setup within system-update job
+            # This replaces the legacy elasticsearchSetupJob
+            {{- if .Values.datahubSystemUpdate.elasticsearch.setup.createUser }}
+            - name: CREATE_USER_ES
+              value: {{ .Values.datahubSystemUpdate.elasticsearch.setup.createUser | default "false" | quote }}
+            {{- $username := .Values.datahubSystemUpdate.elasticsearch.setup.createUsername | default .Values.global.elasticsearch.auth.username }}
+            {{- if $username }}
+            - name: CREATE_USER_ES_USERNAME
+              value: {{ $username | quote }}
+            {{- end }}
+            {{- $password := .Values.datahubSystemUpdate.elasticsearch.setup.createPassword | default .Values.global.elasticsearch.auth.password }}
+            {{- if $password.value }}
+            - name: CREATE_USER_ES_PASSWORD
+              value: {{ $password.value | quote }}
+            {{- else if $password.secretRef }}
+            - name: CREATE_USER_ES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $password.secretRef | quote }}
+                  key: {{ $password.secretKey | quote }}
+            {{- end }}
+            {{- if .Values.datahubSystemUpdate.elasticsearch.setup.createUserIamRoleArn }}
+            - name: CREATE_USER_ES_IAM_ROLE_ARN
+              value: {{ .Values.datahubSystemUpdate.elasticsearch.setup.createUserIamRoleArn | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
             {{- include "datahub.semantic-search.env" . | nindent 12 }}
             - name: DATAHUB_ANALYTICS_ENABLED
               value: {{ .Values.global.datahub_analytics_enabled | quote }}

--- a/charts/datahub/values.schema.json
+++ b/charts/datahub/values.schema.json
@@ -1315,6 +1315,81 @@
         "extraInitContainers": {
           "type": "array",
           "items": {}
+        },
+        "sql": {
+          "type": "object",
+          "properties": {
+            "iam": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              },
+              "required": ["enabled"]
+            },
+            "setup": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "createTables": { "type": "boolean" },
+                "createDatabase": { "type": "boolean" },
+                "createUser": { "type": "boolean" },
+                "createUsername": { "type": "string" },
+                "createPassword": {
+                  "type": "object",
+                  "properties": {
+                    "value": { "type": "string" },
+                    "secretRef": { "type": "string" },
+                    "secretKey": { "type": "string" }
+                  }
+                }
+              },
+              "required": [
+                "enabled",
+                "createTables",
+                "createDatabase",
+                "createUser"
+              ]
+            }
+          },
+          "required": ["iam", "setup"]
+        },
+        "elasticsearch": {
+          "type": "object",
+          "properties": {
+            "iam": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              },
+              "required": ["enabled"]
+            },
+            "setup": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "createUser": { "type": "boolean" },
+                "createUserIamRoleArn": { "type": "string" },
+                "createUsername": { "type": "string" },
+                "createPassword": {
+                  "type": "object",
+                  "properties": {
+                    "value": { "type": "string" },
+                    "secretRef": { "type": "string" },
+                    "secretKey": { "type": "string" }
+                  }
+                }
+              },
+              "required": [
+                "enabled",
+                "createUser"
+              ]
+            }
+          },
+          "required": ["iam", "setup"]
         }
       },
       "required": [
@@ -1327,7 +1402,9 @@
         "podAnnotations",
         "resources",
         "extraSidecars",
-        "extraInitContainers"
+        "extraInitContainers",
+        "sql",
+        "elasticsearch"
       ]
     },
     "global": {


### PR DESCRIPTION
## Summary

This PR adds Helm values to run **SQL** and **Elasticsearch** setup inside the existing `datahub-system-update` job, replacing the legacy standalone setup jobs. It also includes minor repo/chart housekeeping.

## New values

### `datahubSystemUpdate.sql.setup`

SQL setup is now configurable inside the system-update job (replaces `mysqlSetupJob` / `postgresqlSetupJob`):

| Value | Type | Default | Description |
|-------|------|---------|-------------|
| `datahubSystemUpdate.sql.setup.enabled` | boolean | `false` | Enable SQL setup in the system-update job. **Required when `global.sql.iam.enabled=true`.** |
| `datahubSystemUpdate.sql.setup.createTables` | boolean | `true` | Create DataHub tables (CREATE_TABLES) |
| `datahubSystemUpdate.sql.setup.createDatabase` | boolean | `true` | Create DataHub database (CREATE_DB) |
| `datahubSystemUpdate.sql.setup.createUser` | boolean | `false` | Create database user (CREATE_USER) |
| `datahubSystemUpdate.sql.setup.createUsername` | string | - | Username for new user (defaults to `global.sql.datasource.username`) |
| `datahubSystemUpdate.sql.setup.createPassword.value` / `.secretRef` / `.secretKey` | string | - | Password for new user (defaults to `global.sql.datasource.password`) |

### `datahubSystemUpdate.elasticsearch.setup`

Elasticsearch setup is now configurable inside the system-update job (replaces `elasticsearchSetupJob`):

| Value | Type | Default | Description |
|-------|------|---------|-------------|
| `datahubSystemUpdate.elasticsearch.setup.enabled` | boolean | `false` | Enable Elasticsearch setup in the system-update job |
| `datahubSystemUpdate.elasticsearch.setup.createUser` | boolean | `false` | Create Elasticsearch user (CREATE_USER_ES) |
| `datahubSystemUpdate.elasticsearch.setup.createUserIamRoleArn` | string | `""` | IAM role ARN for the created user (when `createUser=true`) |
| `datahubSystemUpdate.elasticsearch.setup.createUsername` | string | - | Username for new ES user (defaults to `global.elasticsearch.auth.username`) |
| `datahubSystemUpdate.elasticsearch.setup.createPassword.value` / `.secretRef` / `.secretKey` | string | - | Password for new ES user (defaults to `global.elasticsearch.auth.password`) |

## Template / schema changes

- **`datahub-system-update-job.yml`**: Injects env vars for SQL and Elasticsearch setup when the corresponding `*.setup.enabled` values are true (CREATE_TABLES, CREATE_DB, CREATE_USER, CREATE_USER_ES, etc.).
- **`values.schema.json`**: Adds JSON schema for `datahubSystemUpdate.sql` and `datahubSystemUpdate.elasticsearch` (including `iam` and `setup`).
- **`VALUES_REFERENCE.md`**: Documents all new values in the reference table.

## Other changes

- **`.gitignore`**: Ignore `.DS_Store`.
- **`Chart.yaml`**: Bump chart version to `0.8.11`.

## Migration note

For IAM-based SQL (`global.sql.iam.enabled=true`), enable the new SQL setup in the system-update job and retire the legacy MySQL/PostgreSQL setup jobs:

```yaml
datahubSystemUpdate:
  sql:
    setup:
      enabled: true
      createTables: true
      createDatabase: true
      # createUser, createUsername, createPassword as needed
```

Similarly, to use Elasticsearch setup from the system-update job instead of `elasticsearchSetupJob`, set `datahubSystemUpdate.elasticsearch.setup.enabled: true` and configure create-user options as needed.
