### PR TITLE
fix(gms): align Hazelcast selection with deployed image version

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,14 +4,14 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.1
+version: 0.9.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.5.0
 dependencies:
   - name: datahub-gms
-    version: 0.3.6
+    version: 0.3.7
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.6
+version: 0.3.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.5.0

--- a/charts/datahub/subcharts/datahub-gms/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-gms/templates/_helpers.tpl
@@ -32,14 +32,33 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Resolved GMS image / DataHub release version (subchart image.tag when set, else global.datahub.version).
+Same as template "datahub.image" tag; used for datahub.acryl.io/datahub-version and Hazelcast selection.
+*/}}
+{{- define "datahub-gms.deploymentAppVersion" -}}
+{{- .Values.image.tag | default .Values.global.datahub.version -}}
+{{- end -}}
+
+{{/*
+Standard Helm/Kubernetes app version (Chart.AppVersion) plus deployed DataHub image version label.
+*/}}
+{{- define "datahub-gms.applicationVersionLabels" -}}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- $dv := include "datahub-gms.deploymentAppVersion" . -}}
+{{- if $dv }}
+datahub.acryl.io/datahub-version: {{ $dv | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "datahub-gms.labels" -}}
 helm.sh/chart: {{ include "datahub-gms.chart" . }}
 {{ include "datahub-gms.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+{{- include "datahub-gms.applicationVersionLabels" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -29,9 +29,7 @@ spec:
     {{- end }}
       labels:
         {{- include "datahub-gms.selectorLabels" . | nindent 8 }}
-        {{- if .Chart.AppVersion }}
-        app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-        {{- end }}
+        {{- include "datahub-gms.applicationVersionLabels" . | trimPrefix "\n" | nindent 8 }}
         {{- range $key, $value := .Values.global.podLabels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}

--- a/charts/datahub/subcharts/datahub-gms/templates/hazelcastService.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/hazelcastService.yaml
@@ -11,10 +11,9 @@ spec:
       protocol: TCP
       targetPort: 5701
   selector:
-    app.kubernetes.io/name: {{- include "datahub-gms.name" . | nindent 6 }}
-    {{- if .Chart.AppVersion }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-    {{- end }}
+    app.kubernetes.io/name: {{ include "datahub-gms.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- include "datahub-gms.applicationVersionLabels" . | trimPrefix "\n" | nindent 4 }}
   type: ClusterIP
 {{- end }}
 

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -986,7 +986,7 @@ global:
       awsRegion: ""  # AWS region for RDS/Aurora IAM authentication
 
   datahub:
-    version: v1.5.0
+    version: v1.5.0.1
     gms:
       protocol: "http"
       port: "8080"


### PR DESCRIPTION
- Add datahub.acryl.io/datahub-version from image.tag or global.datahub.version
- Keep app.kubernetes.io/version from Chart.AppVersion for standard Helm labeling
- Hazelcast headless Service selector: name, instance, and both version labels
- Bump datahub chart to 0.9.2 and datahub-gms subchart to 0.3.7
- Default global.datahub.version to v1.5.0.1

Made-with: Cursor



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
