### PR TITLE
fix(gms): fail install when UI index paths are both off

### DIFF
--- a/charts/datahub/Chart.yaml
+++ b/charts/datahub/Chart.yaml
@@ -4,14 +4,14 @@ description: A Helm chart for DataHub (defaults include non-root security contex
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.2
+version: 1.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.7.0
 dependencies:
   - name: datahub-gms
-    version: 0.3.18
+    version: 0.3.19
     repository: file://./subcharts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend
@@ -19,7 +19,7 @@ dependencies:
     repository: file://./subcharts/datahub-frontend
     condition: datahub-frontend.enabled
   - name: datahub-mae-consumer
-    version: 0.3.12
+    version: 0.3.13
     repository: file://./subcharts/datahub-mae-consumer
     condition: global.datahub_standalone_consumers_enabled
   - name: datahub-mce-consumer

--- a/charts/datahub/VALUES_REFERENCE.md
+++ b/charts/datahub/VALUES_REFERENCE.md
@@ -1239,13 +1239,13 @@ GMS-only, opt-in cache for domain/container/glossary hierarchies and group membe
 <td><code>global.datahub.preProcessHooksUIEnabled</code></td>
 <td>boolean</td>
 <td><code>true</code></td>
-<td>Enable fast path for processing UI-sourced events with synchronous index updates.</td>
+<td>GMS GraphQL fast path for UI-sourced index updates. Applied to GMS and MAE. Helm refuses to install if this and <code>reProcessUIEventHooks</code> are both false.</td>
 </tr>
 <tr>
 <td><code>global.datahub.reProcessUIEventHooks</code></td>
 <td>boolean</td>
 <td><code>false</code></td>
-<td>Reprocess UI events at MAE Consumer. Not required when preprocess is enabled. Helm refuses to install if this and <code>preProcessHooksUIEnabled</code> are both false.</td>
+<td>Reprocess UI events in MAE (embedded GMS or standalone). Not required when preprocess is enabled. Helm refuses to install if this and <code>preProcessHooksUIEnabled</code> are both false.</td>
 </tr>
 </tbody>
 </table>

--- a/charts/datahub/VALUES_REFERENCE.md
+++ b/charts/datahub/VALUES_REFERENCE.md
@@ -1245,7 +1245,7 @@ GMS-only, opt-in cache for domain/container/glossary hierarchies and group membe
 <td><code>global.datahub.reProcessUIEventHooks</code></td>
 <td>boolean</td>
 <td><code>false</code></td>
-<td>Reprocess UI events at MAE Consumer. Not required when preprocess is enabled.</td>
+<td>Reprocess UI events at MAE Consumer. Not required when preprocess is enabled. Helm refuses to install if this and <code>preProcessHooksUIEnabled</code> are both false.</td>
 </tr>
 </tbody>
 </table>

--- a/charts/datahub/subcharts/datahub-gms/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-gms/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for DataHub's datahub-gms component
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.18
+version: 0.3.19
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.7.0

--- a/charts/datahub/subcharts/datahub-gms/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-gms/templates/_helpers.tpl
@@ -287,7 +287,7 @@ Hazelcast cluster required when GMS runs distributed search cache (replicaCount 
 {{/*
 Reject the silent-drop combination from datahub-project/datahub#19119: UI-sourced
 writes are stored but never indexed when both the GMS fast path and MAE reprocess
-path are off.
+path are off. Applies to a single GMS with embedded consumers and to standalone MAE.
 */}}
 {{- define "datahub.validate.preprocessHooks" -}}
 {{- if and (not .Values.global.datahub.preProcessHooksUIEnabled) (not .Values.global.datahub.reProcessUIEventHooks) -}}

--- a/charts/datahub/subcharts/datahub-gms/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-gms/templates/_helpers.tpl
@@ -283,3 +283,14 @@ Hazelcast cluster required when GMS runs distributed search cache (replicaCount 
 {{- define "datahub-gms.hazelcast.required" -}}
 {{- if or (gt (.Values.replicaCount | int) 1) (eq (include "datahub.entity-graph-cache.enabled" .) "true") -}}true{{- end -}}
 {{- end -}}
+
+{{/*
+Reject the silent-drop combination from datahub-project/datahub#19119: UI-sourced
+writes are stored but never indexed when both the GMS fast path and MAE reprocess
+path are off.
+*/}}
+{{- define "datahub.validate.preprocessHooks" -}}
+{{- if and (not .Values.global.datahub.preProcessHooksUIEnabled) (not .Values.global.datahub.reProcessUIEventHooks) -}}
+{{- fail "ERROR: global.datahub.preProcessHooksUIEnabled and global.datahub.reProcessUIEventHooks are both false. UI-sourced writes (GraphQL appSource=ui) would be stored but never indexed. Set preProcessHooksUIEnabled=true (GMS synchronous path) or reProcessUIEventHooks=true (MAE consumer path). See https://github.com/datahub-project/datahub/issues/19119" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -191,10 +191,11 @@ spec:
             - name: PE_CONSUMER_ENABLED
               value: "true"
             {{- end }}
+            {{- /* Same pair on GMS and MAE: embedded consumers and standalone MAE. */}}
             - name: PRE_PROCESS_HOOKS_UI_ENABLED
               value: {{ .Values.global.datahub.preProcessHooksUIEnabled | quote }}
             - name: PRE_PROCESS_HOOKS_REPROCESS_ENABLED
-              value: {{ .Values.global.datahub.reProcessUIEventHooks | quote }}
+              value: {{ or .Values.global.datahub.reProcessUIEventHooks (not .Values.global.datahub.preProcessHooksUIEnabled) | quote }}
             - name: ENTITY_REGISTRY_CONFIG_PATH
               value: /datahub/datahub-gms/resources/entity-registry.yml
             - name: DATAHUB_ANALYTICS_ENABLED

--- a/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "datahub.validate.preprocessHooks" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -190,6 +191,10 @@ spec:
             - name: PE_CONSUMER_ENABLED
               value: "true"
             {{- end }}
+            - name: PRE_PROCESS_HOOKS_UI_ENABLED
+              value: {{ .Values.global.datahub.preProcessHooksUIEnabled | quote }}
+            - name: PRE_PROCESS_HOOKS_REPROCESS_ENABLED
+              value: {{ .Values.global.datahub.reProcessUIEventHooks | quote }}
             - name: ENTITY_REGISTRY_CONFIG_PATH
               value: /datahub/datahub-gms/resources/entity-registry.yml
             - name: DATAHUB_ANALYTICS_ENABLED

--- a/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.12
+version: 0.3.13
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v1.7.0

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/_helpers.tpl
@@ -154,7 +154,7 @@ http
 {{/*
 Reject the silent-drop combination from datahub-project/datahub#19119: UI-sourced
 writes are stored but never indexed when both the GMS fast path and MAE reprocess
-path are off.
+path are off. Applies to a single GMS with embedded consumers and to standalone MAE.
 */}}
 {{- define "datahub.validate.preprocessHooks" -}}
 {{- if and (not .Values.global.datahub.preProcessHooksUIEnabled) (not .Values.global.datahub.reProcessUIEventHooks) -}}

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/_helpers.tpl
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/_helpers.tpl
@@ -150,3 +150,14 @@ prometheus
 http
 {{- end -}}
 {{- end -}}
+
+{{/*
+Reject the silent-drop combination from datahub-project/datahub#19119: UI-sourced
+writes are stored but never indexed when both the GMS fast path and MAE reprocess
+path are off.
+*/}}
+{{- define "datahub.validate.preprocessHooks" -}}
+{{- if and (not .Values.global.datahub.preProcessHooksUIEnabled) (not .Values.global.datahub.reProcessUIEventHooks) -}}
+{{- fail "ERROR: global.datahub.preProcessHooksUIEnabled and global.datahub.reProcessUIEventHooks are both false. UI-sourced writes (GraphQL appSource=ui) would be stored but never indexed. Set preProcessHooksUIEnabled=true (GMS synchronous path) or reProcessUIEventHooks=true (MAE consumer path). See https://github.com/datahub-project/datahub/issues/19119" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -112,8 +112,9 @@ spec:
             - name: DATAHUB_GMS_BASE_PATH
               value: {{ .Values.global.basePath.gms | quote }}
             {{- end }}
+            {{- /* Same pair as GMS. uiEnabled means GMS already indexed appSource=ui. */}}
             - name: PRE_PROCESS_HOOKS_UI_ENABLED
-              value: {{ or .Values.global.datahub.reProcessUIEventHooks (not .Values.global.datahub.preProcessHooksUIEnabled) | quote }}
+              value: {{ .Values.global.datahub.preProcessHooksUIEnabled | quote }}
             - name: PRE_PROCESS_HOOKS_REPROCESS_ENABLED
               value: {{ or .Values.global.datahub.reProcessUIEventHooks (not .Values.global.datahub.preProcessHooksUIEnabled) | quote }}
             {{- include "datahub.semantic-search.env" . | nindent 12 }}

--- a/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
+++ b/charts/datahub/subcharts/datahub-mae-consumer/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "datahub.validate.preprocessHooks" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -112,6 +113,8 @@ spec:
               value: {{ .Values.global.basePath.gms | quote }}
             {{- end }}
             - name: PRE_PROCESS_HOOKS_UI_ENABLED
+              value: {{ or .Values.global.datahub.reProcessUIEventHooks (not .Values.global.datahub.preProcessHooksUIEnabled) | quote }}
+            - name: PRE_PROCESS_HOOKS_REPROCESS_ENABLED
               value: {{ or .Values.global.datahub.reProcessUIEventHooks (not .Values.global.datahub.preProcessHooksUIEnabled) | quote }}
             {{- include "datahub.semantic-search.env" . | nindent 12 }}
             - name: ENTITY_GRAPH_CACHE_ENABLED

--- a/charts/datahub/templates/_preprocess-hooks-validation.tpl
+++ b/charts/datahub/templates/_preprocess-hooks-validation.tpl
@@ -1,0 +1,10 @@
+{{/*
+Reject the silent-drop combination from datahub-project/datahub#19119: UI-sourced
+writes are stored but never indexed when both the GMS fast path and MAE reprocess
+path are off.
+*/}}
+{{- define "datahub.validate.preprocessHooks" -}}
+{{- if and (not .Values.global.datahub.preProcessHooksUIEnabled) (not .Values.global.datahub.reProcessUIEventHooks) -}}
+{{- fail "ERROR: global.datahub.preProcessHooksUIEnabled and global.datahub.reProcessUIEventHooks are both false. UI-sourced writes (GraphQL appSource=ui) would be stored but never indexed. Set preProcessHooksUIEnabled=true (GMS synchronous path) or reProcessUIEventHooks=true (MAE consumer path). See https://github.com/datahub-project/datahub/issues/19119" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/datahub/templates/_preprocess-hooks-validation.tpl
+++ b/charts/datahub/templates/_preprocess-hooks-validation.tpl
@@ -1,7 +1,7 @@
 {{/*
 Reject the silent-drop combination from datahub-project/datahub#19119: UI-sourced
 writes are stored but never indexed when both the GMS fast path and MAE reprocess
-path are off.
+path are off. Applies to a single GMS with embedded consumers and to standalone MAE.
 */}}
 {{- define "datahub.validate.preprocessHooks" -}}
 {{- if and (not .Values.global.datahub.preProcessHooksUIEnabled) (not .Values.global.datahub.reProcessUIEventHooks) -}}

--- a/charts/datahub/templates/datahub-auth-secrets.yml
+++ b/charts/datahub/templates/datahub-auth-secrets.yml
@@ -1,3 +1,4 @@
+{{- include "datahub.validate.preprocessHooks" . -}}
 {{- $secretRef := .Values.global.datahub.metadata_service_authentication.systemClientSecret.secretRef | required "secretRef required" -}}
 {{- $secret := lookup "v1" "Secret" .Release.Namespace $secretRef -}}
 {{- $data := $secret.data | default dict -}}

--- a/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
+++ b/charts/datahub/templates/datahub-upgrade/datahub-system-update-job.yml
@@ -1,4 +1,5 @@
 {{- include "datahub.validate.iam.setup" . -}}
+{{- include "datahub.validate.preprocessHooks" . -}}
 {{- if .Values.global.datahub.systemUpdate.enabled -}}
 {{- $zduStage20 := .Values.global.datahub.systemUpdate.zdu.enable | default false }}
 {{- $scaleDownEffective := and (.Values.global.datahub.systemUpdate.scaleDown.enabled | default false) (not $zduStage20) }}

--- a/charts/datahub/values.schema.json
+++ b/charts/datahub/values.schema.json
@@ -2715,6 +2715,14 @@
             "alwaysEmitChangeLog": {
               "type": "boolean"
             },
+            "preProcessHooksUIEnabled": {
+              "type": "boolean",
+              "description": "Synchronous GMS index updates for GraphQL/UI-sourced writes (PRE_PROCESS_HOOKS_UI_ENABLED). Must not be false while reProcessUIEventHooks is also false."
+            },
+            "reProcessUIEventHooks": {
+              "type": "boolean",
+              "description": "Reprocess UI-sourced events in the MAE UpdateIndicesHook (PRE_PROCESS_HOOKS_REPROCESS_ENABLED). Must not be false while preProcessHooksUIEnabled is also false."
+            },
             "enableGraphDiffMode": {
               "type": "boolean"
             },

--- a/charts/datahub/values.schema.json
+++ b/charts/datahub/values.schema.json
@@ -2717,11 +2717,11 @@
             },
             "preProcessHooksUIEnabled": {
               "type": "boolean",
-              "description": "Synchronous GMS index updates for GraphQL/UI-sourced writes (PRE_PROCESS_HOOKS_UI_ENABLED). Must not be false while reProcessUIEventHooks is also false."
+              "description": "Synchronous GMS index updates for GraphQL/UI-sourced writes (PRE_PROCESS_HOOKS_UI_ENABLED). Applied to GMS and MAE. Must not be false while reProcessUIEventHooks is also false."
             },
             "reProcessUIEventHooks": {
               "type": "boolean",
-              "description": "Reprocess UI-sourced events in the MAE UpdateIndicesHook (PRE_PROCESS_HOOKS_REPROCESS_ENABLED). Must not be false while preProcessHooksUIEnabled is also false."
+              "description": "Reprocess UI-sourced events in MAE UpdateIndicesHook, embedded or standalone (PRE_PROCESS_HOOKS_REPROCESS_ENABLED). Must not be false while preProcessHooksUIEnabled is also false."
             },
             "enableGraphDiffMode": {
               "type": "boolean"

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -1361,10 +1361,11 @@ global:
     entityVersioning:
       enabled: false
 
-    ## Enables a fast path for processing events sourced from the UI, updates indices synchronously for requests originating from GraphQL
+    ## GMS GraphQL fast path for UI-sourced index updates. Set the same pair on GMS and MAE so
+    ## both a single GMS with embedded consumers and standalone MAE/MCE consumers stay valid.
     preProcessHooksUIEnabled: true
-    ## Reprocess UI events at MAE Consumer, normally if preprocess is enabled this is not required.
-    ## Helm fails install/upgrade if both this and preProcessHooksUIEnabled are false (datahub#19119).
+    ## Reprocess UI events in MAE UpdateIndicesHook (embedded or standalone). Not required when
+    ## preprocess is on. Helm fails if both this and preProcessHooksUIEnabled are false (#19119).
     reProcessUIEventHooks: false
 
   externalSecrets:

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -1364,6 +1364,7 @@ global:
     ## Enables a fast path for processing events sourced from the UI, updates indices synchronously for requests originating from GraphQL
     preProcessHooksUIEnabled: true
     ## Reprocess UI events at MAE Consumer, normally if preprocess is enabled this is not required.
+    ## Helm fails install/upgrade if both this and preProcessHooksUIEnabled are false (datahub#19119).
     reProcessUIEventHooks: false
 
   externalSecrets:

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -485,6 +485,7 @@ datahubSystemUpdate:
       - app.kubernetes.io/name=datahub-mae-consumer
       - app.kubernetes.io/name=datahub-mce-consumer
     # Deployments that get env vars set when scaling down (labelSelector -> env map). State stores previous env per deployment for restore.
+    # PRE_PROCESS_HOOKS_UI_ENABLED=false must stay paired with MAE_CONSUMER_ENABLED=false (issue 19119).
     deploymentEnvUpdates:
       - labelSelector: app.kubernetes.io/name=datahub-gms
         env:

--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -492,6 +492,7 @@ datahubSystemUpdate:
           PRE_PROCESS_HOOKS_UI_ENABLED: "false"
           MCE_CONSUMER_ENABLED: "false"
           MAE_CONSUMER_ENABLED: "false"
+          MCL_CONSUMER_ENABLED: "false"
           PE_CONSUMER_ENABLED: "false"
           MCP_CONSUMER_ENABLED: "false"
   # ServiceAccount configuration for the system update job (enables RBAC when running upgrade jobs)


### PR DESCRIPTION
## Summary
- Helm refuses install/upgrade when `global.datahub.preProcessHooksUIEnabled` and `global.datahub.reProcessUIEventHooks` are both false. That combination stores GraphQL/UI writes (`appSource=ui`) without indexing them ([datahub#19119](https://github.com/datahub-project/datahub/issues/19119), companion GMS change [datahub#19295](https://github.com/datahub-project/datahub/pull/19295)).
- GMS now gets `PRE_PROCESS_HOOKS_UI_ENABLED` / `PRE_PROCESS_HOOKS_REPROCESS_ENABLED` from those values. Standalone MAE still uses the existing OR so reprocess stays on when preprocess is off.
- Chart version bump: `datahub` 1.1.2 → 1.1.3, `datahub-gms` 0.3.18 → 0.3.19, `datahub-mae-consumer` 0.3.12 → 0.3.13.

## Test plan
- [x] `helm template` with defaults succeeds; GMS env is `PRE_PROCESS_HOOKS_UI_ENABLED=true`, `PRE_PROCESS_HOOKS_REPROCESS_ENABLED=false`
- [x] `helm template --set global.datahub.preProcessHooksUIEnabled=false --set global.datahub.reProcessUIEventHooks=false` fails
- [x] `preProcessHooksUIEnabled=false` + `reProcessUIEventHooks=true` succeeds; GMS gets `false`/`true`, standalone MAE gets reprocess `true`
- [ ] Confirm `helm install`/`upgrade` of the default chart still works


Made with [Cursor](https://cursor.com)