### PR TITLE
feat(datahub): add global.datahub.tls PEM bundle with fan-out to all Kafka/SR consumers

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.6
+version: 0.9.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
@@ -62,6 +62,7 @@ spec:
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
       initContainers:
+        {{- include "datahub.globalTls.initContainer" . | nindent 8 }}
       {{- if .Values.extraInitContainers }}
       {{- .Values.extraInitContainers | toYaml | nindent 6 }}
       {{- end }}

--- a/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
@@ -48,6 +48,7 @@ spec:
             defaultMode: 0444
             secretName: {{ .name }}
       {{- end }}
+      {{- include "datahub.globalTls.volume" . | nindent 8 }}
       {{- with .Values.ingestionSecretFiles }}
         - name: ingestion-secret-files
           secret:
@@ -123,21 +124,10 @@ spec:
             {{- end }}
             - name: KAFKA_AUTO_OFFSET_POLICY
               value: "{{ .Values.actions.kafkaAutoOffsetPolicy }}"
-            {{- if .Values.global.springKafkaConfigurationOverrides }}
-            {{- range $configName, $configValue := .Values.global.springKafkaConfigurationOverrides }}
-            - name: KAFKA_PROPERTIES_{{ $configName | replace "." "_" | upper }}
-              value: {{ $configValue | quote }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.global.credentialsAndCertsSecrets }}
-            {{- range $envVarName, $envVarValue := .Values.global.credentialsAndCertsSecrets.secureEnv }}
-            - name: KAFKA_PROPERTIES_{{ $envVarName | replace "." "_" | upper }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $.Values.global.credentialsAndCertsSecrets.name }}
-                  key: {{ $envVarValue }}
-            {{- end }}
-            {{- end }}
+            {{- include "datahub.python.kafka.overrides.with.fallback" . | nindent 12 }}
+            {{- include "datahub.python.kafka.secrets.with.fallback" . | nindent 12 }}
+            {{- include "datahub.globalTls.librdkafka.env" . | nindent 12 }}
+            {{- include "datahub.globalTls.requestsCaBundle.env" . | nindent 12 }}
             {{- with .Values.global.kafka.topics }}
             - name: METADATA_CHANGE_EVENT_NAME
               value: {{ .metadata_change_event_name }}
@@ -192,6 +182,7 @@ spec:
             - name: datahub-certs-dir
               mountPath: {{ .path | default "/mnt/certs" }}
           {{- end }}
