### PR TITLE
feat(zdu): add ZDU flags and rollback dual-write configuration

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.7
+version: 0.9.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.8
+version: 0.9.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -552,6 +552,10 @@ spec:
             - name: STRICT_URN_VALIDATION_ENABLED
               value: "{{ . }}"
             {{- end }}
+            {{- if .Values.global.datahub.systemUpdate.zdu.enable }}
+            - name: ZDU_STAGE_20
+              value: "true"
+            {{- end }}
             - name: MCP_CONSUMER_BATCH_ENABLED
               value: {{ .Values.global.datahub.metadataChangeProposal.consumer.batch.enabled | quote }}
             {{- with .Values.global.datahub.gms.s3 }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
@@ -236,9 +236,14 @@ spec:
             - name: ELASTICSEARCH_INDEX_BUILDER_REFRESH_INTERVAL_SECONDS
               value: {{ . | quote }}
             {{- end }}
+            {{- if .Values.global.datahub.systemUpdate.zdu.enable }}
+            - name: ELASTICSEARCH_BUILD_INDICES_ALLOW_DOC_COUNT_MISMATCH
+              value: "true"
+            {{- else }}
             {{- with .Values.global.elasticsearch.index.upgrade.allowDocCountMismatch }}
             - name: ELASTICSEARCH_BUILD_INDICES_ALLOW_DOC_COUNT_MISMATCH
               value: {{ . | quote }}
+            {{- end }}
             {{- end }}
             {{- range $k, $v := .Values.datahubSystemUpdate.bootstrapMCPs }}
             {{- if ne $k "default" }}
@@ -465,9 +470,14 @@ spec:
             - name: ELASTICSEARCH_INDEX_BUILDER_REFRESH_INTERVAL_SECONDS
               value: {{ . | quote }}
             {{- end }}
+            {{- if .Values.global.datahub.systemUpdate.zdu.enable }}
+            - name: ELASTICSEARCH_BUILD_INDICES_ALLOW_DOC_COUNT_MISMATCH
+              value: "true"
+            {{- else }}
             {{- with .Values.global.elasticsearch.index.upgrade.allowDocCountMismatch }}
             - name: ELASTICSEARCH_BUILD_INDICES_ALLOW_DOC_COUNT_MISMATCH
               value: {{ . | quote }}
+            {{- end }}
             {{- end }}
             {{- range $k, $v := .Values.datahubSystemUpdate.bootstrapMCPs }}
             {{- if ne $k "default" }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
@@ -1,6 +1,7 @@
 {{- include "datahub.validate.iam.setup" . -}}
 {{- if .Values.global.datahub.systemUpdate.enabled -}}
-{{- $scaleDownEffective := .Values.global.datahub.systemUpdate.scaleDown.enabled | default false }}
+{{- $zduStage20 := .Values.global.datahub.systemUpdate.zdu.enable | default false }}
+{{- $scaleDownEffective := and (.Values.global.datahub.systemUpdate.scaleDown.enabled | default false) (not $zduStage20) }}
 {{- $sa := .Values.datahubSystemUpdate.serviceAccount | default dict }}
 apiVersion: batch/v1
 kind: Job
@@ -107,6 +108,18 @@ spec:
               value: "false"
             - name: DATAHUB_UPGRADE_K8_SCALE_DOWN_JAVA_ENABLED
               value: "false"
+            {{- end }}
+            {{- if .Values.global.datahub.systemUpdate.zdu.preEnable }}
+            - name: ZDU_STAGE_10
+              value: "true"
+            {{- end }}
+            {{- if .Values.global.datahub.systemUpdate.zdu.enable }}
+            - name: ZDU_STAGE_20
+              value: "true"
+            {{- end }}
+            {{- if .Values.global.elasticsearch.index.upgrade.rollbackDualWriteEnabled }}
+            - name: ELASTICSEARCH_BUILD_INDICES_ROLLBACK_DUAL_WRITE_ENABLED
+              value: {{ .Values.global.elasticsearch.index.upgrade.rollbackDualWriteEnabled | quote }}
             {{- end }}
             {{- if .Values.datahubSystemUpdate.sql.setup.enabled }}
             # Enable SQL setup within system-update job
@@ -333,7 +346,8 @@ spec:
       restartPolicy: Never
       securityContext:
         {{- toYaml .Values.datahubSystemUpdate.podSecurityContext | nindent 8 }}
-      {{- $scaleDownEffective := .Values.global.datahub.systemUpdate.scaleDown.enabled | default false }}
+      {{- $zduStage20 := .Values.global.datahub.systemUpdate.zdu.enable | default false }}
+      {{- $scaleDownEffective := and (.Values.global.datahub.systemUpdate.scaleDown.enabled | default false) (not $zduStage20) }}
       {{- with .Values.datahubSystemUpdate.extraInitContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}
@@ -379,6 +393,18 @@ spec:
               value: "false"
             - name: DATAHUB_UPGRADE_K8_SCALE_DOWN_JAVA_ENABLED
               value: "false"
+            {{- end }}
+            {{- if .Values.global.datahub.systemUpdate.zdu.preEnable }}
+            - name: ZDU_STAGE_10
+              value: "true"
+            {{- end }}
+            {{- if .Values.global.datahub.systemUpdate.zdu.enable }}
+            - name: ZDU_STAGE_20
+              value: "true"
+            {{- end }}
+            {{- if .Values.global.elasticsearch.index.upgrade.rollbackDualWriteEnabled }}
+            - name: ELASTICSEARCH_BUILD_INDICES_ROLLBACK_DUAL_WRITE_ENABLED
+              value: {{ .Values.global.elasticsearch.index.upgrade.rollbackDualWriteEnabled | quote }}
             {{- end }}
             {{- include "datahub.semantic-search.env" . | nindent 12 }}
             - name: DATAHUB_ANALYTICS_ENABLED

--- a/charts/datahub/values.schema.json
+++ b/charts/datahub/values.schema.json
@@ -1680,6 +1680,9 @@
                     },
                     "reindexOptimizationEnabled": {
                       "type": "boolean"
+                    },
+                    "rollbackDualWriteEnabled": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -2435,6 +2438,17 @@
                   "type": "object",
                   "properties": {
                     "enabled": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "zdu": {
+                  "type": "object",
+                  "properties": {
+                    "preEnable": {
+                      "type": "boolean"
+                    },
+                    "enable": {
                       "type": "boolean"
                     }
                   }

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -735,6 +735,12 @@ global:
         ## Will use full replication during reindexing which will make the process slower
         reindexOptimizationEnabled: true
 
+        ## Individual override for ELASTICSEARCH_BUILD_INDICES_ROLLBACK_DUAL_WRITE_ENABLED.
+        ## When set explicitly, overrides the ZDU_STAGE_20 group flag cascade.
+        ## Dual-writes to old backing index during incremental reindex for rollback safety.
+        ## Defaults to ZDU_STAGE_20 value if not set here.
+        # rollbackDualWriteEnabled: false
+
     ## Search related configuration
     search:
       ## Maximum terms in aggregations
@@ -1033,8 +1039,22 @@ global:
       ## managed ES indices and other update related work
       enabled: true
       # K8 scale-down (available in v1.5.0): when true, Java-based scale-down runs (KubernetesScaleDownStep)
+      # NOTE: scaleDown is automatically disabled when zdu.enable=true
       scaleDown:
         enabled: true
+      # Zero Downtime Upgrade (ZDU) group flags — each stage enables a set of individual feature flags.
+      # Individual flags can still be overridden separately (e.g. via global.elasticsearch.index.upgrade).
+      zdu:
+        # ZDU_STAGE_10: group flag for pre-enablement stage.
+        # Enables: CREATE_SCHEMA_VERSION_INDEX (schema version index on metadata_aspect_v2)
+        preEnable: false
+        # ZDU_STAGE_20: group flag for first ZDU release.
+        # Enables: ELASTICSEARCH_BUILD_INDICES_INCREMENTAL_REINDEX_ENABLED,
+        #          ELASTICSEARCH_BUILD_INDICES_ROLLBACK_DUAL_WRITE_ENABLED,
+        #          SYSTEM_UPDATE_MIGRATE_ASPECTS_ENABLED,
+        #          ASPECT_MIGRATION_MUTATOR_ENABLED (GMS runtime)
+        # NOTE: setting enable=true automatically disables scaleDown operations
+        enable: false
 
     encryptionKey:
       secretRef: "datahub-encryption-secrets"

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -729,6 +729,8 @@ global:
         ##
         ## This setting allows continuing if and only if the cloneIndices setting is also enabled which
         ## ensures a complete backup of the original index is preserved.
+        ## Automatically set to true when zdu.enable=true. Individual value is
+        ## only respected when zdu.enable is not set.
         allowDocCountMismatch: false
 
         ## Only disable for OpenSearch/ElasticSearch clusters with zone awareness, otherwise optimization should be utilized


### PR DESCRIPTION
Exposes ZDU group flags introduced in the zero-downtime upgrade branch:

- global.datahub.systemUpdate.zdu.preEnable → ZDU_STAGE_10 (enables CREATE_SCHEMA_VERSION_INDEX for schema version index on metadata_aspect_v2)
- global.datahub.systemUpdate.zdu.enable → ZDU_STAGE_20 (enables ELASTICSEARCH_BUILD_INDICES_INCREMENTAL_REINDEX_ENABLED, ELASTICSEARCH_BUILD_INDICES_ROLLBACK_DUAL_WRITE_ENABLED, SYSTEM_UPDATE_MIGRATE_ASPECTS_ENABLED, and ASPECT_MIGRATION_MUTATOR_ENABLED)
- When zdu.enable=true,
   ELASTICSEARCH_BUILD_INDICES_ALLOW_DOC_COUNT_MISMATCH  is automatically forced to true in both    The individual allowDocCountMismatch value is only respected when zdu.enable is not set.
- Setting zdu.enable=true automatically disables scaleDown operations in both blocking and nonblocking system-update jobs
- ZDU_STAGE_20 also propagated to GMS deployment for runtime aspect migration mutator chain activation
- global.elasticsearch.index.upgrade.rollbackDualWriteEnabled exposed as an explicit per-flag override for ELASTICSEARCH_BUILD_INDICES_ROLLBACK_DUAL_WRITE_ENABLED



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
