### PR TITLE
feat(ingestion): Default uv cache mode to hardlink

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for DataHub (defaults include non-root security contex
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
@@ -31,7 +31,7 @@ dependencies:
     repository: file://./subcharts/datahub-ingestion-cron
     condition: datahub-ingestion-cron.enabled
   - name: acryl-datahub-actions
-    version: 0.3.9
+    version: 0.3.10
     repository: file://./subcharts/acryl-datahub-actions
     condition: acryl-datahub-actions.enabled
 maintainers:

--- a/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.9
+version: 0.3.10
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.7.0

--- a/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/templates/deployment.yaml
@@ -107,6 +107,8 @@ spec:
             - name: EXECUTOR_ID
               value: "{{ .Values.actions.executorId }}"
             {{- end }}
+            - name: UV_LINK_MODE
+              value: {{ .Values.actions.uvLinkMode | default "hardlink" | quote }}
             {{- if .Values.debug.enabled }}
             - name: DATAHUB_DEBUG
               value: "true"

--- a/charts/datahub/subcharts/acryl-datahub-actions/values.yaml
+++ b/charts/datahub/subcharts/acryl-datahub-actions/values.yaml
@@ -91,6 +91,11 @@ actions:
   kafkaAutoOffsetPolicy: "latest"
   # Configure a custom executor id that will be set as the EXECUTOR_ID environment variable
   # executorId: ""
+  # uv link mode for building dynamic ingestion venvs. "hardlink" (default) shares package bytes
+  # with the uv cache so concurrent/repeated runs don't each copy their dependencies; requires the
+  # venv dir and ~/.cache/uv on the same filesystem, otherwise uv degrades to "copy". Set to "copy"
+  # if hardlinking isn't possible in your storage layout.
+  uvLinkMode: "hardlink"
 
 # mount the k8s secret as a volume in the container, each key name is mounted as a file on the mount path /etc/datahub/ingestion-secret-files
 # ingestionSecretFiles:


### PR DESCRIPTION
Most FS, do not support CoW, in such cases UV_LINK_MODE might default from clone to copy instead of hardlink, therefor causing huge spikes of storage consumption whenever an ingestion is started. On average it can take 400 MB storage for a new venv in copy mode, compared with 50 MB (.pyc files only) in hardlink. This was one of the causes of disk pressure-based evictions of the executor pods.
