### PR TITLE
feat(datahub): configurable Prometheus metrics modes

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,26 +4,26 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.5
+version: 0.9.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.5.0
 dependencies:
   - name: datahub-gms
-    version: 0.3.10
+    version: 0.3.11
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.3.3
+    version: 0.3.4
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer
-    version: 0.3.3
+    version: 0.3.4
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.3.4
+    version: 0.3.5
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron

--- a/charts/datahub/VALUES_REFERENCE.md
+++ b/charts/datahub/VALUES_REFERENCE.md
@@ -834,6 +834,30 @@ This document provides a comprehensive reference for every single configurable v
 <td>Custom name for the monitoring port.</td>
 </tr>
 <tr>
+<td><code>global.datahub.monitoring.metricsMode</code></td>
+<td>string</td>
+<td><code>legacy</code></td>
+<td>Prometheus scrape layout for JMX workloads (GMS, frontend, MAE/MCE consumers). Set only via this global key; there are no per-workload overrides. <code>legacy</code>: JMX on <code>jmxPort</code>; GMS Spring actuator on the main HTTP service port only. <code>jmx_and_actuator</code>: JMX exporter scrape uses <code>jmxExporter.metricsPath</code> on <code>jmxPort</code>; <code>/actuator/prometheus</code> is exposed on <code>actuatorPrometheusPort</code>. <code>actuator_only</code>: no JMX sidecar scrape port; actuator only on <code>actuatorPrometheusPort</code>. <code>actuatorPrometheusPort</code> is not derived from <code>jmxPort</code>.</td>
+</tr>
+<tr>
+<td><code>global.datahub.monitoring.jmxPort</code></td>
+<td>integer</td>
+<td><code>4318</code></td>
+<td>Base port for JMX metrics (<code>legacy</code> and <code>jmx_and_actuator</code>). Configure <code>actuatorPrometheusPort</code> separately for the Spring actuator listener when <code>metricsMode</code> is <code>jmx_and_actuator</code> or <code>actuator_only</code>.</td>
+</tr>
+<tr>
+<td><code>global.datahub.monitoring.actuatorPrometheusPort</code></td>
+<td>integer</td>
+<td><code>4319</code></td>
+<td>Dedicated port for <code>/actuator/prometheus</code> when <code>metricsMode</code> is <code>jmx_and_actuator</code> or <code>actuator_only</code>. Independent of <code>jmxPort</code> (not computed as <code>jmxPort + 1</code>).</td>
+</tr>
+<tr>
+<td><code>global.datahub.monitoring.jmxExporter.metricsPath</code></td>
+<td>string</td>
+<td><code>/metrics</code></td>
+<td>HTTP path for the JMX exporter sidecar scrape target (ServiceMonitor and pod annotations where applicable).</td>
+</tr>
+<tr>
 <td><code>global.datahub.mae_consumer.port</code></td>
 <td>string</td>
 <td><code>9091</code></td>

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.3
+version: 0.3.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.5.0

--- a/charts/datahub/subcharts/datahub-frontend/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-frontend/templates/_helpers.tpl
@@ -212,3 +212,22 @@ Selector alternative labels
 app.kubernetes.io/name: {{ include "datahub-frontend-alt.name" . }}
 app.kubernetes.io/instance: {{ $.Release.Name }}
 {{- end -}}
+
+{{/*
+global.datahub.monitoring metricsMode: legacy | jmx_and_actuator | actuator_only (default legacy).
+*/}}
+{{- define "datahub-frontend.monitoring.metricsMode" -}}
+{{- .Values.global.datahub.monitoring.metricsMode | default "legacy" | trim -}}
+{{- end -}}
+
+{{- define "datahub-frontend.monitoring.jmxPort" -}}
+{{- int (.Values.global.datahub.monitoring.jmxPort | default 4318) -}}
+{{- end -}}
+
+{{- define "datahub-frontend.monitoring.actuatorPrometheusPort" -}}
+{{- int (.Values.global.datahub.monitoring.actuatorPrometheusPort | default 4319) -}}
+{{- end -}}
+
+{{- define "datahub-frontend.monitoring.jmxMetricsPath" -}}
+{{- (.Values.global.datahub.monitoring.jmxExporter | default dict).metricsPath | default "/metrics" -}}
+{{- end -}}

