### PR TITLE
feat(zdu): force cloneIndices=true when ZDU_STAGE_20 is set

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.9
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
@@ -204,8 +204,13 @@ spec:
               value: "{{ . }}"
             {{- end }}
             {{- end }}
+            {{- if .Values.global.datahub.systemUpdate.zdu.enable }}
+            - name: ELASTICSEARCH_BUILD_INDICES_CLONE_INDICES
+              value: "true"
+            {{- else }}
             - name: ELASTICSEARCH_BUILD_INDICES_CLONE_INDICES
               value: {{ .Values.global.elasticsearch.index.upgrade.cloneIndices | quote }}
+            {{- end }}
             {{- with .Values.global.elasticsearch.index.enableMappingsReindex }}
             - name: ELASTICSEARCH_INDEX_BUILDER_MAPPINGS_REINDEX
               value: {{ . | quote }}
@@ -438,8 +443,13 @@ spec:
             {{- end }}
             - name: ELASTICSEARCH_BUILD_INDICES_REINDEX_OPTIMIZATION_ENABLED
               value: {{ .Values.global.elasticsearch.index.upgrade.reindexOptimizationEnabled | quote }}
+            {{- if .Values.global.datahub.systemUpdate.zdu.enable }}
+            - name: ELASTICSEARCH_BUILD_INDICES_CLONE_INDICES
+              value: "true"
+            {{- else }}
             - name: ELASTICSEARCH_BUILD_INDICES_CLONE_INDICES
               value: {{ .Values.global.elasticsearch.index.upgrade.cloneIndices | quote }}
+            {{- end }}
             {{- with .Values.global.elasticsearch.index.enableMappingsReindex }}
             - name: ELASTICSEARCH_INDEX_BUILDER_MAPPINGS_REINDEX
               value: {{ . | quote }}

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -720,6 +720,8 @@ global:
       upgrade:
         ## When reindexing is required, this option will clone the existing index as a backup
         ## The clone indices are not currently managed.
+        ## Automatically set to true when zdu.enable=true (ZDU_STAGE_20). Individual value is
+        ## only respected when zdu.enable is not set.
         cloneIndices: true
 
         ## Typically when reindexing the document counts between the original and destination indices should match.


### PR DESCRIPTION
## Summary

- When `zdu.enable=true` (which sets `ZDU_STAGE_20`), `ELASTICSEARCH_BUILD_INDICES_CLONE_INDICES` is forced to `true` in both system-update job container specs, regardless of the `cloneIndices` value in values.yaml
- The individual `cloneIndices` key is only respected when `zdu.enable` is not set — mirrors the same pattern used for `allowDocCountMismatch` - allowDocCountMismatch requires cloneIndices to also be set.
- Updated `values.yaml` comment to document this cascade behavior
- Bumps chart version to `0.10.0`

## Test plan

- [ ] Verify that with `zdu.enable=true`, `ELASTICSEARCH_BUILD_INDICES_CLONE_INDICES=true` is rendered regardless of `cloneIndices` value
- [ ] Verify that with `zdu.enable` unset, `ELASTICSEARCH_BUILD_INDICES_CLONE_INDICES` uses the `cloneIndices` value from values.yaml
- [ ] Confirm both system-update container specs (init + main) are updated consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)