### PR TITLE
feat(datahub): add opt-in GMS entity graph cache support

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,14 +4,14 @@ description: A Helm chart for DataHub (defaults include non-root security contex
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.6.0
 dependencies:
   - name: datahub-gms
-    version: 0.3.16
+    version: 0.3.17
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
@@ -19,11 +19,11 @@ dependencies:
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer
-    version: 0.3.10
+    version: 0.3.11
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.3.12
+    version: 0.3.13
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron

--- a/charts/datahub/VALUES_REFERENCE.md
+++ b/charts/datahub/VALUES_REFERENCE.md
@@ -365,6 +365,35 @@ This document provides a comprehensive reference for every single configurable v
 </tbody>
 </table>
 
+### Global Entity Graph Cache Configuration
+
+GMS-only, opt-in cache for domain/container/glossary hierarchies and group membership (see DataHub `docs/deploy/gms-entity-graph-cache.md`). The chart default is disabled when `entity_graph_cache` is unset. Standalone MAE/MCE consumers and all datahub-upgrade jobs (including system-update) always receive `ENTITY_GRAPH_CACHE_ENABLED=false`.
+
+<table>
+<thead>
+<tr>
+<th>Parameter</th>
+<th>Type</th>
+<th>Default</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>global.datahub.entity_graph_cache.enabled</code></td>
+<td>boolean</td>
+<td><em>unset</em> (chart: <code>false</code>)</td>
+<td>Enable entity graph cache on <strong>datahub-gms</strong> only. Sets <code>ENTITY_GRAPH_CACHE_ENABLED</code>. Requires a GMS image that includes the entity graph cache feature. When <code>true</code> on single-replica GMS, the chart provisions Hazelcast (headless service, port 5701, <code>SEARCH_SERVICE_HAZELCAST_SERVICE_NAME</code>). DataHub <code>application.yaml</code> defaults this to <code>true</code> when the env var is unset on GMS; this chart explicitly sets the env var so the default install stays off until opted in.</td>
+</tr>
+<tr>
+<td><code>global.datahub.entity_graph_cache.configJson</code></td>
+<td>string</td>
+<td><em>unset</em></td>
+<td>Optional JSON overlay merged at startup. Sets <code>ENTITY_GRAPH_CACHE_CONFIG_JSON</code> on GMS when non-empty (per-graph bounds, <code>population.intervalSeconds</code>, etc.). Omitted from manifests when unset. <code>ENTITY_GRAPH_CACHE_CONFIG_FILE*</code> env vars are not set by the chart; GMS uses bundled <code>entity-graph-cache.yaml</code> via application defaults when enabled.</td>
+</tr>
+</tbody>
+</table>
+
 ### Global Kafka Configuration
 
 <table>

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.16
+version: 0.3.17
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.6.0

--- a/charts/datahub/subcharts/datahub-gms/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-gms/templates/_helpers.tpl
@@ -269,3 +269,17 @@ global.datahub.monitoring metricsMode: legacy | jmx_and_actuator | actuator_only
 {{- define "datahub-gms.monitoring.gmsScrapeActuatorOnHttp" -}}
 {{- if eq (include "datahub-gms.monitoring.metricsMode" .) "legacy" }}true{{- end -}}
 {{- end -}}
+
+{{/*
+Headless Hazelcast service name shared by search cache (multi-replica) and entity graph cache.
+*/}}
+{{- define "datahub-gms.hazelcast.serviceName" -}}
+{{- printf "%s-%s-%s" .Release.Name (regexReplaceAll "[^-a-z0-9]+" .Values.global.datahub.version "-") "hazelcast-svc" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Hazelcast cluster required when GMS runs distributed search cache (replicaCount > 1) or entity graph cache.
+*/}}
+{{- define "datahub-gms.hazelcast.required" -}}
+{{- if or (gt (.Values.replicaCount | int) 1) (eq (include "datahub.entity-graph-cache.enabled" .) "true") -}}true{{- end -}}
+{{- end -}}

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -98,7 +98,7 @@ spec:
               containerPort: {{ include "datahub-gms.monitoring.actuatorPrometheusPort" . }}
               protocol: TCP
           {{- end }}
-          {{- if gt (.Values.replicaCount | int) 1 }}
+          {{- if eq (include "datahub-gms.hazelcast.required" .) "true" }}
             - name: hazelcast
               containerPort: 5701
               protocol: TCP
@@ -162,8 +162,10 @@ spec:
             {{- if gt (.Values.replicaCount | int) 1 }}
             - name: SEARCH_SERVICE_CACHE_IMPLEMENTATION
               value: "hazelcast"
+            {{- end }}
+            {{- if eq (include "datahub-gms.hazelcast.required" .) "true" }}
             - name: SEARCH_SERVICE_HAZELCAST_SERVICE_NAME
-              value: {{ printf "%s-%s-%s" .Release.Name (regexReplaceAll "[^-a-z0-9]+" .Values.global.datahub.version "-") "hazelcast-svc" | trunc 63 | trimSuffix "-" }}
+              value: {{ include "datahub-gms.hazelcast.serviceName" . }}
             {{- end }}
             {{- if .Values.global.datahub.systemUpdate.enabled }}
             - name: DATAHUB_REVISION
@@ -432,6 +434,7 @@ spec:
               value: {{ .Values.global.datahub.cache.search.homepage.entityCounts.ttlSeconds | quote }}
             {{- end }}
             {{- include "datahub.semantic-search.env" . | nindent 12 }}
+            {{- include "datahub.entity-graph-cache.gms.env" . | nindent 12 }}
             - name: LINEAGE_SEARCH_CACHE_ENABLED
               value: {{ .Values.global.datahub.cache.search.lineage.enabled | quote }}
             {{- if .Values.global.datahub.cache.search.lineage.enabled }}

--- a/charts/datahub/subcharts/datahub-gms/templates/hazelcastService.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/hazelcastService.yaml
@@ -1,8 +1,8 @@
-{{- if gt (.Values.replicaCount | int) 1 }}
+{{- if eq (include "datahub-gms.hazelcast.required" .) "true" }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s-%s" .Release.Name (regexReplaceAll "[^-a-z0-9]+" .Values.global.datahub.version "-") "hazelcast-svc" | trunc 63 | trimSuffix "-" }}
+  name: {{ include "datahub-gms.hazelcast.serviceName" . }}
   labels:
     {{- include "datahub-gms.labels" . | nindent 4 }}
 spec:

--- a/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.10
+version: 0.3.11
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.6.0

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -112,6 +112,8 @@ spec:
             - name: PRE_PROCESS_HOOKS_UI_ENABLED
               value: {{ or .Values.global.datahub.reProcessUIEventHooks (not .Values.global.datahub.preProcessHooksUIEnabled) | quote }}
             {{- include "datahub.semantic-search.env" . | nindent 12 }}
+            - name: ENTITY_GRAPH_CACHE_ENABLED
+              value: "false"
             - name: ENTITY_VERSIONING_ENABLED
               value: {{ .Values.global.datahub.entityVersioning.enabled | quote }}
             - name: SHOW_SEARCH_FILTERS_V2

--- a/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.12
+version: 0.3.13
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.6.0

--- a/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/templates/deployment.yaml
@@ -118,6 +118,8 @@ spec:
               value: {{ .Values.global.cdc.enabled | quote }}
             {{- end }}
             {{- include "datahub.semantic-search.env" . | nindent 12 }}
+            - name: ENTITY_GRAPH_CACHE_ENABLED
+              value: "false"
             - name: ENTITY_VERSIONING_ENABLED
               value: {{ .Values.global.datahub.entityVersioning.enabled | quote }}
             - name: SHOW_SEARCH_FILTERS_V2

--- a/charts/datahub/templates/_helpers.tpl
+++ b/charts/datahub/templates/_helpers.tpl
@@ -1004,3 +1004,29 @@ USAGE: Include in services that run embedding ingestion:
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Whether GMS entity graph cache is enabled (chart default: false).
+Always emitted as ENTITY_GRAPH_CACHE_ENABLED on GMS — required because DataHub application.yaml defaults enabled=true when unset.
+*/}}
+{{- define "datahub.entity-graph-cache.enabled" -}}
+{{- $egc := .Values.global.datahub.entity_graph_cache | default dict -}}
+{{- if hasKey $egc "enabled" -}}
+{{- $egc.enabled -}}
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
+GMS entity graph cache env vars. CONFIG_FILE* and other toggles use application.yaml defaults when omitted.
+USAGE: datahub-gms deployment only.
+*/}}
+{{- define "datahub.entity-graph-cache.gms.env" -}}
+- name: ENTITY_GRAPH_CACHE_ENABLED
+  value: {{ include "datahub.entity-graph-cache.enabled" . | quote }}
+{{- with (.Values.global.datahub.entity_graph_cache | default dict).configJson }}
+- name: ENTITY_GRAPH_CACHE_CONFIG_JSON
+  value: {{ . | quote }}
+{{- end }}
+{{- end -}}

