### PR TITLE
feat(datahub): consolidate app ServiceAccounts, chart 0.10.0

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,34 +4,34 @@ description: A Helm chart for DataHub (defaults include non-root security contex
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.12
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.5.0
 dependencies:
   - name: datahub-gms
-    version: 0.3.12
+    version: 0.3.15
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
-    version: 0.3.5
+    version: 0.3.8
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer
-    version: 0.3.6
+    version: 0.3.9
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.3.7
+    version: 0.3.10
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron
-    version: 0.2.149
+    version: 0.2.151
     repository: file://./subcharts/datahub-ingestion-cron
     condition: datahub-ingestion-cron.enabled
   - name: acryl-datahub-actions
-    version: 0.3.4
+    version: 0.3.7
     repository: file://./subcharts/acryl-datahub-actions
     condition: acryl-datahub-actions.enabled
 maintainers:

--- a/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.4
+version: 0.3.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.5.0

--- a/charts/datahub/subcharts/acryl-datahub-actions/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/acryl-datahub-actions/templates/_helpers.tpl
@@ -55,10 +55,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "acryl-datahub-actions.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "acryl-datahub-actions.fullname" .) .Values.serviceAccount.name }}
+{{- if .Values.serviceAccount.name -}}
+{{- .Values.serviceAccount.name -}}
+{{- else if and .Values.global.datahub.appServiceAccount .Values.global.datahub.appServiceAccount.name -}}
+{{- .Values.global.datahub.appServiceAccount.name -}}
+{{- else if .Values.serviceAccount.create -}}
+{{- default (include "acryl-datahub-actions.fullname" .) .Values.serviceAccount.name -}}
 {{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
+{{- default "default" .Values.serviceAccount.name -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/datahub/subcharts/acryl-datahub-actions/templates/serviceaccount.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/templates/serviceaccount.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.serviceAccount.create -}}
+{{- $g := .Values.global.datahub.appServiceAccount | default dict }}
+{{- $gn := $g.name | default "" }}
+{{- $skipDup := and $g.create $gn (eq (include "acryl-datahub-actions.serviceAccountName" .) $gn) }}
+{{- if and .Values.serviceAccount.create (not $skipDup) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/datahub/subcharts/datahub-frontend/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.5
+version: 0.3.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.5.0

--- a/charts/datahub/subcharts/datahub-frontend/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-frontend/templates/_helpers.tpl
@@ -55,10 +55,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "datahub-frontend.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "datahub-frontend.fullname" .) .Values.serviceAccount.name }}
+{{- if .Values.serviceAccount.name -}}
+{{- .Values.serviceAccount.name -}}
+{{- else if and .Values.global.datahub.appServiceAccount .Values.global.datahub.appServiceAccount.name -}}
+{{- .Values.global.datahub.appServiceAccount.name -}}
+{{- else if .Values.serviceAccount.create -}}
+{{- default (include "datahub-frontend.fullname" .) .Values.serviceAccount.name -}}
 {{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
+{{- default "default" .Values.serviceAccount.name -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/datahub/subcharts/datahub-frontend/templates/serviceaccount.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/serviceaccount.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.serviceAccount.create -}}
+{{- $g := .Values.global.datahub.appServiceAccount | default dict }}
+{{- $gn := $g.name | default "" }}
+{{- $skipDup := and $g.create $gn (eq (include "datahub-frontend.serviceAccountName" .) $gn) }}
+{{- if and .Values.serviceAccount.create (not $skipDup) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.12
+version: 0.3.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.5.0

--- a/charts/datahub/subcharts/datahub-gms/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-gms/templates/_helpers.tpl
@@ -74,10 +74,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "datahub-gms.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "datahub-gms.fullname" .) .Values.serviceAccount.name }}
+{{- if .Values.serviceAccount.name -}}
+{{- .Values.serviceAccount.name -}}
+{{- else if and .Values.global.datahub.appServiceAccount .Values.global.datahub.appServiceAccount.name -}}
+{{- .Values.global.datahub.appServiceAccount.name -}}
+{{- else if .Values.serviceAccount.create -}}
+{{- default (include "datahub-gms.fullname" .) .Values.serviceAccount.name -}}
 {{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
+{{- default "default" .Values.serviceAccount.name -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/datahub/subcharts/datahub-gms/templates/serviceaccount.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/serviceaccount.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.serviceAccount.create -}}
+{{- $g := .Values.global.datahub.appServiceAccount | default dict }}
+{{- $gn := $g.name | default "" }}
+{{- $skipDup := and $g.create $gn (eq (include "datahub-gms.serviceAccountName" .) $gn) }}
+{{- if and .Values.serviceAccount.create (not $skipDup) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/datahub/subcharts/datahub-ingestion-cron/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.149
+version: 0.2.151
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.5.0

--- a/charts/datahub/subcharts/datahub-ingestion-cron/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/templates/_helpers.tpl
@@ -63,6 +63,15 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Global consolidated app ServiceAccount name from parent chart values (optional).
+*/}}
+{{- define "datahub-ingestion-cron.globalAppSA" -}}
+{{- if and .Values.global.datahub.appServiceAccount .Values.global.datahub.appServiceAccount.name }}
+{{- .Values.global.datahub.appServiceAccount.name }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for cronjob.
 */}}
 {{- define "datahub-ingestion-cron.cronjob.apiVersion" -}}

--- a/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
+++ b/charts/datahub/subcharts/datahub-ingestion-cron/templates/cron.yaml
@@ -50,8 +50,9 @@ spec:
           hostAliases:
           {{- toYaml .hostAliases | nindent 12 }}
         {{- end }}
-        {{- if .serviceAccountName }}
-          serviceAccountName: {{ .serviceAccountName }}
+        {{- $cronSa := default (include "datahub-ingestion-cron.globalAppSA" $) .serviceAccountName }}
+        {{- with $cronSa }}
+          serviceAccountName: {{ . }}
         {{- end }}
           securityContext:
             {{- toYaml $.Values.podSecurityContext | nindent 12 }}

--- a/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.6
+version: 0.3.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.5.0

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/_helpers.tpl
@@ -55,10 +55,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "datahub-mae-consumer.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "datahub-mae-consumer.fullname" .) .Values.serviceAccount.name }}
+{{- if .Values.serviceAccount.name -}}
+{{- .Values.serviceAccount.name -}}
+{{- else if and .Values.global.datahub.appServiceAccount .Values.global.datahub.appServiceAccount.name -}}
+{{- .Values.global.datahub.appServiceAccount.name -}}
+{{- else if .Values.serviceAccount.create -}}
+{{- default (include "datahub-mae-consumer.fullname" .) .Values.serviceAccount.name -}}
 {{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
+{{- default "default" .Values.serviceAccount.name -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/serviceaccount.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/serviceaccount.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.serviceAccount.create -}}
+{{- $g := .Values.global.datahub.appServiceAccount | default dict }}
+{{- $gn := $g.name | default "" }}
+{{- $skipDup := and $g.create $gn (eq (include "datahub-mae-consumer.serviceAccountName" .) $gn) }}
+{{- if and .Values.serviceAccount.create (not $skipDup) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.7
+version: 0.3.10
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.5.0

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/_helpers.tpl
@@ -55,10 +55,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "datahub-mce-consumer.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "datahub-mce-consumer.fullname" .) .Values.serviceAccount.name }}
+{{- if .Values.serviceAccount.name -}}
+{{- .Values.serviceAccount.name -}}
+{{- else if and .Values.global.datahub.appServiceAccount .Values.global.datahub.appServiceAccount.name -}}
+{{- .Values.global.datahub.appServiceAccount.name -}}
+{{- else if .Values.serviceAccount.create -}}
+{{- default (include "datahub-mce-consumer.fullname" .) .Values.serviceAccount.name -}}
 {{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
+{{- default "default" .Values.serviceAccount.name -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/serviceaccount.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/serviceaccount.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.serviceAccount.create -}}
+{{- $g := .Values.global.datahub.appServiceAccount | default dict }}
+{{- $gn := $g.name | default "" }}
+{{- $skipDup := and $g.create $gn (eq (include "datahub-mce-consumer.serviceAccountName" .) $gn) }}
+{{- if and .Values.serviceAccount.create (not $skipDup) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/datahub/templates/_helpers.tpl
+++ b/charts/datahub/templates/_helpers.tpl
@@ -63,6 +63,23 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Consolidated application ServiceAccount name from global.datahub.appServiceAccount (for Jobs/CronJobs templates).
+Returns empty string when unset.
+*/}}
+{{- define "datahub.appServiceAccountName" -}}
+{{- $asa := .Values.global.datahub.appServiceAccount | default dict }}
+{{- with $asa.name }}{{ . }}{{ end }}
+{{- end -}}
+
+{{/*
+Operator / system-update ServiceAccount name (same as datahubSystemUpdate.serviceAccount; default datahub-operator-sa).
+*/}}
+{{- define "datahub.operatorServiceAccountName" -}}
+{{- $sa := .Values.datahubSystemUpdate.serviceAccount | default dict }}
+{{- default "datahub-operator-sa" (index $sa "name") }}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for cronjob.
 */}}
 {{- define "datahub.cronjob.apiVersion" -}}

--- a/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-restore-indices-job-template.yml
@@ -40,7 +40,8 @@ spec:
           hostAliases:
             {{- toYaml . | nindent 12 }}
         {{- end }}
-        {{- with .Values.datahubUpgrade.serviceAccount }}
+        {{- $jobSa := default (include "datahub.appServiceAccountName" .) .Values.datahubUpgrade.serviceAccount }}
+        {{- with $jobSa }}
           serviceAccountName: {{ . }}
         {{- end }}
         {{- with .Values.imagePullSecrets }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-cron-hourly-job-template.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-cron-hourly-job-template.yml
@@ -38,7 +38,8 @@ spec:
           hostAliases:
             {{- toYaml . | nindent 12 }}
         {{- end }}
-        {{- with .Values.datahubSystemCronHourly.serviceAccount }}
+        {{- $jobSa := default (include "datahub.appServiceAccountName" .) .Values.datahubSystemCronHourly.serviceAccount }}
+        {{- with $jobSa }}
           serviceAccountName: {{ . }}
         {{- end }}
         {{- with .Values.datahubSystemCronHourly.imagePullSecrets }}

--- a/charts/datahub/templates/elasticsearch-setup-job.yml
+++ b/charts/datahub/templates/elasticsearch-setup-job.yml
@@ -32,7 +32,8 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.elasticsearchSetupJob.serviceAccount }}
+    {{- $jobSa := default (include "datahub.operatorServiceAccountName" .) .Values.elasticsearchSetupJob.serviceAccount }}
+    {{- with $jobSa }}
       serviceAccountName: {{ . }}
     {{- end }}
     {{- with .Values.imagePullSecrets }}

--- a/charts/datahub/templates/kafka-setup-job.yml
+++ b/charts/datahub/templates/kafka-setup-job.yml
@@ -32,7 +32,8 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.kafkaSetupJob.serviceAccount }}
+    {{- $jobSa := default (include "datahub.operatorServiceAccountName" .) .Values.kafkaSetupJob.serviceAccount }}
+    {{- with $jobSa }}
       serviceAccountName: {{ . }}
     {{- end }}
       restartPolicy: Never

--- a/charts/datahub/templates/mysql-setup-job.yml
+++ b/charts/datahub/templates/mysql-setup-job.yml
@@ -32,7 +32,8 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.mysqlSetupJob.serviceAccount }}
+    {{- $jobSa := default (include "datahub.operatorServiceAccountName" .) .Values.mysqlSetupJob.serviceAccount }}
+    {{- with $jobSa }}
       serviceAccountName: {{ . }}
     {{- end }}
     {{- with .Values.imagePullSecrets }}

--- a/charts/datahub/templates/postgresql-setup-job.yml
+++ b/charts/datahub/templates/postgresql-setup-job.yml
@@ -32,7 +32,8 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.postgresqlSetupJob.serviceAccount }}
+    {{- $jobSa := default (include "datahub.operatorServiceAccountName" .) .Values.postgresqlSetupJob.serviceAccount }}
+    {{- with $jobSa }}
       serviceAccountName: {{ . }}
     {{- end }}
     {{- with .Values.imagePullSecrets }}

--- a/charts/datahub/templates/serviceaccount-app.yaml
+++ b/charts/datahub/templates/serviceaccount-app.yaml
@@ -1,0 +1,14 @@
+{{- $asa := .Values.global.datahub.appServiceAccount | default dict }}
+{{- if $asa.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ required "global.datahub.appServiceAccount.name is required when create is true" $asa.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "datahub.labels" . | nindent 4 }}
+  {{- with $asa.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -28,6 +28,8 @@ datahub-gms:
     enabled: true
     default: true
     toggeable: true
+  serviceAccount:
+    create: false
   # Optionaly specify service type for datahub-gms: LoadBalancer, ClusterIP or NodePort, by default: LoadBalancer
   # service:
   #   type: ClusterIP
@@ -100,6 +102,8 @@ datahub-frontend:
     #   initialViewer:manualPassword
   service:
     extraLabels: {}
+  serviceAccount:
+    create: false
   # Optionaly specify service type for datahub-frontend: LoadBalancer, ClusterIP or NodePort, by default: LoadBalancer
   #   type: ClusterIP
 
@@ -122,6 +126,8 @@ acryl-datahub-actions:
     requests:
       cpu: 300m
       memory: 256Mi
+  serviceAccount:
+    create: false
 
 datahub-mae-consumer:
   image:
@@ -137,8 +143,12 @@ datahub-mae-consumer:
     requests:
       cpu: 100m
       memory: 256Mi
+  serviceAccount:
+    create: false
 
 datahub-mce-consumer:
+  serviceAccount:
+    create: false
   image:
     repository: acryldata/datahub-mce-consumer
     # tag: "v0.11.0" # defaults to .global.datahub.version
@@ -1025,6 +1035,12 @@ global:
 
   datahub:
     version: v1.5.0.1
+    # Consolidated ServiceAccount for application Deployments/Jobs/CronJobs (not system-update operator).
+    # Override per subchart via <subchart>.serviceAccount.name / .create.
+    appServiceAccount:
+      create: true
+      name: datahub-app-sa
+      annotations: {}
     gms:
       protocol: "http"
       port: "8080"


### PR DESCRIPTION
- Add global.datahub.appServiceAccount and parent-managed datahub-app-sa
- Wire GMS, frontend, MAE/MCE consumers, actions to global default with per-chart override
- Jobs/CronJobs default to app SA where applicable; ES/Kafka/MySQL/Postgres setup jobs use operator SA
- Subcharts bumped patch versions; umbrella chart 0.10.0 (breaking for IAM bindings tied to per-component SAs)



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
