### PR TITLE
fix(token-authentication): Refactor and consolidate changes to handle metadata_authorization env vars

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.8.15
+version: 0.8.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
@@ -23,7 +23,7 @@ dependencies:
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.3.2
+    version: 0.3.3
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron

--- a/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.2
+version: 0.3.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.5.0

--- a/charts/datahub/subcharts/datahub-mce-consumer/README.md
+++ b/charts/datahub/subcharts/datahub-mce-consumer/README.md
@@ -2,7 +2,7 @@ datahub-mce-consumer
 ====================
 A Helm chart for datahub-mce-consumer
 
-Current chart version is `0.2.0`
+Current chart version is `0.3.3`
 
 ## Chart Values
 

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
@@ -244,13 +244,6 @@ spec:
             {{- if .Values.global.datahub.metadata_service_authentication.enabled }}
             - name: METADATA_SERVICE_AUTH_ENABLED
               value: "true"
-            - name: DATAHUB_SYSTEM_CLIENT_ID
-              value: {{ .Values.global.datahub.metadata_service_authentication.systemClientId }}
-            - name: DATAHUB_SYSTEM_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretRef }}
-                  key: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretKey }}
             - name: DATAHUB_TOKEN_SERVICE_SIGNING_KEY
               valueFrom:
                 secretKeyRef:
@@ -261,6 +254,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.global.datahub.metadata_service_authentication.tokenService.salt.secretRef }}
                   key: {{ .Values.global.datahub.metadata_service_authentication.tokenService.salt.secretKey }}
+            - name: DATAHUB_SYSTEM_CLIENT_ID
+              value: {{ .Values.global.datahub.metadata_service_authentication.systemClientId }}
+            - name: DATAHUB_SYSTEM_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretRef }}
+                  key: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretKey }}
             {{- else }}
             - name: METADATA_SERVICE_AUTH_ENABLED
               value: "false"

--- a/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
+++ b/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
@@ -237,6 +237,36 @@ Return the env variables for upgrade jobs
 {{- end -}}
 
 {{/*
+Return the metadata service authentication env variables for upgrade jobs
+*/}}
+{{- define "datahub.upgrade.auth.env" -}}
+{{- if .Values.global.datahub.metadata_service_authentication.enabled }}
+- name: METADATA_SERVICE_AUTH_ENABLED
+  value: "true"
+- name: DATAHUB_TOKEN_SERVICE_SIGNING_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.global.datahub.metadata_service_authentication.tokenService.signingKey.secretRef }}
+      key: {{ .Values.global.datahub.metadata_service_authentication.tokenService.signingKey.secretKey }}
+- name: DATAHUB_TOKEN_SERVICE_SALT
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.global.datahub.metadata_service_authentication.tokenService.salt.secretRef }}
+      key: {{ .Values.global.datahub.metadata_service_authentication.tokenService.salt.secretKey }}
+- name: DATAHUB_SYSTEM_CLIENT_ID
+  value: {{ .Values.global.datahub.metadata_service_authentication.systemClientId }}
+- name: DATAHUB_SYSTEM_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretRef }}
+      key: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretKey }}
+{{- else }}
+- name: METADATA_SERVICE_AUTH_ENABLED
+  value: "false"
+{{- end }}
+{{- end -}}
+
+{{/*
 Set up cron hourly custom scheduling
 */}}
 {{- define "datahub.upgrade.hourlyCronWindow" -}}

--- a/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
@@ -120,30 +120,7 @@ spec:
               {{- end }}
               env:
                 {{- include "datahub.upgrade.env" . | nindent 16 }}
-                {{- if .Values.global.datahub.metadata_service_authentication.enabled }}
-                - name: METADATA_SERVICE_AUTH_ENABLED
-                  value: "true"
-                - name: DATAHUB_TOKEN_SERVICE_SIGNING_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: {{ .Values.global.datahub.metadata_service_authentication.tokenService.signingKey.secretRef }}
-                      key: {{ .Values.global.datahub.metadata_service_authentication.tokenService.signingKey.secretKey }}
-                - name: DATAHUB_TOKEN_SERVICE_SALT
-                  valueFrom:
-                    secretKeyRef:
-                      name: {{ .Values.global.datahub.metadata_service_authentication.tokenService.salt.secretRef }}
-                      key: {{ .Values.global.datahub.metadata_service_authentication.tokenService.salt.secretKey }}
-                - name: DATAHUB_SYSTEM_CLIENT_ID
-                  value: {{ .Values.global.datahub.metadata_service_authentication.systemClientId }}
-                - name: DATAHUB_SYSTEM_CLIENT_SECRET
-                  valueFrom:
-                    secretKeyRef:
-                      name: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretRef }}
-                      key: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretKey }}
-                {{- else }}
-                - name: METADATA_SERVICE_AUTH_ENABLED
-                  value: "false"
-                {{- end }}
+                {{- include "datahub.upgrade.auth.env" . | nindent 16 }}
               {{- with .Values.datahubUpgrade.extraEnvs }}
                 {{- toYaml . | nindent 16 }}
               {{- end }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-cron-hourly-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-cron-hourly-job-template.yml
@@ -78,30 +78,7 @@ spec:
                 # - "dryRun=true"
               env:
                 {{- include "datahub.upgrade.env" . | nindent 16}}
-                {{- if .Values.global.datahub.metadata_service_authentication.enabled }}
-                - name: METADATA_SERVICE_AUTH_ENABLED
-                  value: "true"
-                - name: DATAHUB_TOKEN_SERVICE_SIGNING_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: {{ .Values.global.datahub.metadata_service_authentication.tokenService.signingKey.secretRef }}
-                      key: {{ .Values.global.datahub.metadata_service_authentication.tokenService.signingKey.secretKey }}
-                - name: DATAHUB_TOKEN_SERVICE_SALT
-                  valueFrom:
-                    secretKeyRef:
-                      name: {{ .Values.global.datahub.metadata_service_authentication.tokenService.salt.secretRef }}
-                      key: {{ .Values.global.datahub.metadata_service_authentication.tokenService.salt.secretKey }}
-                - name: DATAHUB_SYSTEM_CLIENT_ID
-                  value: {{ .Values.global.datahub.metadata_service_authentication.systemClientId }}
-                - name: DATAHUB_SYSTEM_CLIENT_SECRET
-                  valueFrom:
-                    secretKeyRef:
-                      name: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretRef }}
-                      key: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretKey }}
-                {{- else }}
-                - name: METADATA_SERVICE_AUTH_ENABLED
-                  value: "false"
-                {{- end }}
+                {{- include "datahub.upgrade.auth.env" . | nindent 16 }}
               {{- with .Values.datahubSystemCronHourly.jvmOpts }}
                 - name: JDK_JAVA_OPTIONS
                   value: >-

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
@@ -77,30 +77,7 @@ spec:
           {{- end }}
           {{- end }}
           env:
