### PR TITLE
fix(mce-consumer): add missing DATAHUB_USAGE_EVENT_NAME env var

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.3.11
+    version: 0.3.12
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron

--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for DataHub (defaults include non-root security contex
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.11
+version: 0.3.12
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.6.0

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
@@ -296,6 +296,8 @@ spec:
               value: {{ .metadata_change_proposal_topic_name }}
             - name: FAILED_METADATA_CHANGE_PROPOSAL_TOPIC_NAME
               value: {{ .failed_metadata_change_proposal_topic_name }}
+            - name: DATAHUB_USAGE_EVENT_NAME
+              value: {{ .datahub_usage_event_name }}
             - name: METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME
               value: {{ .metadata_change_log_versioned_topic_name }}
             - name: METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME


### PR DESCRIPTION
The MCE consumer template was missing the DATAHUB_USAGE_EVENT_NAME environment variable that other subcharts (MAE consumer, GMS) already inject. Without it, the OpenTelemetry usage span exporter falls back to the hardcoded default topic name, causing TopicAuthorizationException when a topic prefix is configured.



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