--- a/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/deployment.yaml
@@ -84,9 +84,15 @@ spec:
             - name: http
               containerPort: {{ .Values.service.containerPort }}
               protocol: TCP
-          {{- if or .Values.global.datahub.monitoring.enablePrometheus .Values.global.datahub.monitoring.enableJMXPort }}
+          {{- $mode := include "datahub-frontend.monitoring.metricsMode" . }}
+          {{- if and (or .Values.global.datahub.monitoring.enablePrometheus .Values.global.datahub.monitoring.enableJMXPort) (or (eq $mode "legacy") (eq $mode "jmx_and_actuator")) }}
             - name: {{ .Values.global.datahub.monitoring.portName }}
-              containerPort: 4318
+              containerPort: {{ include "datahub-frontend.monitoring.jmxPort" . }}
+              protocol: TCP
+          {{- end }}
+          {{- if and .Values.global.datahub.monitoring.enablePrometheus (or (eq $mode "jmx_and_actuator") (eq $mode "actuator_only")) }}
+            - name: prometheus
+              containerPort: {{ include "datahub-frontend.monitoring.actuatorPrometheusPort" . }}
               protocol: TCP
           {{- end }}
           livenessProbe:

--- a/charts/datahub/subcharts/datahub-frontend/templates/service.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/service.yaml
@@ -24,10 +24,19 @@ spec:
       {{- end }}
       {{- end }}
     {{- if .Values.global.datahub.monitoring.enablePrometheus }}
+    {{- $mode := include "datahub-frontend.monitoring.metricsMode" . }}
+    {{- if or (eq $mode "legacy") (eq $mode "jmx_and_actuator") }}
     - name: {{ .Values.global.datahub.monitoring.portName }}
-      port: 4318
+      port: {{ include "datahub-frontend.monitoring.jmxPort" . }}
       targetPort: {{ .Values.global.datahub.monitoring.portName }}
       protocol: TCP
+    {{- end }}
+    {{- if or (eq $mode "jmx_and_actuator") (eq $mode "actuator_only") }}
+    - name: prometheus
+      port: {{ include "datahub-frontend.monitoring.actuatorPrometheusPort" . }}
+      targetPort: prometheus
+      protocol: TCP
+    {{- end }}
     {{- end }}
   selector:
     {{- include "datahub-frontend.selectorLabels" . | nindent 4 }}

--- a/charts/datahub/subcharts/datahub-frontend/templates/servicemonitor.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/servicemonitor.yaml
@@ -14,13 +14,29 @@ metadata:
   {{- end }}
 spec:
   endpoints:
+{{- $mode := include "datahub-frontend.monitoring.metricsMode" . }}
+{{- if or (eq $mode "legacy") (eq $mode "jmx_and_actuator") }}
   - port: {{ .Values.global.datahub.monitoring.portName }}
+{{- if eq $mode "jmx_and_actuator" }}
+    path: {{ include "datahub-frontend.monitoring.jmxMetricsPath" . | quote }}
+{{- end }}
     relabelings:
     - separator: /
       sourceLabels:
       - namespace
       - pod
       targetLabel: instance
