### PR TITLE
fix(charts): probe actuator health on prometheus port for MAE/MCE

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.6
+version: 0.9.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
@@ -19,11 +19,11 @@ dependencies:
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer
-    version: 0.3.4
+    version: 0.3.5
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.3.5
+    version: 0.3.6
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron

--- a/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.4
+version: 0.3.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.5.0

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/_helpers.tpl
@@ -133,3 +133,16 @@ global.datahub.monitoring metricsMode: legacy | jmx_and_actuator | actuator_only
 {{- define "datahub-mae-consumer.monitoring.jmxMetricsPath" -}}
 {{- (.Values.global.datahub.monitoring.jmxExporter | default dict).metricsPath | default "/metrics" -}}
 {{- end -}}
+
+{{/*
+Kubernetes httpGet port name for liveness/readiness: when metricsMode moves Spring actuator to actuatorPrometheusPort,
+/actuator/health must be probed on the "prometheus" container port, not the main "http" port.
+*/}}
+{{- define "datahub-mae-consumer.monitoring.healthProbePortName" -}}
+{{- $mode := include "datahub-mae-consumer.monitoring.metricsMode" . -}}
+{{- if and .Values.global.datahub.monitoring.enablePrometheus (or (eq $mode "jmx_and_actuator") (eq $mode "actuator_only")) -}}
+prometheus
+{{- else -}}
+http
+{{- end -}}
+{{- end -}}

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -69,11 +69,11 @@ spec:
           {{- if .Values.image.args }}
           args: {{ .Values.image.args | toRawJson }}
           {{- end }}
+          {{- $mode := include "datahub-mae-consumer.monitoring.metricsMode" . }}
           ports:
             - name: http
               containerPort: 9091
               protocol: TCP
-          {{- $mode := include "datahub-mae-consumer.monitoring.metricsMode" . }}
           {{- if and (or .Values.global.datahub.monitoring.enablePrometheus .Values.global.datahub.monitoring.enableJMXPort) (or (eq $mode "legacy") (eq $mode "jmx_and_actuator")) }}
             - name: {{ .Values.global.datahub.monitoring.portName }}
               containerPort: {{ include "datahub-mae-consumer.monitoring.jmxPort" . }}
@@ -87,14 +87,14 @@ spec:
           livenessProbe:
             httpGet:
               path: /actuator/health
-              port: http
+              port: {{ include "datahub-mae-consumer.monitoring.healthProbePortName" . }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
               path: /actuator/health
-              port: http
+              port: {{ include "datahub-mae-consumer.monitoring.healthProbePortName" . }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}

--- a/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.5
+version: 0.3.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.5.0

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/_helpers.tpl
@@ -133,3 +133,16 @@ global.datahub.monitoring metricsMode: legacy | jmx_and_actuator | actuator_only
 {{- define "datahub-mce-consumer.monitoring.jmxMetricsPath" -}}
 {{- (.Values.global.datahub.monitoring.jmxExporter | default dict).metricsPath | default "/metrics" -}}
 {{- end -}}
+
+{{/*
+Kubernetes httpGet port name for liveness/readiness: when metricsMode moves Spring actuator to actuatorPrometheusPort,
+/actuator/health must be probed on the "prometheus" container port, not the main "http" port.
+*/}}
+{{- define "datahub-mce-consumer.monitoring.healthProbePortName" -}}
+{{- $mode := include "datahub-mce-consumer.monitoring.metricsMode" . -}}
+{{- if and .Values.global.datahub.monitoring.enablePrometheus (or (eq $mode "jmx_and_actuator") (eq $mode "actuator_only")) -}}
+prometheus
+{{- else -}}
+http
+{{- end -}}
+{{- end -}}

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
@@ -73,11 +73,11 @@ spec:
           {{- if .Values.image.args }}
           args: {{ .Values.image.args | toRawJson }}
           {{- end }}
+          {{- $mode := include "datahub-mce-consumer.monitoring.metricsMode" . }}
           ports:
             - name: http
               containerPort: 9090
               protocol: TCP
-          {{- $mode := include "datahub-mce-consumer.monitoring.metricsMode" . }}
           {{- if and (or .Values.global.datahub.monitoring.enablePrometheus .Values.global.datahub.monitoring.enableJMXPort) (or (eq $mode "legacy") (eq $mode "jmx_and_actuator")) }}
             - name: {{ .Values.global.datahub.monitoring.portName }}
               containerPort: {{ include "datahub-mce-consumer.monitoring.jmxPort" . }}
@@ -91,14 +91,14 @@ spec:
           livenessProbe:
             httpGet:
               path: /actuator/health
-              port: http
+              port: {{ include "datahub-mce-consumer.monitoring.healthProbePortName" . }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
               path: /actuator/health
-              port: http
+              port: {{ include "datahub-mce-consumer.monitoring.healthProbePortName" . }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -1014,6 +1014,8 @@ global:
       # - legacy: JMX on jmxPort; GMS Spring actuator on main http service port only (current default).
       # - jmx_and_actuator: JMX with explicit metricsPath on jmxPort; /actuator/prometheus on actuatorPrometheusPort.
       # - actuator_only: no JMX; /actuator/prometheus only on actuatorPrometheusPort where the app exposes it.
+      # When jmx_and_actuator or actuator_only: MAE/MCE consumers probe /actuator/health on the
+      # prometheus Service/container port (actuatorPrometheusPort); allow that port if you use NetworkPolicy.
       metricsMode: legacy
       jmxPort: 4318
       # Dedicated listener for Spring /actuator/prometheus (non-legacy modes). Independent of jmxPort so JMX can be removed later.


### PR DESCRIPTION
When metricsMode is jmx_and_actuator or actuator_only with Prometheus enabled, Spring exposes /actuator/health on actuatorPrometheusPort. Point liveness and readiness httpGet at the prometheus container port instead of http.

Bump umbrella chart to 0.9.7 and MAE/MCE subchart versions. Document NetworkPolicy considerations in values.yaml.

Made-with: Cursor



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