--- a/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
+++ b/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
@@ -215,6 +215,8 @@ Return the env variables for upgrade jobs
   value: {{ . | quote }}
 {{- end }}
 {{- end }}
+- name: ENTITY_GRAPH_CACHE_ENABLED
+  value: "false"
 {{- end -}}
 
 {{/*

--- a/charts/datahub/values.schema.json
+++ b/charts/datahub/values.schema.json
@@ -2649,6 +2649,20 @@
                 "backfill_browse_v2"
               ]
             },
+            "entity_graph_cache": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Opt-in GMS entity graph cache (Hazelcast-backed hierarchy and membership snapshots). Chart default when unset: false. Sets ENTITY_GRAPH_CACHE_ENABLED on datahub-gms only. Never enabled on standalone MAE/MCE consumers or datahub-upgrade jobs (including system-update). Provisions the headless Hazelcast service on single-replica GMS when true."
+                },
+                "configJson": {
+                  "type": "string",
+                  "description": "Optional JSON overlay merged at startup (ENTITY_GRAPH_CACHE_CONFIG_JSON). Per-graph bounds, refresh intervals, etc. CONFIG_FILE settings use DataHub application.yaml defaults (entity-graph-cache.yaml) when not overridden via env."
+                }
+              },
+              "required": []
+            },
             "mcp": {
               "type": "object",
               "properties": {

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -1257,6 +1257,18 @@ global:
           ## Cohere API endpoint
           endpoint: "https://api.cohere.ai/v1/embed"  # Sets COHERE_EMBEDDING_ENDPOINT
 
+    ## GMS entity graph cache (Hazelcast-backed hierarchy/membership snapshots).
+    ## Opt-in on GMS only; never enabled on standalone MAE/MCE consumers or system-update jobs.
+    ## Chart always sets ENTITY_GRAPH_CACHE_ENABLED on GMS (false unless enabled below) because
+    ## DataHub application.yaml defaults enabled=true when that env var is omitted.
+    ## Uncomment to enable. CONFIG_FILE* uses application.yaml defaults unless overridden via configJson.
+    # entity_graph_cache:
+    #   enabled: true  # ENTITY_GRAPH_CACHE_ENABLED
+    #   configJson: |  # ENTITY_GRAPH_CACHE_CONFIG_JSON — optional per-graph overlay
+    #     {"graphs":{"domain":{"bounds":{"maxVertices":50000}}}}
+    ## Application defaults when env vars are unset (GMS): ENTITY_GRAPH_CACHE_CONFIG_FILE_ENABLED=true,
+    ## ENTITY_GRAPH_CACHE_CONFIG_FILE=entity-graph-cache.yaml
+
     ## v0.15.0+
     metadataChangeProposal:
       consumer:


### PR DESCRIPTION
## Summary
- Adds Helm support for the GMS entity graph cache from [datahub-project/datahub#17886](https://github.com/datahub-project/datahub/pull/17886)
- Chart default keeps the cache **disabled** on GMS by explicitly setting `ENTITY_GRAPH_CACHE_ENABLED=false` (overriding DataHub `application.yaml`, which defaults `true` when unset)
- Standalone MAE/MCE consumers and all datahub-upgrade jobs (including system-update) always receive `ENTITY_GRAPH_CACHE_ENABLED=false`
- Opt-in via `global.datahub.entity_graph_cache.enabled` and optional `configJson`; CONFIG_FILE settings use application defaults when enabled
- Provisions Hazelcast (headless service, port 5701) on single-replica GMS when the cache is enabled
- Documents new values in `values.schema.json` and `VALUES_REFERENCE.md`

## Test plan
- [x] `helm lint charts/datahub`
- [x] `values.schema.json` JSON validation
- [x] `helm template` default render (GMS/consumers/upgrade all `ENTITY_GRAPH_CACHE_ENABLED=false`, no Hazelcast on single-replica default)
- [x] `helm template` with `global.datahub.entity_graph_cache.enabled=true` (GMS true, Hazelcast provisioned, non-GMS workloads false)
- [x] `helm template` with `configJson` values overlay


Made with [Cursor](https://cursor.com)