### PR TITLE
feat(charts/datahub): consolidatedUpgrade, system-update SQL, and IAM

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for DataHub (defaults include non-root security contex
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.10.0
+version: 0.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/VALUES_REFERENCE.md
+++ b/charts/datahub/VALUES_REFERENCE.md
@@ -888,6 +888,12 @@ This document provides a comprehensive reference for every single configurable v
 <td>When true, the system-update job runs the Java-based Kubernetes scale-down step (KubernetesScaleDownStep), scaling selected deployments to zero and applying deployment env updates during upgrade. Available in v1.5.0.</td>
 </tr>
 <tr>
+<td><code>global.datahub.systemUpdate.consolidatedUpgrade</code></td>
+<td>boolean</td>
+<td><code>true</code></td>
+<td>When <code>true</code>, the chart does not render the legacy <code>elasticsearchSetupJob</code>, <code>kafkaSetupJob</code>, <code>mysqlSetupJob</code>, or <code>postgresqlSetupJob</code> hooks; SQL and Elasticsearch setup stay under <code>datahubSystemUpdate.sql</code> / <code>datahubSystemUpdate.elasticsearch</code> and the system-update Job. IAM validation (<code>_iam-validation.tpl</code>) allows that layout when consolidated upgrade replaces those Jobs.</td>
+</tr>
+<tr>
 <td><code>global.datahub.encryptionKey.secretRef</code></td>
 <td>string</td>
 <td><code>datahub-encryption-secrets</code></td>
@@ -2047,7 +2053,7 @@ This document provides a comprehensive reference for every single configurable v
 
 ## DataHub System Update Configuration
 
-System-update scale-down options and operator ServiceAccount/RBAC are available in v1.5.0.
+System-update scale-down options and operator ServiceAccount/RBAC are available in v1.5.0. Legacy prerequisite SetupJobs are gated by <code>global.datahub.systemUpdate.consolidatedUpgrade</code> (see Global Values). Optional JDBC and IAM overrides under <code>datahubSystemUpdate.sql</code> / <code>datahubSystemUpdate.elasticsearch</code> apply to the system-update Job via helpers documented below under <code>datahub.upgrade.env</code>.
 
 <table>
 <thead>
@@ -2198,10 +2204,28 @@ System-update scale-down options and operator ServiceAccount/RBAC are available 
 <td>ServiceAccount for the system-update job. When <code>global.datahub.systemUpdate.scaleDown.enabled</code> is true or this is set, the job uses an operator SA with RBAC for configmaps and KEDA scaledobjects. Available in v1.5.0.</td>
 </tr>
 <tr>
+<td><code>datahubSystemUpdate.sql.iam</code></td>
+<td>object</td>
+<td><code>{}</code></td>
+<td>SQL IAM override for system-update Jobs only. Omit <code>enabled</code> under <code>iam</code> to follow <code>global.sql.iam.enabled</code>; set <code>enabled: true|false</code> to override for this Job. Rendered via <code>datahub.sql.iam.env.systemUpdate</code> (with <code>datahub.sql.connection.env.systemUpdate</code> for <code>EBEAN_*</code>).</td>
+</tr>
+<tr>
+<td><code>datahubSystemUpdate.sql.username</code></td>
+<td>string / object</td>
+<td>—</td>
+<td>Optional override for <code>EBEAN_DATASOURCE_USERNAME</code> on system-update Jobs (merged onto <code>global.sql.datasource</code>). Same shapes as <code>global.sql.datasource.username</code> (plain string or <code>secretRef</code>/<code>secretKey</code>). Host, URL, and driver always come from <code>global.sql.datasource</code>.</td>
+</tr>
+<tr>
+<td><code>datahubSystemUpdate.sql.password</code></td>
+<td>object</td>
+<td>—</td>
+<td>Optional override for <code>EBEAN_DATASOURCE_PASSWORD</code> on system-update Jobs (<code>value</code> and/or <code>secretRef</code>/<code>secretKey</code>). Not emitted when SQL IAM is effective for the Job.</td>
+</tr>
+<tr>
 <td><code>datahubSystemUpdate.sql.setup.enabled</code></td>
 <td>boolean</td>
-<td><code>false</code></td>
-<td>Enable SQL setup within system-update job. Replaces the legacy <code>mysqlSetupJob</code> and <code>postgresqlSetupJob</code>. REQUIRED when <code>global.sql.iam.enabled=true</code>. Default enabled in chart for v1.5.0+.</td>
+<td><code>true</code></td>
+<td>Enable SQL setup within system-update job (<code>DATAHUB_SQL_SETUP_ENABLED</code>, …). Replaces the legacy <code>mysqlSetupJob</code> and <code>postgresqlSetupJob</code>. When <code>global.sql.iam.enabled=true</code>, IAM validation expects SQL setup via this job (see <code>_iam-validation.tpl</code>).</td>
 </tr>
 <tr>
 <td><code>datahubSystemUpdate.sql.setup.createTables</code></td>
@@ -2246,10 +2270,16 @@ System-update scale-down options and operator ServiceAccount/RBAC are available 
 <td>Secret key for the new user password. Defaults to <code>global.sql.datasource.password.secretKey</code>.</td>
 </tr>
 <tr>
+<td><code>datahubSystemUpdate.elasticsearch.iam</code></td>
+<td>object</td>
+<td><code>{}</code></td>
+<td>OpenSearch/Elasticsearch IAM override for system-update Jobs only. Omit <code>enabled</code> under <code>iam</code> to follow <code>global.elasticsearch.iam.enabled</code>; set <code>enabled: true|false</code> to override for this Job. Rendered via <code>datahub.elasticsearch.iam.env.systemUpdate</code>.</td>
+</tr>
+<tr>
 <td><code>datahubSystemUpdate.elasticsearch.setup.enabled</code></td>
 <td>boolean</td>
-<td><code>false</code></td>
-<td>Enable Elasticsearch setup (BuildIndices) within system-update job. Replaces the legacy <code>elasticsearchSetupJob</code>. Default enabled in chart for v1.5.0+.</td>
+<td><code>true</code></td>
+<td>Enable Elasticsearch setup (BuildIndices) within system-update job. Replaces the legacy <code>elasticsearchSetupJob</code>.</td>
 </tr>
 <tr>
 <td><code>datahubSystemUpdate.elasticsearch.setup.createUser</code></td>
@@ -2289,6 +2319,20 @@ System-update scale-down options and operator ServiceAccount/RBAC are available 
 </tr>
 </tbody>
 </table>
+
+### System-update upgrade environment (`datahub.upgrade.env`)
+
+The named template `datahub.upgrade.env` renders shared environment variables for workloads that run **datahub-upgrade**, including the blocking and non-blocking **system-update** Jobs, the **restore-indices** CronJob template, and the **hourly system-update** CronJob template.
+
+Templates are selected via optional context keys merged into the chart root (same pattern as optional Helm values):
+
+| Key | Default helper | Purpose |
+|-----|----------------|---------|
+| `sqlConnTpl` | `datahub.sql.connection.env` | JDBC / `EBEAN_*` variables |
+| `sqlIamTpl` | `datahub.sql.iam.env` | SQL IAM (`EBEAN_USE_IAM_AUTH`, …) when `global.sql.iam.enabled` |
+| `esIamTpl` | `datahub.elasticsearch.iam.env` | OpenSearch IAM (`OPENSEARCH_USE_AWS_IAM_AUTH`, `AWS_REGION`, …) when effective |
+
+The **system-update** Job passes `sqlConnTpl=datahub.sql.connection.env.systemUpdate`, `sqlIamTpl=datahub.sql.iam.env.systemUpdate`, and `esIamTpl=datahub.elasticsearch.iam.env.systemUpdate` so optional `datahubSystemUpdate.sql` / `sql.iam` / `elasticsearch.iam` apply **only** there; restore-indices and hourly cron keep the defaults above.
 
 ## DataHub System Cron Hourly Configuration
 

--- a/charts/datahub/templates/_helpers.tpl
+++ b/charts/datahub/templates/_helpers.tpl
@@ -343,6 +343,35 @@ Validates that Kafka and OpenSearch regions match when both are configured with 
 {{- end -}}
 
 {{/*
+Elasticsearch/OpenSearch IAM env for system-update Jobs: uses global.elasticsearch.iam.enabled unless
+datahubSystemUpdate.elasticsearch.iam.enabled is explicitly set.
+*/}}
+{{- define "datahub.elasticsearch.iam.env.systemUpdate" -}}
+{{- $effective := .Values.global.elasticsearch.iam.enabled }}
+{{- if .Values.datahubSystemUpdate.elasticsearch }}
+{{- if hasKey .Values.datahubSystemUpdate.elasticsearch "iam" }}
+{{- $ji := .Values.datahubSystemUpdate.elasticsearch.iam | default dict }}
+{{- if hasKey $ji "enabled" }}
+{{- $effective = $ji.enabled }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if $effective }}
+{{- if and .Values.global.elasticsearch.region .Values.global.kafka.region }}
+{{- if ne .Values.global.elasticsearch.region .Values.global.kafka.region }}
+{{- fail (printf "AWS_REGION mismatch: Kafka region (%s) differs from OpenSearch region (%s). Both must be in the same region for IAM authentication." .Values.global.kafka.region .Values.global.elasticsearch.region) }}
+{{- end }}
+{{- end }}
+- name: OPENSEARCH_USE_AWS_IAM_AUTH
+  value: "true"
+{{- if .Values.global.elasticsearch.region }}
+- name: AWS_REGION
+  value: {{ .Values.global.elasticsearch.region | quote }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
 SQL IAM authentication environment variables for AWS RDS IAM authentication.
 Supports both MySQL and PostgreSQL with automatic cloud provider detection.
 Sets EBEAN_USE_IAM_AUTH=true and EBEAN_CLOUD_PROVIDER when IAM authentication is enabled.
@@ -356,6 +385,35 @@ DO NOT include in services that only connect to GMS or Kafka (Frontend, Actions,
 */}}
 {{- define "datahub.sql.iam.env" -}}
 {{- if .Values.global.sql.iam.enabled }}
