### PR TITLE
chore(prerequisites): bump Confluent cp-kafka image to 7.5.13

### DIFF
--- a/charts/prerequisites/Chart.yaml
+++ b/charts/prerequisites/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for packages that Datahub depends on
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.2
+version: 0.2.3
 dependencies:
   - name: elasticsearch
     version: 7.17.3

--- a/charts/prerequisites/values.yaml
+++ b/charts/prerequisites/values.yaml
@@ -175,6 +175,9 @@ cp-helm-charts:
       bootstrapServers: "prerequisites-kafka:9092"
   cp-kafka:
     enabled: false
+    # Use a pullable tag; 7.5.0 is no longer on Docker Hub
+    image: confluentinc/cp-kafka
+    imageTag: "7.5.13"
   cp-zookeeper:
     enabled: false
   cp-kafka-rest:


### PR DESCRIPTION
- Set cp-kafka image to confluentinc/cp-kafka:7.5.13 (7.5.0 no longer on Docker Hub)
- Bump chart version to 0.2.3

Made-with: Cursor



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
