### PR TITLE
fix: create provisioned auth and encryption secrets in pre-install hook

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.8.20
+version: 0.8.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/VALUES_REFERENCE.md
+++ b/charts/datahub/VALUES_REFERENCE.md
@@ -867,7 +867,7 @@ This document provides a comprehensive reference for every single configurable v
 <td><code>global.datahub.encryptionKey.provisionSecret.enabled</code></td>
 <td>boolean</td>
 <td><code>true</code></td>
-<td>Enable automatic provisioning of encryption key secret.</td>
+<td>Enable automatic provisioning of encryption key secret. When enabled, the secret is created via a pre-install/pre-upgrade hook (weight -5) so it exists before the system-update Job and GMS.</td>
 </tr>
 <tr>
 <td><code>global.datahub.encryptionKey.provisionSecret.autoGenerate</code></td>
@@ -945,7 +945,7 @@ This document provides a comprehensive reference for every single configurable v
 <td><code>global.datahub.metadata_service_authentication.provisionSecrets.enabled</code></td>
 <td>boolean</td>
 <td><code>true</code></td>
-<td>Enable automatic provisioning of authentication secrets.</td>
+<td>Enable automatic provisioning of authentication secrets. When enabled, the secret is created via a pre-install/pre-upgrade hook (weight -5) so it exists before the system-update Job and other workloads that reference it.</td>
 </tr>
 <tr>
 <td><code>global.datahub.metadata_service_authentication.provisionSecrets.autoGenerate</code></td>
@@ -957,7 +957,7 @@ This document provides a comprehensive reference for every single configurable v
 <td><code>global.datahub.metadata_service_authentication.provisionSecrets.annotations</code></td>
 <td>object</td>
 <td><code>{}</code></td>
-<td>Annotations for the provisioned authentication secrets.</td>
+<td>Optional annotations for the provisioned authentication secrets. The chart also adds <code>helm.sh/hook</code> and <code>helm.sh/hook-weight</code> so the secret is created before Jobs that use it.</td>
 </tr>
 <tr>
 <td><code>global.datahub.alwaysEmitChangeLog</code></td>

--- a/charts/datahub/templates/datahub-auth-secrets.yml
+++ b/charts/datahub/templates/datahub-auth-secrets.yml
@@ -8,10 +8,14 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretRef }}
-  {{- with .annotations }}
   annotations:
+    # Create this secret in pre-install so it exists before the system-update Job (weight -4) runs.
+    # Avoids "secret datahub-auth-secrets not found" ordering issues (e.g. issue #295).
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    {{- with .annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 type: Opaque
 data:
   {{- if .autoGenerate }}

--- a/charts/datahub/templates/datahub-encryption-secrets.yml
+++ b/charts/datahub/templates/datahub-encryption-secrets.yml
@@ -9,10 +9,13 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretRef }}
-  {{- with .annotations }}
   annotations:
+    # Create in pre-install so it exists before system-update Job and GMS (which mount this secret).
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    {{- with .annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 type: Opaque
 data:
   {{- if .autoGenerate }}


### PR DESCRIPTION
- Add pre-install,pre-upgrade hook (weight -5) to datahub-auth-secrets so the secret exists before the system-update Job (weight -4) runs, avoiding 'secret datahub-auth-secrets not found' ordering issues.
- Apply same hook to datahub-encryption-secrets so GMS and other workloads have the secret before they start.
- Document hook behavior in VALUES_REFERENCE.md.
- Bump chart version to 0.8.21.

Made-with: Cursor



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