+{{- end }}
+{{- if eq $mode "actuator_only" }}
+  - port: prometheus
+    path: /actuator/prometheus
+    relabelings:
+    - separator: /
+      sourceLabels:
+      - namespace
+      - pod
+      targetLabel: instance
+{{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/managed-by: Helm

--- a/charts/datahub/subcharts/datahub-frontend/values.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/values.yaml
@@ -255,9 +255,7 @@ global:
     version: head
     gms:
       port: "8080"
-    monitoring:
-      enablePrometheus: true
-      portName: "jmx"
+    # monitoring: use umbrella global.datahub.monitoring only (do not set here; partial maps drop metricsMode).
     appVersion: "1.0"
     frontend:
       validateSignUpEmail: true

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.10
+version: 0.3.11
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.5.0

--- a/charts/datahub/subcharts/datahub-gms/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-gms/templates/_helpers.tpl
@@ -235,3 +235,33 @@ Validates that Kafka and OpenSearch regions match when both are configured with 
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+GMS base path prefix for HTTP paths (matches liveness path construction).
+*/}}
+{{- define "datahub-gms.basePath" -}}
+{{- if .Values.global.basePath.enabled }}{{ if eq .Values.global.basePath.gms "/" }}{{ else }}{{ .Values.global.basePath.gms }}{{ end }}{{ end -}}
+{{- end -}}
+
+{{/*
+global.datahub.monitoring metricsMode: legacy | jmx_and_actuator | actuator_only (default legacy).
+*/}}
+{{- define "datahub-gms.monitoring.metricsMode" -}}
+{{- .Values.global.datahub.monitoring.metricsMode | default "legacy" | trim -}}
+{{- end -}}
+
+{{- define "datahub-gms.monitoring.jmxPort" -}}
+{{- int (.Values.global.datahub.monitoring.jmxPort | default 4318) -}}
+{{- end -}}
+
+{{- define "datahub-gms.monitoring.actuatorPrometheusPort" -}}
+{{- int (.Values.global.datahub.monitoring.actuatorPrometheusPort | default 4319) -}}
+{{- end -}}
+
+{{- define "datahub-gms.monitoring.jmxMetricsPath" -}}
+{{- (.Values.global.datahub.monitoring.jmxExporter | default dict).metricsPath | default "/metrics" -}}
+{{- end -}}
+
+{{- define "datahub-gms.monitoring.gmsScrapeActuatorOnHttp" -}}
+{{- if eq (include "datahub-gms.monitoring.metricsMode" .) "legacy" }}true{{- end -}}
+{{- end -}}

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -87,9 +87,15 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-          {{- if or .Values.global.datahub.monitoring.enablePrometheus .Values.global.datahub.monitoring.enableJMXPort }}
+          {{- $mode := include "datahub-gms.monitoring.metricsMode" . }}
+          {{- if and (or .Values.global.datahub.monitoring.enablePrometheus .Values.global.datahub.monitoring.enableJMXPort) (or (eq $mode "legacy") (eq $mode "jmx_and_actuator")) }}
             - name: {{ .Values.global.datahub.monitoring.portName }}
-              containerPort: 4318
+              containerPort: {{ include "datahub-gms.monitoring.jmxPort" . }}
+              protocol: TCP
+          {{- end }}
+          {{- if and .Values.global.datahub.monitoring.enablePrometheus (or (eq $mode "jmx_and_actuator") (eq $mode "actuator_only")) }}
+            - name: prometheus
+              containerPort: {{ include "datahub-gms.monitoring.actuatorPrometheusPort" . }}
               protocol: TCP
           {{- end }}
           {{- if gt (.Values.replicaCount | int) 1 }}

--- a/charts/datahub/subcharts/datahub-gms/templates/service.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/service.yaml
@@ -26,10 +26,19 @@ spec:
       {{- end }}
       {{- end }}
     {{- if .Values.global.datahub.monitoring.enablePrometheus }}
+    {{- $mode := include "datahub-gms.monitoring.metricsMode" . | trim }}
+    {{- if or (eq $mode "legacy") (eq $mode "jmx_and_actuator") }}
     - name: {{ .Values.global.datahub.monitoring.portName }}
-      port: 4318
+      port: {{ include "datahub-gms.monitoring.jmxPort" . }}
       targetPort: {{ .Values.global.datahub.monitoring.portName }}
       protocol: TCP
