### PR TITLE
feat(datahub): share Kafka producer/consumer limits and add ES catch-up tuning

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for DataHub (defaults include non-root security contex
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datahub/VALUES_REFERENCE.md
+++ b/charts/datahub/VALUES_REFERENCE.md
@@ -170,6 +170,24 @@ This document provides a comprehensive reference for every single configurable v
 <td><code>true</code></td>
 <td>Enable optimized reindexing during upgrades. Improves upgrade performance by using efficient bulk operations and parallel processing.</td>
 </tr>
+<tr>
+<td><code>global.elasticsearch.index.upgrade.catchUpSqlPageSize</code></td>
+<td>integer</td>
+<td><code>50</code></td>
+<td>SQL page size for incremental reindex catch-up MCL emission.</td>
+</tr>
+<tr>
+<td><code>global.elasticsearch.index.upgrade.catchUpFlushInterval</code></td>
+<td>integer</td>
+<td><code>500</code></td>
+<td>Row count between producer flush and checkpoint during catch-up.</td>
+</tr>
+<tr>
+<td><code>global.elasticsearch.index.upgrade.catchUpFlushBytesThreshold</code></td>
+<td>integer</td>
+<td><code>134217728</code></td>
+<td>Metadata-column char proxy for early catch-up flush (128 MiB). Set to 0 to disable byte-based flush.</td>
+</tr>
 </tbody>
 </table>
 

--- a/charts/datahub/templates/_helpers.tpl
+++ b/charts/datahub/templates/_helpers.tpl
@@ -245,6 +245,24 @@ Helper to process extraIndex URLs - handles multiple formats:
 {{- end -}}
 
 {{/*
+Kafka producer/consumer size limits shared by GMS, MAE, MCE, system-update, and upgrade jobs.
+*/}}
+{{- define "datahub.kafka.producerConsumerLimits.env" -}}
+{{- with .Values.global.kafka.producer.compressionType }}
+- name: KAFKA_PRODUCER_COMPRESSION_TYPE
+  value: "{{ . }}"
+{{- end }}
+{{- with .Values.global.kafka.producer.maxRequestSize }}
+- name: KAFKA_PRODUCER_MAX_REQUEST_SIZE
+  value: {{ . | quote }}
+{{- end }}
+{{- with .Values.global.kafka.consumer.maxPartitionFetchBytes }}
+- name: KAFKA_CONSUMER_MAX_PARTITION_FETCH_BYTES
+  value: {{ . | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Kafka IAM environment variables for AWS MSK authentication if enabled.
 For Java/Spring-based services that use Spring Kafka.
 */}}

--- a/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
+++ b/charts/datahub/templates/datahub-upgrade/_upgrade.tpl
@@ -48,18 +48,7 @@ Return the env variables for upgrade jobs
 - name: REPLICATION_FACTOR
   value: {{ . | quote }}
 {{- end }}
-{{- with .Values.global.kafka.producer.compressionType }}
-- name: KAFKA_PRODUCER_COMPRESSION_TYPE
-  value: "{{ . }}"
-{{- end }}
-{{- with .Values.global.kafka.producer.maxRequestSize }}
-- name: KAFKA_PRODUCER_MAX_REQUEST_SIZE
-  value: {{ . | quote }}
-{{- end }}
-{{- with .Values.global.kafka.consumer.maxPartitionFetchBytes }}
-- name: KAFKA_CONSUMER_MAX_PARTITION_FETCH_BYTES
-  value: {{ . | quote }}
-{{- end }}
+{{- include "datahub.kafka.producerConsumerLimits.env" . | nindent 0 }}
 {{- if eq .Values.global.kafka.schemaregistry.type "INTERNAL" }}
 - name: KAFKA_SCHEMAREGISTRY_URL
   value: {{ printf "http://%s-%s:%s%s/schema-registry/api/" .Release.Name "datahub-gms" .Values.global.datahub.gms.port (ternary .Values.global.basePath.gms "" .Values.global.basePath.enabled) }}

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
@@ -240,6 +240,12 @@ spec:
             - name: ELASTICSEARCH_BUILD_INDICES_ALLOW_DOC_COUNT_MISMATCH
               value: {{ . | quote }}
             {{- end }}
+            - name: ELASTICSEARCH_BUILD_INDICES_CATCH_UP_SQL_PAGE_SIZE
+              value: {{ (.Values.global.elasticsearch.index.upgrade.catchUpSqlPageSize | default 50) | quote }}
+            - name: ELASTICSEARCH_BUILD_INDICES_CATCH_UP_FLUSH_INTERVAL
+              value: {{ (.Values.global.elasticsearch.index.upgrade.catchUpFlushInterval | default 500) | quote }}
+            - name: ELASTICSEARCH_BUILD_INDICES_CATCH_UP_FLUSH_BYTES_THRESHOLD
+              value: {{ (.Values.global.elasticsearch.index.upgrade.catchUpFlushBytesThreshold | default 134217728) | quote }}
             {{- range $k, $v := .Values.datahubSystemUpdate.bootstrapMCPs }}
             {{- if ne $k "default" }}
             {{- $result := dict }}
@@ -469,6 +475,12 @@ spec:
             - name: ELASTICSEARCH_BUILD_INDICES_ALLOW_DOC_COUNT_MISMATCH
               value: {{ . | quote }}
             {{- end }}
+            - name: ELASTICSEARCH_BUILD_INDICES_CATCH_UP_SQL_PAGE_SIZE
+              value: {{ (.Values.global.elasticsearch.index.upgrade.catchUpSqlPageSize | default 50) | quote }}
+            - name: ELASTICSEARCH_BUILD_INDICES_CATCH_UP_FLUSH_INTERVAL
+              value: {{ (.Values.global.elasticsearch.index.upgrade.catchUpFlushInterval | default 500) | quote }}
+            - name: ELASTICSEARCH_BUILD_INDICES_CATCH_UP_FLUSH_BYTES_THRESHOLD
+              value: {{ (.Values.global.elasticsearch.index.upgrade.catchUpFlushBytesThreshold | default 134217728) | quote }}
             {{- range $k, $v := .Values.datahubSystemUpdate.bootstrapMCPs }}
             {{- if ne $k "default" }}
             {{- $result := dict }}

--- a/charts/datahub/values.schema.json
+++ b/charts/datahub/values.schema.json
@@ -1696,6 +1696,15 @@
                     "reindexOptimizationEnabled": {
                       "type": "boolean"
                     },
+                    "catchUpSqlPageSize": {
+                      "type": "integer"
+                    },
+                    "catchUpFlushInterval": {
+                      "type": "integer"
+                    },
+                    "catchUpFlushBytesThreshold": {
+                      "type": "integer"
+                    },
                     "rollbackDualWriteEnabled": {
                       "type": "boolean"
                     }

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -781,6 +781,13 @@ global:
         ## Will use full replication during reindexing which will make the process slower
         reindexOptimizationEnabled: true
 
+        ## SQL page size for incremental reindex catch-up MCL emission
+        catchUpSqlPageSize: 50
+        ## Row count between producer flush and checkpoint during catch-up
+        catchUpFlushInterval: 500
+        ## Metadata-column char proxy for early catch-up flush (128 MiB); 0 disables byte-based flush
+        catchUpFlushBytesThreshold: 134217728
+
         ## Individual override for ELASTICSEARCH_BUILD_INDICES_ROLLBACK_DUAL_WRITE_ENABLED.
         ## When set explicitly, overrides the ZDU_STAGE_20 group flag cascade.
         ## Dual-writes to old backing index during incremental reindex for rollback safety.


### PR DESCRIPTION
## Summary
- Extract Kafka producer/consumer size limit env vars (`KAFKA_PRODUCER_COMPRESSION_TYPE`, `KAFKA_PRODUCER_MAX_REQUEST_SIZE`, `KAFKA_CONSUMER_MAX_PARTITION_FETCH_BYTES`) into a shared `datahub.kafka.producerConsumerLimits.env` helper used by upgrade jobs (including system-update via `datahub.upgrade.env`).
- Add configurable incremental reindex catch-up settings for system-update: `catchUpSqlPageSize`, `catchUpFlushInterval`, and `catchUpFlushBytesThreshold` under `global.elasticsearch.index.upgrade`.
- Bump chart version to `1.0.3`.

## Test plan
- [x] `helm template` renders Kafka producer/consumer limit env vars on upgrade/system-update jobs
- [x] `helm template` renders `ELASTICSEARCH_BUILD_INDICES_CATCH_UP_*` env vars on both system-update containers with defaults (50 / 500 / 134217728)
- [ ] Override catch-up values and confirm rendered env vars change accordingly


Made with [Cursor](https://cursor.com)