### PR TITLE
feat(frontend): add Gateway API HTTPRoute support and bump ESO to v1

### DIFF
--- a/charts/datahub/subcharts/datahub-frontend/templates/httproute.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/httproute.yaml
@@ -26,14 +26,14 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.ingress.httproute.rules }}
-    {{- with .matches }}
-    - matches:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .filters }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .filters }}
       filters:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       backendRefs:
         - group: ""
           kind: Service

--- a/charts/datahub/subcharts/datahub-frontend/templates/httproute.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/templates/httproute.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.ingress.httproute.enabled }}
+{{- $fullName := include "datahub-frontend.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "datahub-frontend.labels" . | nindent 4 }}
+    {{- with .Values.ingress.httproute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.ingress.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.httproute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.ingress.httproute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.httproute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/charts/datahub/subcharts/datahub-frontend/values.yaml
+++ b/charts/datahub/subcharts/datahub-frontend/values.yaml
@@ -121,6 +121,20 @@ ingress:
   #    hosts:
   #      - chart-example.local
   pathType: ImplementationSpecific
+  httproute:
+    enabled: false
+    labels: {}
+    annotations: {}
+    parentRefs: []
+    # - name: my-gateway
+    #   namespace: default
+    hostnames: []
+    # - datahub.example.com
+    rules: []
+    # - matches:
+    #     - path:
+    #         type: PathPrefix
+    #         value: /
 
 auth:
   sessionTTLHours: "24"

--- a/charts/datahub/templates/external-secrets/external-secret.yml
+++ b/charts/datahub/templates/external-secrets/external-secret.yml
@@ -6,11 +6,7 @@
 {{- end }}
 {{- if $enabled }}
 ---
-{{- if $.Capabilities.APIVersions.Has "external-secrets.io/v1beta1" }}
-apiVersion: external-secrets.io/v1beta1
-{{- else }}
-apiVersion: external-secrets.io/v1alpha1
-{{- end }}
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ $secretName }}-es

--- a/charts/datahub/templates/external-secrets/secret-store.yml
+++ b/charts/datahub/templates/external-secrets/secret-store.yml
@@ -1,11 +1,7 @@
 {{- if .Values.global.externalSecrets.enabled }}
 {{- range $storeName, $storeInfo := .Values.global.externalSecrets.stores }}
 ---
-{{- if $.Capabilities.APIVersions.Has "external-secrets.io/v1beta1" }}
-apiVersion: external-secrets.io/v1beta1
-{{- else }}
-apiVersion: external-secrets.io/v1alpha1
-{{- end }}
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: {{ tpl $storeName $ }}

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -94,6 +94,20 @@ datahub-frontend:
     #    hosts:
     #      - chart-example.local
     # pathType: ImplementationSpecific
+    # httproute:
+    #   enabled: false
+    #   labels: {}
+    #   annotations: {}
+    #   parentRefs:
+    #     - name: my-gateway
+    #       namespace: default
+    #   hostnames:
+    #     - datahub.example.com
+    #   rules:
+    #     - matches:
+    #         - path:
+    #             type: PathPrefix
+    #             value: /
   defaultUserCredentials: {}
     # randomAdminPassword: true
     # You can also set specific passwords for default users


### PR DESCRIPTION
## Summary

- **HTTPRoute support for datahub-frontend**: Adds a new `httproute.yaml` template to the datahub-frontend sub-chart, enabling users running the Kubernetes Gateway API to expose the frontend without a classic Ingress resource. The template supports `parentRefs`, `hostnames`, match rules, filters, and weighted `backendRefs`. Disabled by default (`ingress.httproute.enabled: false`).
- **ESO API version bump**: Updates the External Secrets Operator templates (`external-secret.yml` and `secret-store.yml`) from the `v1beta1`/`v1alpha1` capability-check pattern to the stable `external-secrets.io/v1` API, which has been GA since ESO 0.10 (early 2024).

## Motivation

The Kubernetes Gateway API (`gateway.networking.k8s.io/v1`) is now GA and increasingly adopted as the successor to the Ingress API. Adding HTTPRoute support allows users who run a Gateway controller (e.g. Envoy Gateway, Istio, Cilium) to natively integrate datahub-frontend without maintaining separate manifests.

The ESO `v1` API has been stable for over two years. Removing the capability check simplifies the templates and avoids falling back to the deprecated `v1alpha1` API on clusters that only advertise `v1`.

## Changes

| File | Change |
|---|---|
| `charts/datahub/subcharts/datahub-frontend/templates/httproute.yaml` | New template |
| `charts/datahub/subcharts/datahub-frontend/values.yaml` | Added `ingress.httproute` defaults |
| `charts/datahub/values.yaml` | Added commented-out `httproute` example in umbrella values |
| `charts/datahub/templates/external-secrets/external-secret.yml` | `v1beta1`/`v1alpha1` → `v1` |
| `charts/datahub/templates/external-secrets/secret-store.yml` | `v1beta1`/`v1alpha1` → `v1` |

## Test plan

- `helm lint charts/datahub` passes
- `helm template` with `ingress.httproute.enabled=true` renders a valid `gateway.networking.k8s.io/v1 HTTPRoute`
- `helm template` with default values produces no HTTPRoute resource
- `helm template` with `global.externalSecrets.enabled=true` renders `external-secrets.io/v1` resources