+    {{- end }}
+    {{- if or (eq $mode "jmx_and_actuator") (eq $mode "actuator_only") }}
+    - name: prometheus
+      port: {{ include "datahub-gms.monitoring.actuatorPrometheusPort" . }}
+      targetPort: prometheus
+      protocol: TCP
+    {{- end }}
     {{- end }}
     {{- if .Values.service.additionalPorts }}
     {{- toYaml .Values.service.additionalPorts | nindent 4 }}

--- a/charts/datahub/subcharts/datahub-gms/templates/servicemonitor.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/servicemonitor.yaml
@@ -14,13 +14,39 @@ metadata:
   {{- end }}
 spec:
   endpoints:
+{{- $mode := include "datahub-gms.monitoring.metricsMode" . | trim }}
+{{- if or (eq $mode "legacy") (eq $mode "jmx_and_actuator") }}
   - port: {{ .Values.global.datahub.monitoring.portName }}
+{{- if eq $mode "jmx_and_actuator" }}
+    path: {{ include "datahub-gms.monitoring.jmxMetricsPath" . | quote }}
+{{- end }}
     relabelings:
     - separator: /
       sourceLabels:
       - namespace
       - pod
       targetLabel: instance
+{{- end }}
+{{- if eq (include "datahub-gms.monitoring.gmsScrapeActuatorOnHttp" .) "true" }}
+  - port: {{ .Values.service.name }}
+    path: {{ include "datahub-gms.basePath" . }}/actuator/prometheus
+    relabelings:
+    - separator: /
+      sourceLabels:
+      - namespace
+      - pod
+      targetLabel: instance
+{{- end }}
+{{- if or (eq $mode "jmx_and_actuator") (eq $mode "actuator_only") }}
+  - port: prometheus
+    path: {{ include "datahub-gms.basePath" . }}/actuator/prometheus
+    relabelings:
+    - separator: /
+      sourceLabels:
+      - namespace
+      - pod
+      targetLabel: instance
+{{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/managed-by: Helm

--- a/charts/datahub/subcharts/datahub-gms/values.yaml
+++ b/charts/datahub/subcharts/datahub-gms/values.yaml
@@ -76,6 +76,8 @@ service:
   targetPort: http
   protocol: TCP
   name: http
+  # WARNING: ServiceMonitor references this port name when global.datahub.monitoring.metricsMode is legacy (scrape /actuator/prometheus on http).
+  # When metricsMode is jmx_and_actuator or actuator_only, actuator is scraped on the prometheus port (actuatorPrometheusPort).
   # Annotations to add to the service, this will help in adding
   # Internal load balancer or various other annotation support in AWS
   annotations: {}
@@ -245,10 +247,8 @@ global:
 
   datahub:
     version: head
-    monitoring:
-      enablePrometheus: false
-      enableJMXPort: false
-      portName: jmx
+    # monitoring: inherited from umbrella global.datahub.monitoring only — do not set here or
+    # Helm may replace the parent map and drop metricsMode / jmxExporter keys.
     gms:
       port: "8080"
       graphql:

--- a/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.3
+version: 0.3.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.5.0

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/_helpers.tpl
@@ -114,3 +114,22 @@ OpenSearch/Elasticsearch IAM authentication environment variables for AWS OpenSe
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+global.datahub.monitoring metricsMode: legacy | jmx_and_actuator | actuator_only (default legacy).
+*/}}
+{{- define "datahub-mae-consumer.monitoring.metricsMode" -}}
+{{- .Values.global.datahub.monitoring.metricsMode | default "legacy" | trim -}}
+{{- end -}}
+
+{{- define "datahub-mae-consumer.monitoring.jmxPort" -}}
+{{- int (.Values.global.datahub.monitoring.jmxPort | default 4318) -}}
+{{- end -}}
+
+{{- define "datahub-mae-consumer.monitoring.actuatorPrometheusPort" -}}
+{{- int (.Values.global.datahub.monitoring.actuatorPrometheusPort | default 4319) -}}
+{{- end -}}
+
+{{- define "datahub-mae-consumer.monitoring.jmxMetricsPath" -}}
+{{- (.Values.global.datahub.monitoring.jmxExporter | default dict).metricsPath | default "/metrics" -}}
+{{- end -}}

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -73,9 +73,15 @@ spec:
             - name: http
               containerPort: 9091
               protocol: TCP
