### PR TITLE
fix(semantic-search): always emit the semantic search on/off flags

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,14 +4,13 @@ description: A Helm chart for DataHub (defaults include non-root security contex
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.4
-
+version: 1.1.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.7.0
 dependencies:
   - name: datahub-gms
-    version: 0.3.20
+    version: 0.3.21
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
@@ -19,11 +18,11 @@ dependencies:
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer
-    version: 0.3.14
+    version: 0.3.15
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer
-    version: 0.3.16
+    version: 0.3.17
     repository: file://./subcharts/datahub-mce-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-ingestion-cron

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.20
+version: 0.3.21
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.7.0

--- a/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.14
+version: 0.3.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.7.0

--- a/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mce-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.16
+version: 0.3.17
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.7.0

--- a/charts/datahub/templates/_helpers.tpl
+++ b/charts/datahub/templates/_helpers.tpl
@@ -880,7 +880,8 @@ USAGE: Include in Python services (executor, integrations, actions)
 
 {{/*
 Semantic search environment variables for vector similarity search.
-Only emits env vars when semantic search is enabled.
+The two on/off flags are always emitted, explicitly "true" or "false"; the rest of
+the configuration is emitted only when semantic search is enabled.
 
 USAGE: Include in services that need semantic search configuration:
 - datahub-gms
@@ -891,15 +892,22 @@ For credentials only (actions pod), see datahub.semantic-search.credentials.env
 */}}
 {{- define "datahub.semantic-search.env" -}}
 {{- $semantic := .Values.global.datahub.semantic_search -}}
-{{- if $semantic.enabled }}
 {{- /* Two separate env vars control different layers of semantic search:
        ELASTICSEARCH_SEMANTIC_SEARCH_ENABLED  = index-time: creates semantic indices and dual-writes documents into them
        SEARCH_SERVICE_SEMANTIC_SEARCH_ENABLED = query-time: allows semantic search queries to execute
-       Both must be true for a fully working setup, so we set them from a single toggle. */ -}}
+       Both must be true for a fully working setup, so we set them from a single toggle.
+
+       These two are emitted even when disabled. Consumers default them to false when
+       absent, so "false" and unset mean the same thing to them -- but an absent variable
+       cannot express "off" to anything that needs to distinguish disabled from
+       unconfigured, such as a bootstrap MCP template's enabledEnvVar kill switch. */ -}}
+{{- $enabled := "false" -}}
+{{- if and $semantic $semantic.enabled -}}{{- $enabled = "true" -}}{{- end }}
 - name: SEARCH_SERVICE_SEMANTIC_SEARCH_ENABLED
-  value: {{ $semantic.enabled | quote }}
+  value: {{ $enabled | quote }}
 - name: ELASTICSEARCH_SEMANTIC_SEARCH_ENABLED
-  value: {{ $semantic.enabled | quote }}
+  value: {{ $enabled | quote }}
+{{- if and $semantic $semantic.enabled }}
 - name: ELASTICSEARCH_SEMANTIC_SEARCH_ENTITIES
   value: {{ $semantic.enabledEntities | quote }}
 - name: ELASTICSEARCH_SEMANTIC_VECTOR_DIMENSION


### PR DESCRIPTION
## Summary

`datahub.semantic-search.env` wraps its whole body in `if $semantic.enabled`, so when semantic search is **disabled** the two on/off flags are not emitted at all rather than emitted as `"false"`.

GMS and the consumers default them to false when absent (`${ELASTICSEARCH_SEMANTIC_SEARCH_ENABLED:false}` in `application.yaml`), so this makes no difference to them. It does matter to anything that has to tell *disabled* apart from *unconfigured* — specifically a bootstrap MCP template's `enabledEnvVar` kill switch, which skips only on an explicit `"false"` and treats an unset variable as enabled.

This change emits the two flags unconditionally with their real value, and keeps everything else — entity list, vector dimension, provider type and credentials — inside the enabled guard, so no provider settings leak into a disabled deployment.

## Why now

The `datahub-documents` system ingestion source generates embeddings for semantic search and nothing else. On an instance with semantic search off it still runs on its schedule, scrolls, chunks, and emits nothing. Gating that bootstrap on `ELASTICSEARCH_SEMANTIC_SEARCH_ENABLED` requires the variable to actually be present and `"false"` — hence this fix.

## Testing

`helm template`, semantic search **disabled** (default) — both flags present, nothing else:

```
- name: SEARCH_SERVICE_SEMANTIC_SEARCH_ENABLED
  value: "false"
- name: ELASTICSEARCH_SEMANTIC_SEARCH_ENABLED
  value: "false"
```

**enabled** — full block, unchanged from before:

```
- name: SEARCH_SERVICE_SEMANTIC_SEARCH_ENABLED
  value: "true"
- name: ELASTICSEARCH_SEMANTIC_SEARCH_ENABLED
  value: "true"
- name: ELASTICSEARCH_SEMANTIC_SEARCH_ENTITIES
  value: "document"
- name: ELASTICSEARCH_SEMANTIC_VECTOR_DIMENSION
  value: "3072"
- name: EMBEDDING_PROVIDER_TYPE
  value: "openai"
```

Confirmed the flags reach `datahub-gms` and **both** system-update jobs (blocking and non-blocking).

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md)
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable) — verified via `helm template` in both states
- [ ] Docs related to the changes have been added/updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Operational note

These env vars are added to `datahub-gms` and both system-update jobs, so upgrading rolls those pods. That is expected for a chart upgrade and the values are semantically identical to what the consumers already defaulted to — no behaviour change for GMS or the consumers, only for readers that need to distinguish "off" from "unset".

## Review updates

- Made the helper nil-safe: it dereferenced `$semantic.enabled` directly, so a values tree without `global.datahub.semantic_search` failed the render with `nil pointer evaluating interface {}.enabled` instead of defaulting to off. Both reads are now guarded with `and $semantic`. Verified `helm template` with `semantic_search` absent entirely, disabled, and enabled.
- Bumped the chart version to 1.1.3, required by `chart-testing` lint.