+- name: EBEAN_POSTGRES_USE_AWS_IAM_AUTH
+  value: "true"
+- name: EBEAN_USE_IAM_AUTH
+  value: "true"
+{{- if .Values.global.sql.iam.cloudProvider }}
+- name: EBEAN_CLOUD_PROVIDER
+  value: {{ .Values.global.sql.iam.cloudProvider | quote }}
+{{- else }}
+- name: EBEAN_CLOUD_PROVIDER
+  value: "auto"
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+SQL IAM env for system-update Jobs: uses global.sql.iam.enabled unless datahubSystemUpdate.sql.iam.enabled
+is explicitly set (same override idea as the fork system-update template).
+*/}}
+{{- define "datahub.sql.iam.env.systemUpdate" -}}
+{{- $effective := .Values.global.sql.iam.enabled }}
+{{- if .Values.datahubSystemUpdate.sql }}
+{{- if hasKey .Values.datahubSystemUpdate.sql "iam" }}
+{{- $ji := .Values.datahubSystemUpdate.sql.iam | default dict }}
+{{- if hasKey $ji "enabled" }}
+{{- $effective = $ji.enabled }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if $effective }}
 - name: EBEAN_POSTGRES_USE_AWS_IAM_AUTH
   value: "true"
 - name: EBEAN_USE_IAM_AUTH