+            {{- include "datahub.globalTls.volumeMount" . | nindent 12 }}
           {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -69,6 +69,7 @@ spec:
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
       initContainers:
+        {{- include "datahub.globalTls.initContainer" . | nindent 8 }}
       {{- with .Values.extraInitContainers }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -56,6 +56,7 @@ spec:
             defaultMode: 0444
             secretName: {{ .name }}
         {{- end }}
+        {{- include "datahub.globalTls.volume" . | nindent 8 }}
         {{- if and .Values.global.elasticsearch.search.custom.enabled .Values.global.elasticsearch.search.custom.config }}
         - configMap:
             name: {{ printf "%s-%s" .Release.Name "search-custom" }}
@@ -311,6 +312,7 @@ spec:
                   key: {{ $envVarValue }}
             {{- end }}
             {{- end }}
+            {{- include "datahub.globalTls.spring.env" . | nindent 12 }}
             {{- with .Values.global.kafka.topics }}
             - name: METADATA_CHANGE_EVENT_NAME
               value: {{ .metadata_change_event_name }}
@@ -572,6 +574,7 @@ spec:
             - name: datahub-certs-dir
               mountPath: {{ .path | default "/mnt/certs" }}
           {{- end }}
+            {{- include "datahub.globalTls.volumeMount" . | nindent 12 }}
           {{- if and .Values.global.elasticsearch.search.custom.enabled .Values.global.elasticsearch.search.custom.config }}
             - name: search-config
               mountPath: "/datahub/datahub-gms/resources/search"

--- a/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
@@ -42,9 +42,12 @@ spec:
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
         {{- end }}
-        {{- if .extraInitContainers }}
+        {{- if or (eq (include "datahub.globalTls.enabled" $) "true") .extraInitContainers }}
           initContainers:
+            {{- include "datahub.globalTls.initContainer" $ | nindent 12 }}
+          {{- if .extraInitContainers }}
           {{- toYaml .extraInitContainers | nindent 12 }}
+          {{- end }}
         {{- end }}
         {{- if .hostAliases }}
           hostAliases:
@@ -66,6 +69,7 @@ spec:
             volumeMounts:
               - name: recipe
                 mountPath: /etc/recipe
+              {{- include "datahub.globalTls.volumeMount" $ | nindent 14 }}
             {{- if .extraVolumeMounts }}
               {{- toYaml .extraVolumeMounts | nindent 14 }}
             {{- end }}
@@ -90,6 +94,8 @@ spec:
                     key: {{ $value.key | quote }}
               {{- end }}
               {{- end }}
+              {{- include "datahub.globalTls.librdkafka.env" $ | nindent 14 }}
+              {{- include "datahub.globalTls.requestsCaBundle.env" $ | nindent 14 }}
             {{- if .extraSidecars }}
               {{- toYaml .extraSidecars | nindent 10 }}
             {{- end }}
@@ -110,6 +116,7 @@ spec:
             - name: recipe
               configMap:
                 name: {{ required "A valid .recipe.configmapName entry is required!" $val.recipe.configmapName }}
+            {{- include "datahub.globalTls.volume" $ | nindent 12 }}
           {{- if .extraVolumes }}
             {{- toYaml .extraVolumes | nindent 12 }}
           {{- end }}

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -47,6 +47,7 @@ spec:
             defaultMode: 0444
             secretName: {{ .name }}
         {{- end }}
+        {{- include "datahub.globalTls.volume" . | nindent 8 }}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -54,6 +55,7 @@ spec:
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
       initContainers:
+        {{- include "datahub.globalTls.initContainer" . | nindent 8 }}
       {{- with .Values.extraInitContainers }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -274,6 +276,7 @@ spec:
                   key: {{ $envVarValue }}
             {{- end }}
             {{- end }}
+            {{- include "datahub.globalTls.spring.env" . | nindent 12 }}
             {{- with .Values.global.kafka.topics }}
             - name: METADATA_AUDIT_EVENT_NAME
               value: {{ .metadata_audit_event_name }}
@@ -348,6 +351,7 @@ spec:
             - name: datahub-certs-dir
               mountPath: {{ .path | default "/mnt/certs" }}
           {{- end }}
+            {{- include "datahub.globalTls.volumeMount" . | nindent 12 }}
           {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
@@ -51,6 +51,7 @@ spec:
             defaultMode: 0444
             secretName: {{ .Values.global.credentialsAndCertsSecrets.name }}
         {{- end }}
+        {{- include "datahub.globalTls.volume" . | nindent 8 }}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -58,6 +59,7 @@ spec:
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
       initContainers:
+        {{- include "datahub.globalTls.initContainer" . | nindent 8 }}
       {{- with .Values.extraInitContainers }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -287,6 +289,7 @@ spec:
                   key: {{ $envVarValue }}
             {{- end }}
             {{- end }}
+            {{- include "datahub.globalTls.spring.env" . | nindent 12 }}
             {{- with .Values.global.kafka.topics }}
             - name: METADATA_CHANGE_EVENT_NAME
               value: {{ .metadata_change_event_name }}
@@ -391,6 +394,7 @@ spec:
             - name: datahub-certs-dir
               mountPath: {{ .path | default "/mnt/certs" }}
           {{- end }}
+            {{- include "datahub.globalTls.volumeMount" . | nindent 12 }}
           {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/datahub/templates/_helpers.tpl
+++ b/charts/datahub/templates/_helpers.tpl
@@ -878,3 +878,168 @@ USAGE: Include in services that run embedding ingestion:
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+────────────────────────────────────────────────────────────────────
+global.tls — projected volume and runtime-native env var helpers
+────────────────────────────────────────────────────────────────────
+
+global.tls is a single operator input for PEM TLS that the chart
+templates into each runtime's native env vars:
+
+  Spring Boot Kafka / Schema Registry clients
+    SPRING_KAFKA_PROPERTIES_SSL_TRUSTSTORE_TYPE=PEM
+    SPRING_KAFKA_PROPERTIES_SSL_TRUSTSTORE_LOCATION=/etc/datahub/tls/ca.pem
+    KAFKA_SCHEMA_REGISTRY_SSL_TRUSTSTORE_TYPE=PEM
+    KAFKA_SCHEMA_REGISTRY_SSL_TRUSTSTORE_LOCATION=/etc/datahub/tls/ca.pem
+    SPRING_KAFKA_PROPERTIES_SCHEMA_REGISTRY_SSL_TRUSTSTORE_TYPE=PEM
+    SPRING_KAFKA_PROPERTIES_SCHEMA_REGISTRY_SSL_TRUSTSTORE_LOCATION=/etc/datahub/tls/ca.pem
+
+  librdkafka clients
+    KAFKA_PROPERTIES_SSL_CA_LOCATION=/etc/datahub/tls/ca.pem
+    KAFKA_PROPERTIES_SSL_CERTIFICATE_LOCATION=/etc/datahub/tls/tls.crt
+    KAFKA_PROPERTIES_SSL_KEY_LOCATION=/etc/datahub/tls/tls.key
+    KAFKA_SCHEMA_REGISTRY_PROPERTIES_SSL_CA_LOCATION=/etc/datahub/tls/ca.pem
+
+  Python HTTP clients (requests / httpx / certifi)
+    REQUESTS_CA_BUNDLE=/etc/datahub/tls/ca.pem
+
+Java Kafka mTLS client auth (ssl.keystore.type=PEM with combined
+cert+key file) is intentionally NOT emitted by these helpers yet —
+pending a design decision on how to materialize the combined PEM
+file (projected volume with path rewriting vs. init container).
+librdkafka consumes the separate cert/key files directly and is
+unaffected.
+*/}}
+
+{{- define "datahub.globalTls.enabled" -}}
+{{- and .Values.global.datahub .Values.global.datahub.tls .Values.global.datahub.tls.enabled -}}
+{{- end -}}
+
+{{/*
+Projected volume spec for global.tls. Emits a single `projected`
+volume assembling the referenced secret keys into /etc/datahub/tls.
+
+USAGE (under spec.template.spec.volumes):
+  {{- include "datahub.globalTls.volume" . | nindent 8 }}
+*/}}
+{{- define "datahub.globalTls.volume" -}}
+{{- if eq (include "datahub.globalTls.enabled" .) "true" }}
+{{- $tls := .Values.global.datahub.tls }}
+- name: datahub-tls
+  projected:
+    defaultMode: 0444
+    sources:
+      - secret:
+          name: {{ $tls.ca.secretName }}
+          items:
+            - key: {{ $tls.ca.key }}
+              path: ca.pem
+      {{- if $tls.cert }}
+      - secret:
+          name: {{ $tls.cert.secretName }}
+          items:
+            - key: {{ $tls.cert.key }}
+              path: tls.crt
+      {{- end }}
+      {{- if $tls.key }}
+      - secret:
+          name: {{ $tls.key.secretName }}
+          items:
+            - key: {{ $tls.key.key }}
+              path: tls.key
+      {{- end }}
+      {{- if $tls.keyPasswordFile }}
+      - secret:
+          name: {{ $tls.keyPasswordFile.secretName }}
+          items:
+            - key: {{ $tls.keyPasswordFile.key }}
+              path: key.pass
+      {{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Volume mount spec for global.tls — mounts the projected volume at
+/etc/datahub/tls read-only.
+
+USAGE (under container.volumeMounts):
+  {{- include "datahub.globalTls.volumeMount" . | nindent 12 }}
+*/}}
+{{- define "datahub.globalTls.volumeMount" -}}
+{{- if eq (include "datahub.globalTls.enabled" .) "true" }}
+- name: datahub-tls
+  mountPath: /etc/datahub/tls
+  readOnly: true
+{{- end }}
+{{- end -}}
+
+{{/*
+Spring Boot Kafka + Schema Registry TLS env vars from global.tls.
+Emits only the truststore (server-auth) side today; Kafka mTLS
+client auth on the Java side is TODO pending combined-keystore
+design decision.
+
+USAGE (under container.env):
+  {{- include "datahub.globalTls.spring.env" . | nindent 12 }}
+*/}}
+{{- define "datahub.globalTls.spring.env" -}}
+{{- if eq (include "datahub.globalTls.enabled" .) "true" }}
+- name: SPRING_KAFKA_PROPERTIES_SSL_TRUSTSTORE_TYPE
+  value: "PEM"
+- name: SPRING_KAFKA_PROPERTIES_SSL_TRUSTSTORE_LOCATION
+  value: "/etc/datahub/tls/ca.pem"
+- name: KAFKA_SCHEMA_REGISTRY_SSL_TRUSTSTORE_TYPE
+  value: "PEM"
+- name: KAFKA_SCHEMA_REGISTRY_SSL_TRUSTSTORE_LOCATION
+  value: "/etc/datahub/tls/ca.pem"
+- name: SPRING_KAFKA_PROPERTIES_SCHEMA_REGISTRY_SSL_TRUSTSTORE_TYPE
+  value: "PEM"
+- name: SPRING_KAFKA_PROPERTIES_SCHEMA_REGISTRY_SSL_TRUSTSTORE_LOCATION
+  value: "/etc/datahub/tls/ca.pem"
+{{- end }}
+{{- end -}}
+
+{{/*
+librdkafka TLS env vars from global.tls, for Python components
+using confluent-kafka. Emits CA plus the separate cert / key files
+when provided (librdkafka natively consumes them as separate files).
+
+USAGE (under container.env):
+  {{- include "datahub.globalTls.librdkafka.env" . | nindent 12 }}
+*/}}
+{{- define "datahub.globalTls.librdkafka.env" -}}
+{{- if eq (include "datahub.globalTls.enabled" .) "true" }}
+{{- $tls := .Values.global.datahub.tls }}
+- name: KAFKA_PROPERTIES_SSL_CA_LOCATION
+  value: "/etc/datahub/tls/ca.pem"
+- name: KAFKA_SCHEMA_REGISTRY_PROPERTIES_SSL_CA_LOCATION
+  value: "/etc/datahub/tls/ca.pem"
+{{- if $tls.cert }}
+- name: KAFKA_PROPERTIES_SSL_CERTIFICATE_LOCATION
+  value: "/etc/datahub/tls/tls.crt"
+{{- end }}
+{{- if $tls.key }}
+- name: KAFKA_PROPERTIES_SSL_KEY_LOCATION
+  value: "/etc/datahub/tls/tls.key"
+{{- end }}
+{{- if $tls.keyPasswordFile }}
+- name: KAFKA_PROPERTIES_SSL_KEY_PASSWORD_LOCATION
+  value: "/etc/datahub/tls/key.pass"
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+REQUESTS_CA_BUNDLE env var from global.tls.ca, for Python HTTP
+clients (requests / httpx / certifi) talking to GMS.
+
+USAGE (under container.env):
+  {{- include "datahub.globalTls.requestsCaBundle.env" . | nindent 12 }}
+*/}}
+{{- define "datahub.globalTls.requestsCaBundle.env" -}}
+{{- if eq (include "datahub.globalTls.enabled" .) "true" }}
+- name: REQUESTS_CA_BUNDLE
+  value: "/etc/datahub/tls/ca.pem"
+{{- end }}
+{{- end -}}

--- a/charts/datahub/templates/_helpers.tpl
+++ b/charts/datahub/templates/_helpers.tpl
@@ -881,44 +881,64 @@ USAGE: Include in services that run embedding ingestion:
 
 {{/*
 ────────────────────────────────────────────────────────────────────
-global.tls — projected volume and runtime-native env var helpers
+global.datahub.tls — volumes, init container, and env var helpers
 ────────────────────────────────────────────────────────────────────
 
-global.tls is a single operator input for PEM TLS that the chart
-templates into each runtime's native env vars:
+global.datahub.tls is a single operator input for PEM TLS that the
+chart fans out into each runtime's native env vars.
+
+Shape at pod level:
+
+  - A projected volume `datahub-tls-src` pulls the referenced secret
+    keys and mounts them read-only at /etc/datahub/tls-src/.
+  - A tmpfs emptyDir `datahub-tls` is mounted at /etc/datahub/tls/
+    in the main container read-only.
+  - A tiny busybox init container reads from /etc/datahub/tls-src/
+    and writes to /etc/datahub/tls/: copies ca.pem, tls.crt,
+    tls.key, and key.pass as-is; concatenates tls.crt + tls.key
+    into bundle.pem when both exist (required by Java Kafka's PEM
+    file-mode keystore).
+
+Main containers see:
+
+  /etc/datahub/tls/ca.pem        (always)
+  /etc/datahub/tls/tls.crt       (when cert set)
+  /etc/datahub/tls/tls.key       (when key set)
+  /etc/datahub/tls/bundle.pem    (when cert AND key set)
+  /etc/datahub/tls/key.pass      (when keyPasswordFile set)
+
+Env vars emitted per runtime:
 
   Spring Boot Kafka / Schema Registry clients
-    SPRING_KAFKA_PROPERTIES_SSL_TRUSTSTORE_TYPE=PEM
-    SPRING_KAFKA_PROPERTIES_SSL_TRUSTSTORE_LOCATION=/etc/datahub/tls/ca.pem
-    KAFKA_SCHEMA_REGISTRY_SSL_TRUSTSTORE_TYPE=PEM
-    KAFKA_SCHEMA_REGISTRY_SSL_TRUSTSTORE_LOCATION=/etc/datahub/tls/ca.pem
-    SPRING_KAFKA_PROPERTIES_SCHEMA_REGISTRY_SSL_TRUSTSTORE_TYPE=PEM
-    SPRING_KAFKA_PROPERTIES_SCHEMA_REGISTRY_SSL_TRUSTSTORE_LOCATION=/etc/datahub/tls/ca.pem
+    SPRING_KAFKA_PROPERTIES_SSL_TRUSTSTORE_{TYPE,LOCATION}
+    KAFKA_SCHEMA_REGISTRY_SSL_TRUSTSTORE_{TYPE,LOCATION}
+    SPRING_KAFKA_PROPERTIES_SCHEMA_REGISTRY_SSL_TRUSTSTORE_{TYPE,LOCATION}
+    (+ keystore variants pointing at bundle.pem when cert+key set)
 
   librdkafka clients
-    KAFKA_PROPERTIES_SSL_CA_LOCATION=/etc/datahub/tls/ca.pem
-    KAFKA_PROPERTIES_SSL_CERTIFICATE_LOCATION=/etc/datahub/tls/tls.crt
-    KAFKA_PROPERTIES_SSL_KEY_LOCATION=/etc/datahub/tls/tls.key
-    KAFKA_SCHEMA_REGISTRY_PROPERTIES_SSL_CA_LOCATION=/etc/datahub/tls/ca.pem
+    KAFKA_PROPERTIES_SSL_CA_LOCATION
+    KAFKA_PROPERTIES_SSL_CERTIFICATE_LOCATION  (when cert set)
+    KAFKA_PROPERTIES_SSL_KEY_LOCATION          (when key set)
+    KAFKA_SCHEMA_REGISTRY_PROPERTIES_SSL_CA_LOCATION
 
   Python HTTP clients (requests / httpx / certifi)
-    REQUESTS_CA_BUNDLE=/etc/datahub/tls/ca.pem
-
-Java Kafka mTLS client auth (ssl.keystore.type=PEM with combined
-cert+key file) is intentionally NOT emitted by these helpers yet —
-pending a design decision on how to materialize the combined PEM
-file (projected volume with path rewriting vs. init container).
-librdkafka consumes the separate cert/key files directly and is
-unaffected.
+    REQUESTS_CA_BUNDLE
 */}}
 
 {{- define "datahub.globalTls.enabled" -}}
 {{- and .Values.global.datahub .Values.global.datahub.tls .Values.global.datahub.tls.enabled -}}
 {{- end -}}
 
+{{- define "datahub.globalTls.hasClientIdentity" -}}
+{{- if eq (include "datahub.globalTls.enabled" .) "true" -}}
+{{- $tls := .Values.global.datahub.tls -}}
+{{- if and $tls.cert $tls.key -}}true{{- else -}}false{{- end -}}
+{{- else -}}false{{- end -}}
+{{- end -}}
+
 {{/*
-Projected volume spec for global.tls. Emits a single `projected`
-volume assembling the referenced secret keys into /etc/datahub/tls.
+Volume specs for global.datahub.tls: projected source volume plus
+tmpfs emptyDir target that the init container populates.
 
 USAGE (under spec.template.spec.volumes):
   {{- include "datahub.globalTls.volume" . | nindent 8 }}
@@ -926,7 +946,7 @@ USAGE (under spec.template.spec.volumes):
 {{- define "datahub.globalTls.volume" -}}
 {{- if eq (include "datahub.globalTls.enabled" .) "true" }}
 {{- $tls := .Values.global.datahub.tls }}
-- name: datahub-tls
+- name: datahub-tls-src
   projected:
     defaultMode: 0444
     sources:
@@ -956,12 +976,57 @@ USAGE (under spec.template.spec.volumes):
             - key: {{ $tls.keyPasswordFile.key }}
               path: key.pass
       {{- end }}
+- name: datahub-tls
+  emptyDir:
+    medium: Memory
+    sizeLimit: 1Mi
 {{- end }}
 {{- end -}}
 
 {{/*
-Volume mount spec for global.tls — mounts the projected volume at
-/etc/datahub/tls read-only.
+Init container that materializes /etc/datahub/tls from the projected
+source volume. Copies ca.pem, tls.crt, tls.key, key.pass as-is;
+concatenates tls.crt + tls.key into bundle.pem when both exist.
+
+USAGE (under spec.template.spec.initContainers):
+  {{- include "datahub.globalTls.initContainer" . | nindent 8 }}
+*/}}
+{{- define "datahub.globalTls.initContainer" -}}
+{{- if eq (include "datahub.globalTls.enabled" .) "true" }}
+{{- $tls := .Values.global.datahub.tls }}
+- name: datahub-tls-init
+  image: {{ dig "initContainer" "image" "busybox:1.37.0" $tls | quote }}
+  imagePullPolicy: IfNotPresent
+  command:
+    - sh
+    - -c
+    - |
+      set -eu
+      cp /etc/datahub/tls-src/ca.pem /etc/datahub/tls/ca.pem
+      if [ -f /etc/datahub/tls-src/tls.crt ]; then
+        cp /etc/datahub/tls-src/tls.crt /etc/datahub/tls/tls.crt
+      fi
+      if [ -f /etc/datahub/tls-src/tls.key ]; then
+        cp /etc/datahub/tls-src/tls.key /etc/datahub/tls/tls.key
+      fi
+      if [ -f /etc/datahub/tls-src/tls.crt ] && [ -f /etc/datahub/tls-src/tls.key ]; then
+        cat /etc/datahub/tls-src/tls.crt /etc/datahub/tls-src/tls.key > /etc/datahub/tls/bundle.pem
+      fi
+      if [ -f /etc/datahub/tls-src/key.pass ]; then
+        cp /etc/datahub/tls-src/key.pass /etc/datahub/tls/key.pass
+      fi
+  volumeMounts:
+    - name: datahub-tls-src
+      mountPath: /etc/datahub/tls-src
+      readOnly: true
+    - name: datahub-tls
+      mountPath: /etc/datahub/tls
+{{- end }}
+{{- end -}}
+
+{{/*
+Volume mount spec for global.datahub.tls — mounts the tmpfs target
+at /etc/datahub/tls read-only in the main container.
 
 USAGE (under container.volumeMounts):
   {{- include "datahub.globalTls.volumeMount" . | nindent 12 }}
@@ -975,10 +1040,10 @@ USAGE (under container.volumeMounts):
 {{- end -}}
 
 {{/*
-Spring Boot Kafka + Schema Registry TLS env vars from global.tls.
-Emits only the truststore (server-auth) side today; Kafka mTLS
-client auth on the Java side is TODO pending combined-keystore
-design decision.
+Spring Boot Kafka + Schema Registry TLS env vars from
+global.datahub.tls. Emits truststore (server-auth) always; emits
+keystore (mTLS client-auth) when cert+key are set, pointing at the
+bundle.pem produced by the init container.
 
 USAGE (under container.env):
   {{- include "datahub.globalTls.spring.env" . | nindent 12 }}
@@ -997,6 +1062,20 @@ USAGE (under container.env):
   value: "PEM"
 - name: SPRING_KAFKA_PROPERTIES_SCHEMA_REGISTRY_SSL_TRUSTSTORE_LOCATION
   value: "/etc/datahub/tls/ca.pem"
+{{- if eq (include "datahub.globalTls.hasClientIdentity" .) "true" }}
+- name: SPRING_KAFKA_PROPERTIES_SSL_KEYSTORE_TYPE
+  value: "PEM"
+- name: SPRING_KAFKA_PROPERTIES_SSL_KEYSTORE_LOCATION
+  value: "/etc/datahub/tls/bundle.pem"
+- name: KAFKA_SCHEMA_REGISTRY_SSL_KEYSTORE_TYPE
+  value: "PEM"
+- name: KAFKA_SCHEMA_REGISTRY_SSL_KEYSTORE_LOCATION
+  value: "/etc/datahub/tls/bundle.pem"
+- name: SPRING_KAFKA_PROPERTIES_SCHEMA_REGISTRY_SSL_KEYSTORE_TYPE
+  value: "PEM"
+- name: SPRING_KAFKA_PROPERTIES_SCHEMA_REGISTRY_SSL_KEYSTORE_LOCATION
+  value: "/etc/datahub/tls/bundle.pem"
+{{- end }}
 {{- end }}
 {{- end -}}
 

--- a/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
+++ b/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
@@ -157,6 +157,7 @@ Return the env variables for upgrade jobs
       key: {{ $envVarValue }}
 {{- end }}
 {{- end }}
+{{- include "datahub.globalTls.spring.env" . }}
 {{- with .Values.global.kafka.topics }}
 - name: METADATA_CHANGE_EVENT_NAME
   value: {{ .metadata_change_event_name }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
@@ -54,6 +54,7 @@ spec:
                 defaultMode: 0444
                 secretName: {{ .name }}
             {{- end }}
+            {{- include "datahub.globalTls.volume" . | nindent 12 }}
           {{- with .Values.datahubUpgrade.extraVolumes }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -61,6 +62,7 @@ spec:
           securityContext:
             {{- toYaml .Values.datahubUpgrade.podSecurityContext | nindent 12 }}
           initContainers:
+            {{- include "datahub.globalTls.initContainer" . | nindent 12 }}
           {{- with .Values.datahubUpgrade.extraInitContainers }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -131,6 +133,7 @@ spec:
                 - name: datahub-certs-dir
                   mountPath: {{ .path | default "/mnt/certs" }}
               {{- end }}
+                {{- include "datahub.globalTls.volumeMount" . | nindent 16 }}
               {{- with .Values.datahubUpgrade.extraVolumeMounts }}
                 {{- toYaml . | nindent 16 }}
               {{- end }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-cron-hourly-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-cron-hourly-job-template.yml
@@ -52,6 +52,7 @@ spec:
                 defaultMode: 0444
                 secretName: {{ .name }}
             {{- end }}
+            {{- include "datahub.globalTls.volume" . | nindent 12 }}
           {{- with .Values.datahubSystemCronHourly.extraVolumes }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -59,6 +60,7 @@ spec:
           securityContext:
             {{- toYaml .Values.datahubSystemCronHourly.podSecurityContext | nindent 12 }}
           initContainers:
+            {{- include "datahub.globalTls.initContainer" . | nindent 12 }}
           {{- with .Values.datahubSystemCronHourly.extraInitContainers }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -96,6 +98,7 @@ spec:
                 - name: datahub-certs-dir
                   mountPath: {{ .path | default "/mnt/certs" }}
               {{- end }}
+                {{- include "datahub.globalTls.volumeMount" . | nindent 16 }}
               {{- with .Values.datahubSystemCronHourly.extraVolumeMounts }}
                 {{- toYaml . | nindent 16 }}
               {{- end }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
@@ -49,15 +49,19 @@ spec:
             defaultMode: 0444
             secretName: {{ .name }}
         {{- end }}
+        {{- include "datahub.globalTls.volume" . | nindent 8 }}
       {{- with .Values.datahubSystemUpdate.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: Never
       securityContext:
         {{- toYaml .Values.datahubSystemUpdate.podSecurityContext | nindent 8 }}
-      {{- with .Values.datahubSystemUpdate.extraInitContainers }}
+      {{- if or (eq (include "datahub.globalTls.enabled" .) "true") .Values.datahubSystemUpdate.extraInitContainers }}
       initContainers:
+        {{- include "datahub.globalTls.initContainer" . | nindent 8 }}
+        {{- with .Values.datahubSystemUpdate.extraInitContainers }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: datahub-system-update-job
@@ -258,6 +262,7 @@ spec:
             - name: datahub-certs-dir
               mountPath: {{ .path | default "/mnt/certs" }}
           {{- end }}
+            {{- include "datahub.globalTls.volumeMount" . | nindent 12 }}
           {{- with .Values.datahubSystemUpdate.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -327,6 +332,7 @@ spec:
             defaultMode: 0444
             secretName: {{ .name }}
         {{- end }}
+        {{- include "datahub.globalTls.volume" . | nindent 8 }}
       {{- with .Values.datahubSystemUpdate.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -334,9 +340,12 @@ spec:
       securityContext:
         {{- toYaml .Values.datahubSystemUpdate.podSecurityContext | nindent 8 }}
       {{- $scaleDownEffective := .Values.global.datahub.systemUpdate.scaleDown.enabled | default false }}
-      {{- with .Values.datahubSystemUpdate.extraInitContainers }}
+      {{- if or (eq (include "datahub.globalTls.enabled" .) "true") .Values.datahubSystemUpdate.extraInitContainers }}
       initContainers:
+        {{- include "datahub.globalTls.initContainer" . | nindent 8 }}
+        {{- with .Values.datahubSystemUpdate.extraInitContainers }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: datahub-system-update-job
@@ -474,6 +483,7 @@ spec:
             - name: datahub-certs-dir
               mountPath: {{ .path | default "/mnt/certs" }}
           {{- end }}
+            {{- include "datahub.globalTls.volumeMount" . | nindent 12 }}
           {{- with .Values.datahubSystemUpdate.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -1310,6 +1310,8 @@ global:
 #      keyPasswordFile:                    # optional, encrypted keys
 #        secretName: datahub-workload-tls
 #        key: key.pass
+#      initContainer:
+#        image: busybox:1.37.0             # concatenates cert+key into bundle.pem
 
 ## ────────────────────────────────────────────────────────────────────
 ## Kafka SSL — low-level escape hatch (free-form overrides)

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -1282,16 +1282,18 @@ global:
 ## secret keys at /etc/datahub/tls/ and templates them into each
 ## component's runtime-native env vars:
 ##   - Spring Boot Kafka clients (GMS, MAE, MCE, datahub-system-update)
-##     → SPRING_KAFKA_PROPERTIES_SSL_TRUSTSTORE_*
+##     → SPRING_KAFKA_PROPERTIES_SSL_TRUSTSTORE_* (server auth, always)
+##     → SPRING_KAFKA_PROPERTIES_SSL_KEYSTORE_*   (mTLS, when cert+key set)
 ##   - librdkafka clients (acryl-datahub-actions)
 ##     → KAFKA_PROPERTIES_SSL_CA_LOCATION / SSL_CERTIFICATE_LOCATION /
 ##       SSL_KEY_LOCATION
 ##   - Python HTTP clients talking to GMS → REQUESTS_CA_BUNDLE
 ##
-## Kafka mTLS client auth on the Java side (ssl.keystore.type=PEM
-## with a combined cert+key file) is not yet wired — pending a chart
-## design decision on how to produce the combined PEM. librdkafka
-## consumes the separate cert/key files directly and is unaffected.
+## Kafka mTLS on the Java side uses ssl.keystore.type=PEM pointed at
+## a combined bundle.pem (tls.crt + tls.key), produced in-cluster by
+## a tiny busybox init container that concatenates the two files into
+## a tmpfs emptyDir. librdkafka consumes the separate cert/key files
+## directly and doesn't need the combined bundle.
 ##
 ## The existing credentialsAndCertsSecrets + springKafkaConfigurationOverrides
 ## interface below keeps working unchanged; global.datahub.tls is additive.

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -1275,7 +1275,51 @@ global:
 #        - "elasticsearch"
 #        - "neo4j"
 
-## Add below to enable SSL for kafka
+## ────────────────────────────────────────────────────────────────────
+## TLS for Kafka / Schema Registry / GMS HTTP — recommended path
+## ────────────────────────────────────────────────────────────────────
+## A single operator input, PEM only. The chart mounts the referenced
+## secret keys at /etc/datahub/tls/ and templates them into each
+## component's runtime-native env vars:
+##   - Spring Boot Kafka clients (GMS, MAE, MCE, datahub-system-update)
+##     → SPRING_KAFKA_PROPERTIES_SSL_TRUSTSTORE_*
+##   - librdkafka clients (acryl-datahub-actions)
+##     → KAFKA_PROPERTIES_SSL_CA_LOCATION / SSL_CERTIFICATE_LOCATION /
+##       SSL_KEY_LOCATION
+##   - Python HTTP clients talking to GMS → REQUESTS_CA_BUNDLE
+##
+## Kafka mTLS client auth on the Java side (ssl.keystore.type=PEM
+## with a combined cert+key file) is not yet wired — pending a chart
+## design decision on how to produce the combined PEM. librdkafka
+## consumes the separate cert/key files directly and is unaffected.
+##
+## The existing credentialsAndCertsSecrets + springKafkaConfigurationOverrides
+## interface below keeps working unchanged; global.datahub.tls is additive.
+#  datahub:
+#    tls:
+#      enabled: true
+#      ca:
+#        secretName: datahub-internal-ca
+#        key: ca.pem
+#      cert:                               # optional, Kafka mTLS only
+#        secretName: datahub-workload-tls
+#        key: tls.crt
+#      key:                                # optional, Kafka mTLS only
+#        secretName: datahub-workload-tls
+#        key: tls.key
+#      keyPasswordFile:                    # optional, encrypted keys
+#        secretName: datahub-workload-tls
+#        key: key.pass
+
+## ────────────────────────────────────────────────────────────────────
+## Kafka SSL — low-level escape hatch (free-form overrides)
+## ────────────────────────────────────────────────────────────────────
+## Use when global.tls cannot express a corner case (custom cipher
+## suites, CRL paths, non-standard endpoint identification, JKS /
+## PKCS12 material you don't want to convert to PEM, split-PKI, ...).
+##
+## Spring side — applies to GMS, MAE, MCE, datahub-system-update.
+## Emitted by the chart as SPRING_KAFKA_PROPERTIES_* env vars.
 #  credentialsAndCertsSecrets:
 #    name: datahub-certs
 #    path: /mnt/datahub/certs
@@ -1297,3 +1341,24 @@ global:
 #    ssl.endpoint.identification.algorithm:
 #    basic.auth.credentials.source: USER_INFO
 #    basic.auth.user.info:
+#
+## Python side — applies to acryl-datahub-actions and other Python
+## components using librdkafka. Emitted by the chart as KAFKA_PROPERTIES_*
+## env vars. Keys are librdkafka vocabulary (ssl.ca.location,
+## ssl.certificate.location, ssl.key.location) — different from Kafka
+## Java client vocabulary. If unset, the chart falls back to a
+## Java-only-filtered view of springKafkaConfigurationOverrides.
+#  pythonKafkaConfigurationOverrides:
+#    ssl.ca.location: /mnt/datahub/certs/ca.pem
+#    ssl.certificate.location: /mnt/datahub/certs/tls.crt
+#    ssl.key.location: /mnt/datahub/certs/tls.key
+#    security.protocol: SSL
+#    ssl.cipher.suites: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
+#
+## Python-side Kafka secrets (passwords, PEM strings) sourced from
+## Kubernetes secrets. If unset, falls back to a Java-only-filtered
+## view of credentialsAndCertsSecrets.secureEnv.
+#  pythonKafkaSecretsOverrides:
+#    ssl.key.password:
+#      secretRef: datahub-certs
+#      secretKey: datahub.linkedin.com.KeyPass


### PR DESCRIPTION
Broader context via RFC: https://github.com/datahub-project/datahub/pull/16975

Adds `global.datahub.tls` — a single PEM-only operator input that fans out into each runtime's native env vars across every DataHub component that talks to Kafka, Schema Registry, or GMS. It is intended not to introduce any breaking changes. Operators on `credentialsAndCertsSecrets` + `springKafkaConfigurationOverrides` should see zero change. `global.datahub.tls` is additive. Comment on the RFC for overall guidance would be much appreciated!

## Side fix

`acryl-datahub-actions` previously forwarded `springKafkaConfigurationOverrides` straight into `KAFKA_PROPERTIES_*`, cross-pollinating Kafka Java vocabulary into librdkafka. Replaced with the existing
`datahub.python.kafka.*.with.fallback` helpers. `global.pythonKafkaConfigurationOverrides` and `global.pythonKafkaSecretsOverrides` are now actually wired and documented.

## Related

- acryldata/datahub-helm#601
- datahub-project/datahub#16975 (parent RFC)
- datahub-project/datahub#16997 (companion GMS fix)

## Test plan

- [x] `helm template` with TLS enabled: 44 TLS anchors across 6 components
- [x] `helm template` with TLS unset: zero TLS output
- [ ] Deploy against PEM-configured Kafka/SR and confirm handshakes