### PR TITLE
fix(helm): decouple allowDocCountMismatch from zdu.enable

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.9
+version: 0.9.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
@@ -236,14 +236,9 @@ spec:
             - name: ELASTICSEARCH_INDEX_BUILDER_REFRESH_INTERVAL_SECONDS
               value: {{ . | quote }}
             {{- end }}
-            {{- if .Values.global.datahub.systemUpdate.zdu.enable }}
-            - name: ELASTICSEARCH_BUILD_INDICES_ALLOW_DOC_COUNT_MISMATCH
-              value: "true"
-            {{- else }}
             {{- with .Values.global.elasticsearch.index.upgrade.allowDocCountMismatch }}
             - name: ELASTICSEARCH_BUILD_INDICES_ALLOW_DOC_COUNT_MISMATCH
               value: {{ . | quote }}
-            {{- end }}
             {{- end }}
             {{- range $k, $v := .Values.datahubSystemUpdate.bootstrapMCPs }}
             {{- if ne $k "default" }}
@@ -470,14 +465,9 @@ spec:
             - name: ELASTICSEARCH_INDEX_BUILDER_REFRESH_INTERVAL_SECONDS
               value: {{ . | quote }}
             {{- end }}
-            {{- if .Values.global.datahub.systemUpdate.zdu.enable }}
-            - name: ELASTICSEARCH_BUILD_INDICES_ALLOW_DOC_COUNT_MISMATCH
-              value: "true"
-            {{- else }}
             {{- with .Values.global.elasticsearch.index.upgrade.allowDocCountMismatch }}
             - name: ELASTICSEARCH_BUILD_INDICES_ALLOW_DOC_COUNT_MISMATCH
               value: {{ . | quote }}
-            {{- end }}
             {{- end }}
             {{- range $k, $v := .Values.datahubSystemUpdate.bootstrapMCPs }}
             {{- if ne $k "default" }}

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -729,8 +729,6 @@ global:
         ##
         ## This setting allows continuing if and only if the cloneIndices setting is also enabled which
         ## ensures a complete backup of the original index is preserved.
-        ## Automatically set to true when zdu.enable=true. Individual value is
-        ## only respected when zdu.enable is not set.
         allowDocCountMismatch: false
 
         ## Only disable for OpenSearch/ElasticSearch clusters with zone awareness, otherwise optimization should be utilized


### PR DESCRIPTION
## Summary
- Removes the conditional that forced `ELASTICSEARCH_BUILD_INDICES_ALLOW_DOC_COUNT_MISMATCH=true` whenever `zdu.enable=true`
- `allowDocCountMismatch` is now always driven solely by `global.elasticsearch.index.upgrade.allowDocCountMismatch`
- Bumps chart version to `0.9.10`

## Test plan
- [x] `helm template` with `zdu.enable=true` + `allowDocCountMismatch=true` renders env var as `"true"`
- [x] `helm template` with `zdu.enable=false` + `allowDocCountMismatch=true` renders env var as `"true"`
- [x] `helm template` with `allowDocCountMismatch` unset (default `false`) renders no env var regardless of `zdu.enable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)