-            {{- if .Values.global.datahub.metadata_service_authentication.enabled }}
-            - name: METADATA_SERVICE_AUTH_ENABLED
-              value: "true"
-            - name: DATAHUB_TOKEN_SERVICE_SIGNING_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.datahub.metadata_service_authentication.tokenService.signingKey.secretRef }}
-                  key: {{ .Values.global.datahub.metadata_service_authentication.tokenService.signingKey.secretKey }}
-            - name: DATAHUB_TOKEN_SERVICE_SALT
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.datahub.metadata_service_authentication.tokenService.salt.secretRef }}
-                  key: {{ .Values.global.datahub.metadata_service_authentication.tokenService.salt.secretKey }}
-            - name: DATAHUB_SYSTEM_CLIENT_ID
-              value: {{ .Values.global.datahub.metadata_service_authentication.systemClientId }}
-            - name: DATAHUB_SYSTEM_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretRef }}
-                  key: {{ .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretKey }}
-            {{- else }}
-            - name: METADATA_SERVICE_AUTH_ENABLED
-              value: "false"
-            {{- end }}
+            {{- include "datahub.upgrade.auth.env" . | nindent 12 }}
             - name: ENTITY_VERSIONING_ENABLED
               value: {{ .Values.global.datahub.entityVersioning.enabled | quote }}
             - name: DATAHUB_REVISION
@@ -350,16 +327,7 @@ spec:
             - "SystemUpdateNonBlocking"
           {{- end }}
           env:
-            - name: DATAHUB_TOKEN_SERVICE_SIGNING_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.datahub.metadata_service_authentication.tokenService.signingKey.secretRef }}
-                  key: {{ .Values.global.datahub.metadata_service_authentication.tokenService.signingKey.secretKey }}
-            - name: DATAHUB_TOKEN_SERVICE_SALT
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.datahub.metadata_service_authentication.tokenService.salt.secretRef }}
-                  key: {{ .Values.global.datahub.metadata_service_authentication.tokenService.salt.secretKey }}
+            {{- include "datahub.upgrade.auth.env" . | nindent 12 }}
             - name: DATAHUB_REVISION
               value: {{ .Release.Revision | quote }}
             {{- include "datahub.upgrade.env" . | nindent 12 }}


### PR DESCRIPTION
Add DATAHUB_TOKEN_SERVICE_SIGNING_KEY and DATAHUB_TOKEN_SERVICE_SALT to datahub-system-update-job — the blocking and non-blocking system update jobs were missing these env vars, unlike the cron and restore-indices jobs which already had them. Both jobs now consistently inject the token signing key and salt when metadata_service_authentication.enabled is true.

Extract auth env block into datahub.upgrade.auth.env helper — the repeated auth env block (METADATA_SERVICE_AUTH_ENABLED, DATAHUB_TOKEN_SERVICE_SIGNING_KEY, DATAHUB_TOKEN_SERVICE_SALT, DATAHUB_SYSTEM_CLIENT_ID, DATAHUB_SYSTEM_CLIENT_SECRET) was duplicated across 4 job templates. It is now defined once in _upgrade.tpl and included via {{- include "datahub.upgrade.auth.env" . | nindent N }}.

Fix env var ordering in datahub-mce-consumer — DATAHUB_TOKEN_SERVICE_SIGNING_KEY/SALT were placed after DATAHUB_SYSTEM_CLIENT_ID/SECRET, inconsistent with all other services. Reordered to match the canonical pattern.

Update datahub-mae-consumer and datahub-mce-consumer READMEs — document the tokenService.signingKey and tokenService.salt values, which were missing from both subchart READMEs.

Bump chart versions — datahub-mce-consumer 0.3.2 → 0.3.3, parent datahub chart 0.8.15 → 0.8.16.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
