### PR TITLE
feat(datahub): add support for new external secret api

### DIFF
--- a/charts/datahub/templates/external-secrets/external-secret.yml
+++ b/charts/datahub/templates/external-secrets/external-secret.yml
@@ -6,7 +6,9 @@
 {{- end }}
 {{- if $enabled }}
 ---
-{{- if $.Capabilities.APIVersions.Has "external-secrets.io/v1beta1" }}
+{{- if $.Capabilities.APIVersions.Has "external-secrets.io/v1" }}
+apiVersion: external-secrets.io/v1
+{{- else if $.Capabilities.APIVersions.Has "external-secrets.io/v1beta1" }}
 apiVersion: external-secrets.io/v1beta1
 {{- else }}
 apiVersion: external-secrets.io/v1alpha1
@@ -20,10 +22,10 @@ metadata:
     "helm.sh/hook-weight": "-11"
     "argocd.argoproj.io/sync-options": "SkipDryRunOnMissingResource=true"
 spec:
-  refreshInterval: {{ default "1m" $secretInfo.refreshInterval }}
+  refreshInterval: {{ default "1h0m0s" $secretInfo.refreshInterval }}
   secretStoreRef:
     name: {{ tpl $secretInfo.secretStoreName $ }}
-    kind: SecretStore
+    kind: {{ default "SecretStore" $secretInfo.secretStoreKind }}
   target:
     name: {{ tpl $secretName $ }}
   data:

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -1342,7 +1342,8 @@ global:
     # # Secrets definition example
     # secrets:
     #   mysql-secrets:
-    #     store: aws-store
+    #     secretStoreName: aws-store
+    #     secretStoreKind: SecretStore
     #     data:
     #       mysql-password: /NAMESPACE/CLUSTER/mysql-password
     #       mysql-root-password: /CLUSTER/shared/mysql/password


### PR DESCRIPTION
- add support for new external secret api for the externalsecret kind
- change default refreshInterval to 1 hour (1 minute is pretty wild)
- add support for different secretstore kind

Tested locally with `helm template`

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
