### PR TITLE
feat(servicemonitor): add interval, scrapeTimeout and metricRelabelin…

### DIFF
--- a/charts/datahub/subcharts/acryl-datahub-actions/templates/servicemonitor.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/templates/servicemonitor.yaml
@@ -15,12 +15,22 @@ metadata:
 spec:
   endpoints:
   - port: {{ .Values.global.datahub.monitoring.portName }}
+    {{- with .Values.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
     relabelings:
     - separator: /
       sourceLabels:
       - namespace
       - pod
       targetLabel: instance
+    {{- with .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/managed-by: Helm

--- a/charts/datahub/subcharts/acryl-datahub-actions/values.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/values.yaml
@@ -29,6 +29,9 @@ serviceAccount:
 serviceMonitor:
   create: false
   extraLabels: {}
+  interval: ""
+  scrapeTimeout: ""
+  metricRelabelings: []
 
 annotations: {}
 

--- a/charts/datahub/subcharts/datahub-frontend/templates/servicemonitor.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/servicemonitor.yaml
@@ -20,22 +20,42 @@ spec:
 {{- if eq $mode "jmx_and_actuator" }}
     path: {{ include "datahub-frontend.monitoring.jmxMetricsPath" . | quote }}
 {{- end }}
+    {{- with .Values.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
     relabelings:
     - separator: /
       sourceLabels:
       - namespace
       - pod
       targetLabel: instance
+    {{- with .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}
 {{- if eq $mode "actuator_only" }}
   - port: prometheus
     path: /actuator/prometheus
+    {{- with .Values.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
     relabelings:
     - separator: /
       sourceLabels:
       - namespace
       - pod
       targetLabel: instance
+    {{- with .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}
   selector:
     matchLabels:

--- a/charts/datahub/subcharts/datahub-frontend/values.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/values.yaml
@@ -104,6 +104,9 @@ service:
 serviceMonitor:
   create: false
   extraLabels: {}
+  interval: ""
+  scrapeTimeout: ""
+  metricRelabelings: []
 
 ingress:
   # className: ""

--- a/charts/datahub/subcharts/datahub-gms/templates/servicemonitor.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/servicemonitor.yaml
@@ -20,32 +20,62 @@ spec:
 {{- if eq $mode "jmx_and_actuator" }}
     path: {{ include "datahub-gms.monitoring.jmxMetricsPath" . | quote }}
 {{- end }}
+    {{- with .Values.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
     relabelings:
     - separator: /
       sourceLabels:
       - namespace
       - pod
       targetLabel: instance
+    {{- with .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}
 {{- if eq (include "datahub-gms.monitoring.gmsScrapeActuatorOnHttp" .) "true" }}
   - port: {{ .Values.service.name }}
     path: {{ include "datahub-gms.basePath" . }}/actuator/prometheus
+    {{- with .Values.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
     relabelings:
     - separator: /
       sourceLabels:
       - namespace
       - pod
       targetLabel: instance
+    {{- with .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}
 {{- if or (eq $mode "jmx_and_actuator") (eq $mode "actuator_only") }}
   - port: prometheus
     path: {{ include "datahub-gms.basePath" . }}/actuator/prometheus
+    {{- with .Values.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
     relabelings:
     - separator: /
       sourceLabels:
       - namespace
       - pod
       targetLabel: instance
+    {{- with .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}
   selector:
     matchLabels:

--- a/charts/datahub/subcharts/datahub-gms/values.yaml
+++ b/charts/datahub/subcharts/datahub-gms/values.yaml
@@ -47,6 +47,9 @@ serviceAccount:
 serviceMonitor:
   create: false
   extraLabels: {}
+  interval: ""
+  scrapeTimeout: ""
+  metricRelabelings: []
 
 annotations: {}
 

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/servicemonitor.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/servicemonitor.yaml
@@ -20,22 +20,42 @@ spec:
 {{- if eq $mode "jmx_and_actuator" }}
     path: {{ include "datahub-mae-consumer.monitoring.jmxMetricsPath" . | quote }}
 {{- end }}
+    {{- with .Values.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
     relabelings:
     - separator: /
       sourceLabels:
       - namespace
       - pod
       targetLabel: instance
+    {{- with .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}
 {{- if eq $mode "actuator_only" }}
   - port: prometheus
     path: /actuator/prometheus
+    {{- with .Values.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
     relabelings:
     - separator: /
       sourceLabels:
       - namespace
       - pod
       targetLabel: instance
+    {{- with .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}
   selector:
     matchLabels:

--- a/charts/datahub/subcharts/datahub-mae-consumer/values.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/values.yaml
@@ -33,6 +33,9 @@ serviceAccount:
 serviceMonitor:
   create: false
   extraLabels: {}
+  interval: ""
+  scrapeTimeout: ""
+  metricRelabelings: []
 
 podAnnotations: {}
   # co.elastic.logs/enabled: "true"

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/servicemonitor.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/servicemonitor.yaml
@@ -20,22 +20,42 @@ spec:
 {{- if eq $mode "jmx_and_actuator" }}
     path: {{ include "datahub-mce-consumer.monitoring.jmxMetricsPath" . | quote }}
 {{- end }}
+    {{- with .Values.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
     relabelings:
     - separator: /
       sourceLabels:
       - namespace
       - pod
       targetLabel: instance
+    {{- with .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}
 {{- if eq $mode "actuator_only" }}
   - port: prometheus
     path: /actuator/prometheus
+    {{- with .Values.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
     relabelings:
     - separator: /
       sourceLabels:
       - namespace
       - pod
       targetLabel: instance
+    {{- with .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}
   selector:
     matchLabels:

--- a/charts/datahub/subcharts/datahub-mce-consumer/values.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/values.yaml
@@ -55,6 +55,9 @@ service:
 serviceMonitor:
   create: false
   extraLabels: {}
+  interval: ""
+  scrapeTimeout: ""
+  metricRelabelings: []
 
 ingress:
   enabled: false


### PR DESCRIPTION
## Description
Add support for `interval`, `scrapeTimeout`, and `metricRelabelings` configuration on ServiceMonitor resources across all DataHub subcharts.
Previously, ServiceMonitor endpoints had no way to customize the scrape interval, timeout, or apply metric relabeling rules. This made it difficult to fine-tune Prometheus scraping behavior,  for example, dropping high-cardinality labels, renaming metrics, or adjusting scrape frequency per component.
### Changes
- Added `serviceMonitor.interval`, `serviceMonitor.scrapeTimeout`, and `serviceMonitor.metricRelabelings` values to **all five subcharts**:
  - `acryl-datahub-actions`
  - `datahub-frontend`
  - `datahub-gms`
  - `datahub-mae-consumer`
  - `datahub-mce-consumer`
- Updated each subchart's `servicemonitor.yaml` template to conditionally render `interval`, `scrapeTimeout`, and `metricRelabelings` on every endpoint block.
- Defaults are no-ops (empty strings / empty list), so existing deployments are unaffected.
### Example usage
serviceMonitor:
  create: true
  interval: 30s
  scrapeTimeout: 10s
  metricRelabelings:
    - sourceLabels: [__name__]
      regex: "jvm_memory_pool_.*"
      action: drop

## Checklist
- [X ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [X ] Docs related to the changes have been added/updated (if applicable)