-          {{- if or .Values.global.datahub.monitoring.enablePrometheus .Values.global.datahub.monitoring.enableJMXPort }}
+          {{- $mode := include "datahub-mae-consumer.monitoring.metricsMode" . }}
+          {{- if and (or .Values.global.datahub.monitoring.enablePrometheus .Values.global.datahub.monitoring.enableJMXPort) (or (eq $mode "legacy") (eq $mode "jmx_and_actuator")) }}
             - name: {{ .Values.global.datahub.monitoring.portName }}
-              containerPort: 4318
+              containerPort: {{ include "datahub-mae-consumer.monitoring.jmxPort" . }}
+              protocol: TCP
+          {{- end }}
+          {{- if and .Values.global.datahub.monitoring.enablePrometheus (or (eq $mode "jmx_and_actuator") (eq $mode "actuator_only")) }}
+            - name: prometheus
+              containerPort: {{ include "datahub-mae-consumer.monitoring.actuatorPrometheusPort" . }}
               protocol: TCP
           {{- end }}
           livenessProbe:

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/service.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/service.yaml
@@ -17,10 +17,19 @@ spec:
       {{- end }}
       {{- end }}
     {{- if .Values.global.datahub.monitoring.enablePrometheus }}
+    {{- $mode := include "datahub-mae-consumer.monitoring.metricsMode" . }}
+    {{- if or (eq $mode "legacy") (eq $mode "jmx_and_actuator") }}
     - name: {{ .Values.global.datahub.monitoring.portName }}
-      port: 4318
+      port: {{ include "datahub-mae-consumer.monitoring.jmxPort" . }}
       targetPort: {{ .Values.global.datahub.monitoring.portName }}
       protocol: TCP
+    {{- end }}
+    {{- if or (eq $mode "jmx_and_actuator") (eq $mode "actuator_only") }}
+    - name: prometheus
+      port: {{ include "datahub-mae-consumer.monitoring.actuatorPrometheusPort" . }}
+      targetPort: prometheus
+      protocol: TCP
+    {{- end }}
     {{- end }}
   selector:
     {{- include "datahub-mae-consumer.selectorLabels" . | nindent 4 }}

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/servicemonitor.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/servicemonitor.yaml
@@ -14,13 +14,29 @@ metadata:
   {{- end }}
 spec:
   endpoints:
+{{- $mode := include "datahub-mae-consumer.monitoring.metricsMode" . }}
+{{- if or (eq $mode "legacy") (eq $mode "jmx_and_actuator") }}
   - port: {{ .Values.global.datahub.monitoring.portName }}
+{{- if eq $mode "jmx_and_actuator" }}
+    path: {{ include "datahub-mae-consumer.monitoring.jmxMetricsPath" . | quote }}
+{{- end }}
     relabelings:
     - separator: /
       sourceLabels:
       - namespace
       - pod
       targetLabel: instance
