### PR TITLE
fix(helm): guard system-update serviceAccountName when scaleDown with…

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.7
+version: 0.9.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
@@ -35,7 +35,7 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if or $scaleDownEffective (index $sa "name") }}
+    {{- if or (index $sa "name") (and $scaleDownEffective (index $sa "create")) }}
       serviceAccountName: {{ default "datahub-operator-sa" (index $sa "name") }}
     {{- end }}
     {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
…out SA

Only emit serviceAccountName when an explicit name is set or when scale-down is enabled and serviceAccount.create is true. Previously, scaleDown alone forced serviceAccountName to the default operator SA even when serviceAccount was empty and no ServiceAccount was rendered, causing InvalidServiceAccountName at schedule time.

Made-with: Cursor



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