@@ -440,6 +498,57 @@ also include datahub.sql.iam.env helper after this one.
     secretKeyRef:
       name: "{{ (.Values.sql).datasource.password.secretRef | default .Values.global.sql.datasource.password.secretRef }}"
       key: "{{ (.Values.sql).datasource.password.secretKey | default .Values.global.sql.datasource.password.secretKey }}"
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+SQL env for system-update Jobs only: same as fork — EBEAN host/url/driver come from global.sql.datasource only;
+optional datahubSystemUpdate.sql username/password are merged onto global.sql.datasource for credentials.
+Then applies the same username/password precedence as datahub.sql.connection.env (.Values.sql, then effective datasource).
+Password is omitted when SQL IAM is effective (global.sql.iam.enabled, or datahubSystemUpdate.sql.iam.enabled when set).
+*/}}
+{{- define "datahub.sql.connection.env.systemUpdate" -}}
+{{- $sqlIamEffective := .Values.global.sql.iam.enabled }}
+{{- if .Values.datahubSystemUpdate.sql }}
+{{- if hasKey .Values.datahubSystemUpdate.sql "iam" }}
+{{- $ji := .Values.datahubSystemUpdate.sql.iam | default dict }}
+{{- if hasKey $ji "enabled" }}
+{{- $sqlIamEffective = $ji.enabled }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- $sql := .Values.datahubSystemUpdate.sql | default dict }}
+{{- $overlay := dict }}
+{{- if hasKey $sql "username" }}{{- $overlay = merge $overlay (dict "username" $sql.username) }}{{- end }}
+{{- if hasKey $sql "password" }}{{- $overlay = merge $overlay (dict "password" $sql.password) }}{{- end }}
+{{- $merged := mergeOverwrite (deepCopy .Values.global.sql.datasource) $overlay }}
+- name: EBEAN_DATASOURCE_HOST
+  value: "{{ .Values.global.sql.datasource.host }}"
+- name: EBEAN_DATASOURCE_URL
+  value: "{{ .Values.global.sql.datasource.url }}"
+- name: EBEAN_DATASOURCE_DRIVER
+  value: "{{ .Values.global.sql.datasource.driver }}"
+- name: EBEAN_DATASOURCE_USERNAME
+  {{- $usernameValue := (.Values.sql).datasource.username | default $merged.username }}
+  {{- if and (kindIs "string" $usernameValue) $usernameValue }}
+  value: {{ $usernameValue | quote }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ (.Values.sql).datasource.username.secretRef | default $merged.username.secretRef }}"
+      key: "{{ (.Values.sql).datasource.username.secretKey | default $merged.username.secretKey }}"
+  {{- end }}
+{{- if not $sqlIamEffective }}
+- name: EBEAN_DATASOURCE_PASSWORD
+  {{- $passwordValue := (.Values.sql).datasource.password.value | default $merged.password.value }}
+  {{- if $passwordValue }}
+  value: {{ $passwordValue | quote }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: "{{ (.Values.sql).datasource.password.secretRef | default $merged.password.secretRef }}"
+      key: "{{ (.Values.sql).datasource.password.secretKey | default $merged.password.secretKey }}"
   {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/datahub/templates/_iam-validation.tpl
+++ b/charts/datahub/templates/_iam-validation.tpl
@@ -8,34 +8,32 @@ This template validates IAM authentication configuration and requirements.
 {{/*
 Validate: SQL IAM authentication requires datahubSystemUpdate.sql.setup.enabled=true
 */}}
-{{- if .Values.global.sql.iam.enabled -}}
-{{- if not .Values.datahubSystemUpdate.sql.setup.enabled -}}
-{{- fail "ERROR: datahubSystemUpdate.sql.setup.enabled must be true when global.sql.iam.enabled is true. When using IAM authentication, SQL setup must be handled by the system-update job. Please set datahubSystemUpdate.sql.setup.enabled=true." -}}
-{{- end -}}
+{{- if and .Values.global.sql.iam.enabled (not .Values.datahubSystemUpdate.sql.setup.enabled) (not (.Values.global.datahub.systemUpdate.consolidatedUpgrade | default true)) -}}
+{{- fail "ERROR: datahubSystemUpdate.sql.setup.enabled must be true when global.sql.iam.enabled is true (or set global.datahub.systemUpdate.consolidatedUpgrade=true). When using IAM authentication, SQL setup must be handled by the system-update job. Please set datahubSystemUpdate.sql.setup.enabled=true." -}}
 {{- end -}}
 
 {{/*
 Validate: MySQL/PostgreSQL Setup Job cannot be enabled with SQL IAM authentication
 */}}
-{{- if and .Values.global.sql.iam.enabled .Values.mysqlSetupJob.enabled -}}
+{{- if and .Values.global.sql.iam.enabled .Values.mysqlSetupJob.enabled (not (.Values.global.datahub.systemUpdate.consolidatedUpgrade | default true)) -}}
 {{- fail "ERROR: mysqlSetupJob.enabled cannot be true when global.sql.iam.enabled is true. When using IAM authentication, SQL setup is handled by the system-update job via datahubSystemUpdate.sql.setup.enabled. Please set mysqlSetupJob.enabled=false." -}}
 {{- end -}}
 
-{{- if and .Values.global.sql.iam.enabled .Values.postgresqlSetupJob.enabled -}}
+{{- if and .Values.global.sql.iam.enabled .Values.postgresqlSetupJob.enabled (not (.Values.global.datahub.systemUpdate.consolidatedUpgrade | default true)) -}}
 {{- fail "ERROR: postgresqlSetupJob.enabled cannot be true when global.sql.iam.enabled is true. When using IAM authentication, SQL setup is handled by the system-update job via datahubSystemUpdate.sql.setup.enabled. Please set postgresqlSetupJob.enabled=false." -}}
 {{- end -}}
 
 {{/*
 Validate: Elasticsearch Setup Job cannot be enabled with OpenSearch IAM authentication
 */}}
-{{- if and .Values.global.elasticsearch.iam.enabled .Values.elasticsearchSetupJob.enabled -}}
+{{- if and .Values.global.elasticsearch.iam.enabled .Values.elasticsearchSetupJob.enabled (not (.Values.global.datahub.systemUpdate.consolidatedUpgrade | default true)) -}}
 {{- fail "ERROR: elasticsearchSetupJob.enabled cannot be true when global.elasticsearch.iam.enabled is true. When using IAM authentication, index setup is handled automatically by the system-update job via BuildIndices. Please set elasticsearchSetupJob.enabled=false." -}}
 {{- end -}}
 
 {{/*
 Validate: Kafka Setup Job cannot be enabled with MSK IAM authentication
 */}}
-{{- if and .Values.global.kafka.iam.enabled .Values.kafkaSetupJob.enabled -}}
+{{- if and .Values.global.kafka.iam.enabled .Values.kafkaSetupJob.enabled (not (.Values.global.datahub.systemUpdate.consolidatedUpgrade | default true)) -}}
 {{- fail "ERROR: kafkaSetupJob.enabled cannot be true when global.kafka.iam.enabled is true. When using IAM authentication, Kafka topic setup is handled automatically by the system-update job via KafkaSetup. Please set kafkaSetupJob.enabled=false." -}}
 {{- end -}}
 

--- a/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
+++ b/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
@@ -19,32 +19,12 @@ Return the env variables for upgrade jobs
   value: {{ printf "%s-%s" .Release.Name "datahub-mae-consumer" }}
 - name: DATAHUB_MAE_CONSUMER_PORT
   value: "{{ .Values.global.datahub.mae_consumer.port }}"
-- name: EBEAN_DATASOURCE_USERNAME
-  {{- $usernameValue := (.Values.sql).datasource.username | default .Values.global.sql.datasource.username }}
-  {{- if and (kindIs "string" $usernameValue) $usernameValue }}
-  value: {{ $usernameValue | quote }}
-  {{- else }}
-  valueFrom:
-    secretKeyRef:
-      name: "{{ (.Values.sql).datasource.username.secretRef | default .Values.global.sql.datasource.username.secretRef }}"
-      key: "{{ (.Values.sql).datasource.username.secretKey | default .Values.global.sql.datasource.username.secretKey }}"
-  {{- end }}
-- name: EBEAN_DATASOURCE_PASSWORD
-  {{- $passwordValue := (.Values.sql).datasource.password.value | default .Values.global.sql.datasource.password.value }}
-  {{- if $passwordValue }}
-  value: {{ $passwordValue | quote }}
-  {{- else }}
-  valueFrom:
-    secretKeyRef:
-      name: "{{ (.Values.sql).datasource.password.secretRef | default .Values.global.sql.datasource.password.secretRef }}"
-      key: "{{ (.Values.sql).datasource.password.secretKey | default .Values.global.sql.datasource.password.secretKey }}"
-  {{- end }}
-- name: EBEAN_DATASOURCE_HOST
-  value: "{{ .Values.global.sql.datasource.host }}"
-- name: EBEAN_DATASOURCE_URL
-  value: "{{ .Values.global.sql.datasource.url }}"
-- name: EBEAN_DATASOURCE_DRIVER
-  value: "{{ .Values.global.sql.datasource.driver }}"
+{{- $sqlTpl := .sqlConnTpl | default "datahub.sql.connection.env" }}
+{{- include $sqlTpl . | nindent 0 }}
+{{- $iamTpl := .sqlIamTpl | default "datahub.sql.iam.env" }}
+{{- include $iamTpl . | nindent 0 }}
+{{- $esIamTpl := .esIamTpl | default "datahub.elasticsearch.iam.env" }}
+{{- include $esIamTpl . | nindent 0 }}
 - name: KAFKA_BOOTSTRAP_SERVER
   value: "{{ .Values.global.kafka.bootstrap.server }}"
 {{- with .Values.global.kafka.maxMessageBytes }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
@@ -85,7 +85,7 @@ spec:
               value: {{ .Values.global.datahub.entityVersioning.enabled | quote }}
             - name: DATAHUB_REVISION
               value: {{ .Release.Revision | quote }}
-            {{- include "datahub.upgrade.env" . | nindent 12 }}
+            {{- include "datahub.upgrade.env" (merge (dict "sqlConnTpl" "datahub.sql.connection.env.systemUpdate" "sqlIamTpl" "datahub.sql.iam.env.systemUpdate" "esIamTpl" "datahub.elasticsearch.iam.env.systemUpdate") .) | nindent 12 }}
             {{- if $scaleDownEffective }}
             - name: DATAHUB_UPGRADE_K8_SCALE_DOWN_ENABLED
               value: "true"
@@ -370,7 +370,7 @@ spec:
             {{- include "datahub.upgrade.auth.env" . | nindent 12 }}
             - name: DATAHUB_REVISION
               value: {{ .Release.Revision | quote }}
-            {{- include "datahub.upgrade.env" . | nindent 12 }}
+            {{- include "datahub.upgrade.env" (merge (dict "sqlConnTpl" "datahub.sql.connection.env.systemUpdate" "sqlIamTpl" "datahub.sql.iam.env.systemUpdate" "esIamTpl" "datahub.elasticsearch.iam.env.systemUpdate") .) | nindent 12 }}
             {{- if $scaleDownEffective }}
             - name: DATAHUB_UPGRADE_K8_SCALE_DOWN_ENABLED
               value: "true"

--- a/charts/datahub/templates/elasticsearch-setup-job.yml
+++ b/charts/datahub/templates/elasticsearch-setup-job.yml
@@ -1,4 +1,4 @@
-{{- if .Values.elasticsearchSetupJob.enabled -}}
+{{- if and .Values.elasticsearchSetupJob.enabled (not (.Values.global.datahub.systemUpdate.consolidatedUpgrade | default true)) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/datahub/templates/kafka-setup-job.yml
+++ b/charts/datahub/templates/kafka-setup-job.yml
@@ -1,4 +1,4 @@
-{{- if .Values.kafkaSetupJob.enabled -}}
+{{- if and .Values.kafkaSetupJob.enabled (not (.Values.global.datahub.systemUpdate.consolidatedUpgrade | default true)) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/datahub/templates/mysql-setup-job.yml
+++ b/charts/datahub/templates/mysql-setup-job.yml
@@ -1,4 +1,4 @@
-{{- if .Values.mysqlSetupJob.enabled -}}
+{{- if and .Values.mysqlSetupJob.enabled (not (.Values.global.datahub.systemUpdate.consolidatedUpgrade | default true)) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/datahub/templates/postgresql-setup-job.yml
+++ b/charts/datahub/templates/postgresql-setup-job.yml
@@ -1,4 +1,4 @@
-{{- if .Values.postgresqlSetupJob.enabled -}}
+{{- if and .Values.postgresqlSetupJob.enabled (not (.Values.global.datahub.systemUpdate.consolidatedUpgrade | default true)) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/datahub/values.schema.json
+++ b/charts/datahub/values.schema.json
@@ -1431,6 +1431,21 @@
         "sql": {
           "type": "object",
           "properties": {
+            "username": {},
+            "password": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "string"
+                },
+                "secretRef": {
+                  "type": "string"
+                },
+                "secretKey": {
+                  "type": "string"
+                }
+              }
+            },
             "iam": {
               "type": "object",
               "properties": {
@@ -1438,7 +1453,7 @@
                   "type": "boolean"
                 }
               },
-              "required": ["enabled"]
+              "required": []
             },
             "setup": {
               "type": "object",
@@ -1481,7 +1496,7 @@
                   "type": "boolean"
                 }
               },
-              "required": ["enabled"]
+              "required": []
             },
             "setup": {
               "type": "object",
@@ -2432,6 +2447,9 @@
               "type": "object",
               "properties": {
                 "enabled": {
+                  "type": "boolean"
+                },
+                "consolidatedUpgrade": {
                   "type": "boolean"
                 },
                 "scaleDown": {

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -451,6 +451,7 @@ datahubSystemCronHourly:
 
 ## Runs system update processes
 ## Includes: Elasticsearch Indices Creation/Reindex (See global.elasticsearch.index for additional configuration)
+## Umbrella: global.datahub.systemUpdate.consolidatedUpgrade toggles legacy SetupJobs vs in-job SQL/ES setup (see global section).
 datahubSystemUpdate:
   # Custom labels to add to the Job metadata
   labels: {}
@@ -481,9 +482,15 @@ datahubSystemUpdate:
     rbac: true  # Create Role and RoleBinding for this ServiceAccount
   # SQL setup configuration (when enabled, runs database setup as part of system update)
   sql:
-    # Override IAM authentication for Ebean (SQL)
-    iam:
-      enabled: false  # Inherit from global.sql.iam.enabled if not set
+    # Override IAM authentication for Ebean (SQL) on system-update Jobs only.
+    # Omit `enabled` under iam to follow global.sql.iam.enabled; set enabled: true/false to override for this Job only.
+    iam: {}
+    # Override Ebean credentials for system-update Jobs only (defaults to global.sql.datasource). Host/url/driver stay global.
+    # username: "override-username"
+    # password:
+    #   value: "override-password"
+    #   secretRef: "override-secret-name"
+    #   secretKey: "override-secret-key"
     # SQL setup within system-update job (replaces legacy mysqlSetupJob/postgresqlSetupJob when IAM is enabled)
     setup:
       enabled: true            # Enable SQL database setup
@@ -494,9 +501,15 @@ datahubSystemUpdate:
   elasticsearch:
     # Optional. ELASTICSEARCH_THREAD_COUNT for system-update / datahub-upgrade jobs only (via datahub.upgrade.env).
     # threadCount: 8
-    # Override IAM authentication for Elasticsearch
-    iam:
-      enabled: false  # Inherit from global.elasticsearch.iam.enabled if not set
+    # Override IAM authentication for Elasticsearch on system-update Jobs only.
+    # Omit `enabled` under iam to follow global.elasticsearch.iam.enabled; set enabled: true/false to override for this Job only.
+    iam: {}
+    # Override Elasticsearch credentials for setup flows (defaults to global.elasticsearch.auth).
+    # username: "override-username"
+    # password:
+    #   value: "override-password"
+    #   secretRef: "override-secret-name"
+    #   secretKey: "override-secret-key"
     # Elasticsearch setup within system-update job
     setup:
       enabled: true             # Enable Elasticsearch index setup (BuildIndices)
@@ -1080,6 +1093,10 @@ global:
       ## The following options control settings for datahub-upgrade job which will
       ## managed ES indices and other update related work
       enabled: true
+      # When true: skip legacy elasticsearch/kafka/mysql/postgresql SetupJob hooks; run SQL and Elasticsearch
+      # setup via the system-update job (see datahubSystemUpdate.sql / elasticsearch). Legacy hooks stay off
+      # unless consolidatedUpgrade is set false. Java KubernetesScaleDownStep applies when scaleDown is enabled.
+      consolidatedUpgrade: true
       # K8 scale-down (available in v1.5.0): when true, Java-based scale-down runs (KubernetesScaleDownStep)
       # NOTE: scaleDown is automatically disabled when zdu.enable=true
       scaleDown:


### PR DESCRIPTION
- **`global.datahub.systemUpdate.consolidatedUpgrade`** (default **`true`**) in `values.yaml` + `values.schema.json`. When **true**, legacy **Elasticsearch / Kafka / MySQL / PostgreSQL SetupJob** templates are not rendered.

- **`templates/_iam-validation.tpl`** — IAM checks that conflict with legacy setup Jobs when global IAM is enabled are skipped when **`consolidatedUpgrade | default true`** (aligned with legacy Jobs being off).

- **`templates/datahub-upgrade/_upgrade.tpl`** — Removes inlined **`EBEAN_*`** in favor of **`sqlConnTpl`** (default **`datahub.sql.connection.env`**). Adds **`sqlIamTpl`** (SQL IAM env) and **`esIamTpl`** (OpenSearch/Elasticsearch IAM env) so all callers of **`datahub.upgrade.env`** share the same wiring.

- **`templates/_helpers.tpl`** — New helpers:
  - **`datahub.sql.connection.env.systemUpdate`** — optional **`datahubSystemUpdate.sql`** username/password merged onto **`global.sql.datasource`**; host/url/driver stay global.
  - **`datahub.sql.iam.env.systemUpdate`** — SQL IAM env vars; effective IAM is **`global.sql.iam.enabled`** unless **`datahubSystemUpdate.sql.iam.enabled`** is explicitly set.
  - **`datahub.elasticsearch.iam.env.systemUpdate`** — OpenSearch IAM env vars; same pattern with **`global.elasticsearch.iam.enabled`** vs **`datahubSystemUpdate.elasticsearch.iam.enabled`**.

- **`templates/datahub-upgrade/datahub-system-update-job.yml`** — **`datahub.upgrade.env`** is invoked with **`merge`** passing **`sqlConnTpl`**, **`sqlIamTpl`**, and **`esIamTpl`** system-update variants.

### Values / schema

- **`consolidatedUpgrade`** documented under **`global.datahub.systemUpdate`**.
- **`datahubSystemUpdate.sql.iam`** and **`datahubSystemUpdate.elasticsearch.iam`** default to **`{}`** so **`enabled`** inherits global unless overridden; schema updated so **`enabled`** is not required on those **`iam`** objects.