+{{- end }}
+{{- if eq $mode "actuator_only" }}
+  - port: prometheus
+    path: /actuator/prometheus
+    relabelings:
+    - separator: /
+      sourceLabels:
+      - namespace
+      - pod
+      targetLabel: instance
+{{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/managed-by: Helm

--- a/charts/datahub/subcharts/datahub-mae-consumer/values.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/values.yaml
@@ -165,9 +165,7 @@ global:
     version: head
     gms:
       port: "8080"
-    monitoring:
-      enablePrometheus: false
-      portName: jmx
+    # monitoring: use umbrella global.datahub.monitoring only.
 
     systemUpdate:
       ## The following options control settings for datahub-upgrade job which will

--- a/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.4
+version: 0.3.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.5.0

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/_helpers.tpl
@@ -114,3 +114,22 @@ OpenSearch/Elasticsearch IAM authentication environment variables for AWS OpenSe
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+global.datahub.monitoring metricsMode: legacy | jmx_and_actuator | actuator_only (default legacy).
+*/}}
+{{- define "datahub-mce-consumer.monitoring.metricsMode" -}}
+{{- .Values.global.datahub.monitoring.metricsMode | default "legacy" | trim -}}
+{{- end -}}
+
+{{- define "datahub-mce-consumer.monitoring.jmxPort" -}}
+{{- int (.Values.global.datahub.monitoring.jmxPort | default 4318) -}}
+{{- end -}}
+
+{{- define "datahub-mce-consumer.monitoring.actuatorPrometheusPort" -}}
+{{- int (.Values.global.datahub.monitoring.actuatorPrometheusPort | default 4319) -}}
+{{- end -}}
+
+{{- define "datahub-mce-consumer.monitoring.jmxMetricsPath" -}}
+{{- (.Values.global.datahub.monitoring.jmxExporter | default dict).metricsPath | default "/metrics" -}}
+{{- end -}}

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
@@ -77,9 +77,15 @@ spec:
             - name: http
               containerPort: 9090
               protocol: TCP
-          {{- if or .Values.global.datahub.monitoring.enablePrometheus .Values.global.datahub.monitoring.enableJMXPort }}
+          {{- $mode := include "datahub-mce-consumer.monitoring.metricsMode" . }}
+          {{- if and (or .Values.global.datahub.monitoring.enablePrometheus .Values.global.datahub.monitoring.enableJMXPort) (or (eq $mode "legacy") (eq $mode "jmx_and_actuator")) }}
             - name: {{ .Values.global.datahub.monitoring.portName }}
-              containerPort: 4318
+              containerPort: {{ include "datahub-mce-consumer.monitoring.jmxPort" . }}
+              protocol: TCP
+          {{- end }}
+          {{- if and .Values.global.datahub.monitoring.enablePrometheus (or (eq $mode "jmx_and_actuator") (eq $mode "actuator_only")) }}
+            - name: prometheus
+              containerPort: {{ include "datahub-mce-consumer.monitoring.actuatorPrometheusPort" . }}
               protocol: TCP
           {{- end }}
           livenessProbe:

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/service.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/service.yaml
@@ -17,10 +17,19 @@ spec:
       {{- end }}
       {{- end }}
     {{- if .Values.global.datahub.monitoring.enablePrometheus }}
+    {{- $mode := include "datahub-mce-consumer.monitoring.metricsMode" . }}
+    {{- if or (eq $mode "legacy") (eq $mode "jmx_and_actuator") }}
     - name: {{ .Values.global.datahub.monitoring.portName }}
-      port: 4318
+      port: {{ include "datahub-mce-consumer.monitoring.jmxPort" . }}
       targetPort: {{ .Values.global.datahub.monitoring.portName }}
       protocol: TCP
+    {{- end }}
+    {{- if or (eq $mode "jmx_and_actuator") (eq $mode "actuator_only") }}
+    - name: prometheus
+      port: {{ include "datahub-mce-consumer.monitoring.actuatorPrometheusPort" . }}
+      targetPort: prometheus
+      protocol: TCP
+    {{- end }}
     {{- end }}
   selector:
     {{- include "datahub-mce-consumer.selectorLabels" . | nindent 4 }}

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/servicemonitor.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/servicemonitor.yaml
@@ -14,13 +14,29 @@ metadata:
   {{- end }}
 spec:
   endpoints:
+{{- $mode := include "datahub-mce-consumer.monitoring.metricsMode" . }}
+{{- if or (eq $mode "legacy") (eq $mode "jmx_and_actuator") }}
   - port: {{ .Values.global.datahub.monitoring.portName }}
+{{- if eq $mode "jmx_and_actuator" }}
+    path: {{ include "datahub-mce-consumer.monitoring.jmxMetricsPath" . | quote }}
+{{- end }}
     relabelings:
     - separator: /
       sourceLabels:
       - namespace
       - pod
       targetLabel: instance
+{{- end }}
+{{- if eq $mode "actuator_only" }}
+  - port: prometheus
+    path: /actuator/prometheus
+    relabelings:
+    - separator: /
+      sourceLabels:
+      - namespace
+      - pod
+      targetLabel: instance
+{{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/managed-by: Helm

--- a/charts/datahub/subcharts/datahub-mce-consumer/values.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/values.yaml
@@ -151,9 +151,7 @@ global:
 
   datahub:
     version: head
-    monitoring:
-      enablePrometheus: false
-      portName: jmx
+    # monitoring: use umbrella global.datahub.monitoring only.
     gms:
       port: "8080"
     metadata_service_authentication:

--- a/charts/datahub/values.schema.json
+++ b/charts/datahub/values.schema.json
@@ -2370,6 +2370,36 @@
                 },
                 "portName": {
                   "type": "string"
+                },
+                "monitoringApiVersion": {
+                  "type": "string",
+                  "description": "Override ServiceMonitor/monitoring.coreos.com API group when the cluster uses a non-default variant (e.g. some AKS setups)."
+                },
+                "metricsMode": {
+                  "type": "string",
+                  "enum": ["legacy", "jmx_and_actuator", "actuator_only"],
+                  "description": "Prometheus scrape layout for JMX workloads (GMS, frontend, MAE/MCE consumers). legacy: JMX on jmxPort; GMS actuator on main http port. jmx_and_actuator: JMX with jmxExporter.metricsPath on jmxPort; Spring /actuator/prometheus on actuatorPrometheusPort. actuator_only: no JMX; actuator on actuatorPrometheusPort only."
+                },
+                "jmxPort": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535,
+                  "description": "Container and Service port for JMX metrics (legacy and jmx_and_actuator). Not derived from actuatorPrometheusPort; configure both independently."
+                },
+                "actuatorPrometheusPort": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535,
+                  "description": "Dedicated container and Service port for Spring Boot /actuator/prometheus when metricsMode is jmx_and_actuator or actuator_only. Independent of jmxPort (not computed as jmxPort+1)."
+                },
+                "jmxExporter": {
+                  "type": "object",
+                  "properties": {
+                    "metricsPath": {
+                      "type": "string",
+                      "description": "HTTP path for the JMX exporter sidecar scrape target (often /metrics)."
+                    }
+                  }
                 }
               },
               "required": [

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -1,5 +1,6 @@
 # Values to start up datahub after starting up the datahub-prerequisites chart with "prerequisites" release name
 # Copy this chart and change configuration as needed.
+# JMX/actuator metrics layout is controlled only by global.datahub.monitoring.metricsMode (see global.datahub below).
 datahub-gms:
   enabled: true
   image:
@@ -1007,6 +1008,18 @@ global:
       enablePrometheus: true
       # Set a custom name for the monitoring port
       portName: jmx
+      # Change if using a service like AKS where it uses a different API namespace for monitoring.coreos.com
+      # monitoringApiVersion: "azmonitoring.coreos.com/v1"
+      # Prometheus scrape layout for JMX workloads (GMS, frontend, MAE/MCE consumers).
+      # - legacy: JMX on jmxPort; GMS Spring actuator on main http service port only (current default).
+      # - jmx_and_actuator: JMX with explicit metricsPath on jmxPort; /actuator/prometheus on actuatorPrometheusPort.
+      # - actuator_only: no JMX; /actuator/prometheus only on actuatorPrometheusPort where the app exposes it.
+      metricsMode: legacy
+      jmxPort: 4318
+      # Dedicated listener for Spring /actuator/prometheus (non-legacy modes). Independent of jmxPort so JMX can be removed later.
+      actuatorPrometheusPort: 4319
+      jmxExporter:
+        metricsPath: "/metrics"
 
     mae_consumer:
       port: "9091"


### PR DESCRIPTION
Metrics non-legacy modes available in v1.6.0 or later

Add global.datahub.monitoring.metricsMode, see [transition plan](https://docs.datahub.com/docs/advanced/monitoring#micrometer-transition-plan) for explanation of the modes.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
